### PR TITLE
Ensure updating function doesn't reset other params

### DIFF
--- a/src/routes/console/project-[project]/functions/function-[function]/settings/+page.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/settings/+page.svelte
@@ -62,7 +62,15 @@
 
     async function updateName() {
         try {
-            await sdkForProject.functions.update(functionId, functionName, $func.execute);
+            await sdkForProject.functions.update(
+                functionId,
+                functionName,
+                $func.execute,
+                $func.events,
+                $func.schedule,
+                $func.timeout,
+                $func.enabled
+            );
             invalidate(Dependencies.FUNCTION);
             addNotification({
                 message: 'Name has been updated',
@@ -79,7 +87,15 @@
 
     async function updatePermissions() {
         try {
-            await sdkForProject.functions.update(functionId, $func.name, permissions);
+            await sdkForProject.functions.update(
+                functionId,
+                $func.name,
+                permissions,
+                $func.events,
+                $func.schedule,
+                $func.timeout,
+                $func.enabled
+            );
             invalidate(Dependencies.FUNCTION);
             addNotification({
                 message: 'Permissions have been updated',
@@ -100,7 +116,10 @@
                 functionId,
                 $func.name,
                 $func.execute,
-                Array.from($eventSet)
+                Array.from($eventSet),
+                $func.schedule,
+                $func.timeout,
+                $func.enabled
             );
             invalidate(Dependencies.FUNCTION);
             addNotification({
@@ -124,7 +143,8 @@
                 $func.execute,
                 $func.events,
                 functionSchedule,
-                timeout
+                $func.timeout,
+                $func.enabled
             );
             invalidate(Dependencies.FUNCTION);
 
@@ -149,9 +169,11 @@
                 $func.execute,
                 $func.events,
                 $func.schedule,
-                timeout
+                timeout,
+                $func.enabled
             );
 
+            invalidate(Dependencies.FUNCTION);
             addNotification({
                 type: 'success',
                 message: 'Timeout has been updated'

--- a/src/routes/console/project-[project]/functions/function-[function]/store.ts
+++ b/src/routes/console/project-[project]/functions/function-[function]/store.ts
@@ -2,5 +2,5 @@ import { page } from '$app/stores';
 import { derived, writable, type Writable } from 'svelte/store';
 import type { Models } from '@aw-labs/appwrite-console';
 
-export const func = derived(page, ($page) => $page.data.function);
+export const func = derived(page, ($page) => $page.data.function as Models.Function);
 export const execute: Writable<Models.Function> = writable();


### PR DESCRIPTION
## What does this PR do?

For any optional param not sent to the API, the values are reset to the default value. This update ensures we pass the existing values so that they aren't reset.

## Test Plan

Manually updated each section of the function settings and refreshed to make sure the other values still remained the same.

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/4746

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes