### PR TITLE
Fix: copy not working on http

### DIFF
--- a/src/lib/components/copy.svelte
+++ b/src/lib/components/copy.svelte
@@ -2,6 +2,7 @@
     import { trackEvent } from '$lib/actions/analytics';
     import { tooltip } from '$lib/actions/tooltip';
     import { clickOnEnter } from '$lib/helpers/a11y';
+    import { copy } from '$lib/helpers/copy';
     import { addNotification } from '$lib/stores/notifications';
 
     export let value: string;
@@ -9,39 +10,8 @@
 
     let content = 'Click to copy';
 
-    async function securedCopy() {
-        try {
-            await navigator.clipboard.writeText(value);
-        } catch {
-            return false;
-        }
-
-        return true;
-    }
-
-    function unsecuredCopy() {
-        const textArea = document.createElement('textarea');
-        textArea.value = value;
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-
-        let success = true;
-        try {
-            document.execCommand('copy');
-        } catch {
-            success = false;
-        } finally {
-            document.body.removeChild(textArea);
-        }
-
-        return success;
-    }
-
-    async function copy() {
-        // securedCopy works only in HTTPS environment.
-        // unsecuredCopy works in HTTP and only runs if securedCopy fails.
-        const success = (await securedCopy()) || unsecuredCopy();
+    async function handleClick() {
+        const success = await copy(value);
 
         if (success) {
             content = 'Copied';
@@ -61,7 +31,7 @@
 </script>
 
 <span
-    on:click|preventDefault={copy}
+    on:click|preventDefault={handleClick}
     on:keyup={clickOnEnter}
     on:mouseenter={() => setTimeout(() => (content = 'Click to copy'))}
     use:tooltip={{

--- a/src/lib/components/copy.svelte
+++ b/src/lib/components/copy.svelte
@@ -39,7 +39,8 @@
     }
 
     async function copy() {
-        // Because of how JS works, unsecuredCopy only runs if securedCopy fails
+        // securedCopy works only in HTTPS environment.
+        // unsecuredCopy works in HTTP and only runs if securedCopy fails.
         const success = (await securedCopy()) || unsecuredCopy();
 
         if (success) {

--- a/src/lib/components/copy.svelte
+++ b/src/lib/components/copy.svelte
@@ -9,23 +9,54 @@
 
     let content = 'Click to copy';
 
-    const copy = async () => {
+    async function securedCopy() {
         try {
             await navigator.clipboard.writeText(value);
+        } catch {
+            return false;
+        }
+
+        return true;
+    }
+
+    function unsecuredCopy() {
+        const textArea = document.createElement('textarea');
+        textArea.value = value;
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+
+        let success = true;
+        try {
+            document.execCommand('copy');
+        } catch {
+            success = false;
+        } finally {
+            document.body.removeChild(textArea);
+        }
+
+        return success;
+    }
+
+    async function copy() {
+        // Because of how JS works, unsecuredCopy only runs if securedCopy fails
+        const success = (await securedCopy()) || unsecuredCopy();
+
+        if (success) {
             content = 'Copied';
-        } catch (error) {
+        } else {
             addNotification({
-                message: error.message,
+                message: 'Unable to copy to clipboard',
                 type: 'error'
             });
-        } finally {
-            if (event) {
-                trackEvent('click_id_tag', {
-                    name: event
-                });
-            }
         }
-    };
+
+        if (event) {
+            trackEvent('click_id_tag', {
+                name: event
+            });
+        }
+    }
 </script>
 
 <span

--- a/src/lib/components/copyInput.svelte
+++ b/src/lib/components/copyInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { tooltip } from '$lib/actions/tooltip';
+    import { copy } from '$lib/helpers/copy';
 
     import { addNotification } from '$lib/stores/notifications';
 
@@ -9,13 +10,14 @@
 
     let content = 'Click to copy';
 
-    const copy = async () => {
-        try {
-            await navigator.clipboard.writeText(value);
+    const handleCopy = async () => {
+        const success = await copy(value);
+
+        if (success) {
             content = 'Copied';
-        } catch (error) {
+        } else {
             addNotification({
-                message: error.message,
+                message: 'Unable to copy to clipboard',
                 type: 'error'
             });
         }
@@ -31,7 +33,7 @@
                 type="button"
                 class="input-button"
                 aria-label="Click to copy."
-                on:click={copy}
+                on:click={handleCopy}
                 on:mouseenter={() => setTimeout(() => (content = 'Click to copy'))}
                 use:tooltip={{
                     content,

--- a/src/lib/helpers/copy.ts
+++ b/src/lib/helpers/copy.ts
@@ -1,0 +1,36 @@
+async function securedCopy(value: string) {
+    try {
+        await navigator.clipboard.writeText(value);
+    } catch {
+        return false;
+    }
+
+    return true;
+}
+
+function unsecuredCopy(value: string) {
+    const textArea = document.createElement('textarea');
+    textArea.value = value;
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    let success = true;
+    try {
+        document.execCommand('copy');
+    } catch {
+        success = false;
+    } finally {
+        document.body.removeChild(textArea);
+    }
+
+    return success;
+}
+
+export async function copy(value: string) {
+    // securedCopy works only in HTTPS environment.
+    // unsecuredCopy works in HTTP and only runs if securedCopy fails.
+    const success = (await securedCopy(value)) || unsecuredCopy(value);
+
+    return success;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes a bug in which the copy component would trigger an error on non-local HTTP endpoints. To fix this, a unsecuredCopy method is introduced, which is called when the previous copy implementation doesn't work.

## Test Plan

Manual

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes