### PR TITLE
Fixed dead link

### DIFF
--- a/src/routes/console/project-[project]/auth/user-[user]/memberships/[[page]]/+page.svelte
+++ b/src/routes/console/project-[project]/auth/user-[user]/memberships/[[page]]/+page.svelte
@@ -72,7 +72,7 @@
             <Button
                 external
                 secondary
-                href="https://appwrite.io/docs/server/auth?sdk=nodejs-default#usersGetMemberships">
+                href="https://appwrite.io/docs/server/users?sdk=nodejs-default#usersListMemberships">
                 Documentation
             </Button>
         </Empty>


### PR DESCRIPTION
Fixed the link to the documentation when a user's memberships list is empty.

Page can be found at console/project-projectId/auth/user-userId/memberships