### PR TITLE
Fix: Update Platform Button Still Enabled After Update

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/[platform]/+page.ts
+++ b/src/routes/console/project-[project]/overview/platforms/[platform]/+page.ts
@@ -5,7 +5,7 @@ import { Dependencies } from '$lib/constants';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params, depends }) => {
-    depends(Dependencies.PROJECT);
+    depends(Dependencies.PLATFORM);
 
     return {
         header: Header,

--- a/src/routes/console/project-[project]/overview/platforms/[platform]/+page@project-[project].svelte
+++ b/src/routes/console/project-[project]/overview/platforms/[platform]/+page@project-[project].svelte
@@ -20,10 +20,7 @@
     import { project } from '../../../store';
     import { platform } from './store';
     import { Dependencies } from '$lib/constants';
-    import type { PageData } from './$types';
     import { invalidate } from '$app/navigation';
-
-    export let data: PageData;
 
     const types: Record<string, typeof SvelteComponent> = {
         web: Web,
@@ -41,20 +38,22 @@
 
     let showDelete = false;
     let name: string = null;
+    let updating = false;
 
     onMount(() => {
-        name ??= data.platform.name;
+        name ??= $platform.name;
     });
 
-    const updateName = async () => {
+    async function updateName() {
+        updating = true;
         try {
             await sdkForConsole.projects.updatePlatform(
                 $project.$id,
-                data.platform.$id,
+                $platform.$id,
                 name,
-                data.platform.key,
-                data.platform.store,
-                data.platform.hostname
+                $platform.key,
+                $platform.store,
+                $platform.hostname
             );
             invalidate(Dependencies.PLATFORM);
             addNotification({
@@ -67,7 +66,13 @@
                 message: error.message
             });
         }
-    };
+    }
+
+    $: {
+        // When platform name is updated, finalize the updating flow
+        $platform.name;
+        updating = false;
+    }
 </script>
 
 <Container>
@@ -87,7 +92,7 @@
             </svelte:fragment>
 
             <svelte:fragment slot="actions">
-                <Button disabled={name === $platform.name} submit>Update</Button>
+                <Button disabled={name === $platform.name || updating} submit>Update</Button>
             </svelte:fragment>
         </CardGrid>
     </Form>

--- a/src/routes/console/project-[project]/settings/+page.svelte
+++ b/src/routes/console/project-[project]/settings/+page.svelte
@@ -17,6 +17,7 @@
 
     let name: string = null;
     let showDelete = false;
+    let updating = false;
     const endpoint = sdkForConsole.client.config.endpoint;
     const projectId = $page.params.project;
 
@@ -24,7 +25,8 @@
         name ??= $project.name;
     });
 
-    const updateName = async () => {
+    async function updateName() {
+        updating = true;
         try {
             await sdkForConsole.projects.update($project.$id, name);
             invalidate(Dependencies.PROJECT);
@@ -39,9 +41,15 @@
                 message: error.message
             });
         }
-    };
+    }
 
-    const serviceUpdate = async (service: Service) => {
+    $: {
+        // When project name is updated, finalize the updating flow
+        $project.name;
+        updating = false;
+    }
+
+    async function serviceUpdate(service: Service) {
         try {
             await sdkForConsole.projects.updateServiceStatus(
                 $project.$id,
@@ -65,7 +73,7 @@
                 message: error.message
             });
         }
-    };
+    }
 
     $: services.load($project);
 </script>
@@ -105,7 +113,7 @@
                 </svelte:fragment>
 
                 <svelte:fragment slot="actions">
-                    <Button disabled={name === $project.name} submit>Update</Button>
+                    <Button disabled={name === $project.name || updating} submit>Update</Button>
                 </svelte:fragment>
             </CardGrid>
         </Form>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Fixes a bug in which the update Platform name button would still be enabled after updating the name
- Disables the update name button on platform and project as soon as the button is clicked to avoid unnecessary additional clicks

## Test Plan

Manual

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes