### PR TITLE
Fix create variable modal not resetting in function wizard

### DIFF
--- a/src/routes/console/project-[project]/functions/createVariable.svelte
+++ b/src/routes/console/project-[project]/functions/createVariable.svelte
@@ -16,14 +16,19 @@
 
     const dispatch = createEventDispatcher();
 
-    const handleVariable = () => {
+    function close() {
+        showCreate = false;
+        selectedVar = null;
+    }
+
+    function handleVariable() {
         if (selectedVar) {
             dispatch('updated', pair);
         } else {
             dispatch('created', pair);
         }
-        showCreate = false;
-    };
+        close();
+    }
 </script>
 
 <Modal bind:show={showCreate} on:submit={handleVariable} size="big">
@@ -48,7 +53,7 @@
             required />
     </FormList>
     <svelte:fragment slot="footer">
-        <Button secondary on:click={() => (showCreate = false)}>Cancel</Button>
+        <Button secondary on:click={close}>Cancel</Button>
         <Button submit>{selectedVar ? 'Update' : 'Create'}</Button>
     </svelte:fragment>
 </Modal>


### PR DESCRIPTION
## What does this PR do?

Ensure `selectedVar` is reset after updating a variable so that the Create Variable modal is functional

## Test Plan

Manual

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/4743

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes