### PR TITLE
Update function settings to recreate Variable modal with correct selectedVar

### DIFF
--- a/src/routes/console/project-[project]/functions/function-[function]/settings/+page.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/settings/+page.svelte
@@ -570,10 +570,12 @@
 </Container>
 
 <Delete bind:showDelete />
-<Variable
-    bind:selectedVar
-    bind:showCreate={showVariablesModal}
-    on:created={handleVariableCreated}
-    on:updated={handleVariableUpdated} />
+{#if showVariablesModal}
+    <Variable
+        bind:selectedVar
+        bind:showCreate={showVariablesModal}
+        on:created={handleVariableCreated}
+        on:updated={handleVariableUpdated} />
+{/if}
 <!-- <Upload bind:show={showVariablesUpload} on:uploaded={handleVariableCreated} /> -->
 <EventModal bind:show={showEvents} on:created={handleEvent} />


### PR DESCRIPTION
## What does this PR do?

It seems the Variable's `selectedVar` was always null when updating a variable. This update makes the Variable match the wizard:

https://github.com/appwrite/console/blob/d0c5079332c0c5016cbc3e4e45c49babdd6f7a01/src/routes/console/project-%5Bproject%5D/functions/wizard/step5.svelte#L114-L120

to ensure the correct `selectedVar` is passed.

There is also a bug here were you can't create a variable after attempting to update a variable, but that should be fixed by:

* https://github.com/appwrite/console/pull/175

## Test Plan

Manual

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/4743

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes