### PR TITLE
Fixed empty url param in pw recovery request

### DIFF
--- a/src/routes/recover/+page.svelte
+++ b/src/routes/recover/+page.svelte
@@ -9,7 +9,7 @@
     let mail: string;
     const recover = async () => {
         try {
-            await sdkForConsole.account.createRecovery(mail, base);
+            await sdkForConsole.account.createRecovery(mail, window.location.hostname);
             addNotification({
                 type: 'success',
                 message: 'We have sent you an email with a password reset link'


### PR DESCRIPTION
## What does this PR do?

Gets the base url using window.location.hostname instead of the "base" variable, which is an empty string. Thus, allowing password recovery requests to work.

## Test Plan

In production environment, I manually edited the password recovery requests sent on submit from "" (empty strings) to "IP" (of domain). This led to the actual sending of the password recovery email.

After that, I used localhost to try to reproduce the working params of the request sent for password recovery.
As I found the issue came from the "base" variable passed to sdkForConsole.account.createRecovery function, which was empty, I changed it to window.location.hostname and inspected the request in the Dev Tools, which matched my (local IP).

**I could not, however, test it in my production environment** as I have no experience with Docker.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/4709

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I did.