### PR TITLE
fix: createIndex attribute select changing all other selects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,9 +6882,9 @@
             }
         },
         "node_modules/svelte": {
-            "version": "3.53.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-            "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
+            "version": "3.52.0",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
+            "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
             "engines": {
                 "node": ">= 8"
             }
@@ -12929,9 +12929,9 @@
             "dev": true
         },
         "svelte": {
-            "version": "3.53.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-            "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw=="
+            "version": "3.52.0",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
+            "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ=="
         },
         "svelte-check": {
             "version": "2.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,9 +6882,9 @@
             }
         },
         "node_modules/svelte": {
-            "version": "3.52.0",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-            "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
+            "version": "3.53.1",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
+            "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
             "engines": {
                 "node": ">= 8"
             }
@@ -12929,9 +12929,9 @@
             "dev": true
         },
         "svelte": {
-            "version": "3.52.0",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-            "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ=="
+            "version": "3.53.1",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
+            "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw=="
         },
         "svelte-check": {
             "version": "2.9.2",

--- a/src/lib/helpers/array.ts
+++ b/src/lib/helpers/array.ts
@@ -3,6 +3,7 @@ export function intersection(arr1: unknown[], arr2: unknown[]) {
     const intersection = new Set(arr1.filter((elem) => set.has(elem)));
     return Array.from(intersection);
 }
+
 export function difference(arr1: unknown[], arr2: unknown[]) {
     const set = new Set(arr2);
     const intersection = new Set(arr1.filter((elem) => !set.has(elem)));
@@ -11,4 +12,9 @@ export function difference(arr1: unknown[], arr2: unknown[]) {
 
 export function symmetricDifference(arr1: unknown[], arr2: unknown[]) {
     return difference(arr1, arr2).concat(difference(arr2, arr1));
+}
+
+export function remove<T>(arr: T[], index: number) {
+    // Remove the element at the given index, return a new array
+    return [...arr.slice(0, index), ...arr.slice(index + 1)];
 }

--- a/src/lib/helpers/array.ts
+++ b/src/lib/helpers/array.ts
@@ -14,7 +14,16 @@ export function symmetricDifference(arr1: unknown[], arr2: unknown[]) {
     return difference(arr1, arr2).concat(difference(arr2, arr1));
 }
 
-export function remove<T>(arr: T[], index: number) {
+/**
+ * Removes the element at the specified index from the array, and returns a new array.
+ *
+ * @export
+ * @template T
+ * @param {T[]} arr
+ * @param {number} index
+ * @returns {T[]}
+ */
+export function remove<T>(arr: T[], index: number): T[] {
     // Remove the element at the given index, return a new array
     return [...arr.slice(0, index), ...arr.slice(index + 1)];
 }

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
@@ -93,8 +93,6 @@
         selectedOrder = '';
         newAttr = true;
     };
-
-    $: console.log(attributeList);
 </script>
 
 <Modal bind:error size="big" on:submit={create} bind:show={showCreateIndex}>
@@ -103,7 +101,7 @@
         <InputText id="key" label="Index Key" placeholder="Enter Key" bind:value={key} autofocus />
         <InputSelect options={types} id="type" label="Index type" bind:value={selectedType} />
 
-        {#each attributeList as attribute, i (selectedAttribute + i)}
+        {#each attributeList as attribute, i}
             <li class="form-item is-multiple">
                 <div class="form-item-part u-stretch">
                     <Select id={`attribute-${i}`} label="Attribute" bind:value={attribute.value}>
@@ -114,9 +112,7 @@
                         </optgroup>
                         <optgroup label="Attributes">
                             {#each attributeOptions as option}
-                                <option
-                                    value={option.value}
-                                    selected={option.value === selectedAttribute}>
+                                <option value={option.value}>
                                     {option.label}
                                 </option>
                             {/each}
@@ -157,9 +153,7 @@
                         </optgroup>
                         <optgroup label="Attributes">
                             {#each attributeOptions as option}
-                                <option
-                                    value={option.value}
-                                    selected={option.value === selectedAttribute}>
+                                <option value={option.value}>
                                     {option.label}
                                 </option>
                             {/each}

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
@@ -138,7 +138,6 @@
             <span class="icon-plus" aria-hidden="true" />
             <span class="text">Add attribute</span>
         </Button>
-        {JSON.stringify(attributeList)}
     </FormList>
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (showCreateIndex = false)}>Cancel</Button>

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
@@ -125,7 +125,6 @@
                         text
                         disabled={attributeList.length <= 1}
                         on:click={() => {
-                            if (i === 0) attributeList = [];
                             attributeList = remove(attributeList, i);
                         }}>
                         <span class="icon-x" aria-hidden="true" />

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/indexes/createIndex.svelte
@@ -31,7 +31,7 @@
         value: attribute.key,
         label: attribute.key
     }));
-    let attributeList = [{ value: '', order: '' }] as Array<{ value: string; order: string }>;
+    let attributeList = [{ value: '', order: '' }];
 
     $: addAttributeDisabled = !attributeList.at(-1)?.value || !attributeList.at(-1)?.order;
 


### PR DESCRIPTION
## What does this PR do?

- Fixes a bug in which changing the last Attribute select value would change all other Attribute select values. I also re-factored a bit of the code.
- Fixes a bug in which if you add a new attribute, and then delete it, you can't create an index

## Test Plan

Manual

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/4762

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes