### PR TITLE
Fix: divider shown before first page interaction

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -123,4 +123,9 @@
             border-right-color: hsl(var(--p-tooltip--bg-color));
         }
     }
+
+    body,
+    html {
+        box-shadow: none !important;
+    }
 </style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When loading the console for the first time, a line shows on the bottom, with a focused box-shadow. This PR removes this line.

## Test Plan
Manual

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes