### PR TITLE
Fix: incorrect origin for non-web platforms

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/[platform]/android.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/[platform]/android.svelte
@@ -10,10 +10,10 @@
     import { project } from '../../../store';
     import { platform } from './store';
 
-    let packageName: string = null;
+    let key: string = null;
 
     onMount(() => {
-        packageName ??= $platform.key;
+        key ??= $platform.key;
     });
 
     const updateHostname = async () => {
@@ -22,7 +22,7 @@
                 $project.$id,
                 $platform.$id,
                 $platform.name,
-                packageName,
+                key,
                 $platform.store,
                 $platform.hostname
             );
@@ -52,16 +52,16 @@
         <svelte:fragment slot="aside">
             <FormList>
                 <InputText
-                    id="packageName"
+                    id="key"
                     label="Package Name"
-                    bind:value={packageName}
+                    bind:value={key}
                     required
                     placeholder="com.company.appname" />
             </FormList>
         </svelte:fragment>
 
         <svelte:fragment slot="actions">
-            <Button disabled={packageName === $platform.hostname} submit>Update</Button>
+            <Button disabled={key === $platform.hostname} submit>Update</Button>
         </svelte:fragment>
     </CardGrid>
 </Form>

--- a/src/routes/console/project-[project]/overview/platforms/[platform]/android.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/[platform]/android.svelte
@@ -10,10 +10,10 @@
     import { project } from '../../../store';
     import { platform } from './store';
 
-    let hostname: string = null;
+    let packageName: string = null;
 
     onMount(() => {
-        hostname ??= $platform.hostname;
+        packageName ??= $platform.key;
     });
 
     const updateHostname = async () => {
@@ -22,9 +22,9 @@
                 $project.$id,
                 $platform.$id,
                 $platform.name,
-                $platform.key,
+                packageName,
                 $platform.store,
-                hostname
+                $platform.hostname
             );
             invalidate(Dependencies.PLATFORM);
             trackEvent('submit_platform_update', {
@@ -52,16 +52,16 @@
         <svelte:fragment slot="aside">
             <FormList>
                 <InputText
-                    id="hostname"
+                    id="packageName"
                     label="Package Name"
-                    bind:value={hostname}
+                    bind:value={packageName}
                     required
                     placeholder="com.company.appname" />
             </FormList>
         </svelte:fragment>
 
         <svelte:fragment slot="actions">
-            <Button disabled={hostname === $platform.hostname} submit>Update</Button>
+            <Button disabled={packageName === $platform.hostname} submit>Update</Button>
         </svelte:fragment>
     </CardGrid>
 </Form>

--- a/src/routes/console/project-[project]/overview/platforms/wizard/android/step1.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/android/step1.svelte
@@ -31,9 +31,9 @@
             projectId,
             'android',
             $createPlatform.name,
+            $createPlatform.key,
             undefined,
-            undefined,
-            $createPlatform.hostname
+            undefined
         );
 
         $createPlatform.$id = platform.$id;
@@ -50,11 +50,11 @@
             required
             bind:value={$createPlatform.name} />
         <InputText
-            id="hostname"
+            id="key"
             label="Package Name"
             placeholder="com.company.appname"
             tooltip="Your package name is generally the applicationId in your app-level build.gradle file."
             required
-            bind:value={$createPlatform.hostname} />
+            bind:value={$createPlatform.key} />
     </FormList>
 </WizardStep>

--- a/src/routes/console/project-[project]/overview/platforms/wizard/apple/step1.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/apple/step1.svelte
@@ -41,9 +41,9 @@
             projectId,
             platform,
             $createPlatform.name,
+            $createPlatform.key,
             undefined,
-            undefined,
-            $createPlatform.hostname
+            undefined
         );
 
         $createPlatform.$id = response.$id;
@@ -95,6 +95,6 @@
             placeholder="com.company.appname"
             tooltip="You can find your Bundle Identifier in the General tab for your app's primary target in Xcode."
             required
-            bind:value={$createPlatform.hostname} />
+            bind:value={$createPlatform.key} />
     </FormList>
 </WizardStep>

--- a/src/routes/console/project-[project]/overview/platforms/wizard/flutter/step1.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/flutter/step1.svelte
@@ -97,9 +97,9 @@
             projectId,
             platform,
             $createPlatform.name,
+            platform !== Platform.Web ? $createPlatform.key : undefined,
             undefined,
-            undefined,
-            $createPlatform.hostname
+            platform === Platform.Web ? $createPlatform.hostname : undefined
         );
 
         $createPlatform.$id = response.$id;
@@ -160,15 +160,16 @@
             placeholder={placeholder[platform].name}
             required
             bind:value={$createPlatform.name} />
-        <div>
-            <InputText
-                id="hostname"
-                label={hostname[platform]}
-                placeholder={placeholder[platform].hostname}
-                tooltip={placeholder[platform].tooltip}
-                required
-                bind:value={$createPlatform.hostname} />
-            {#if platform === Platform.Web}
+        {#if platform === Platform.Web}
+            <div>
+                <InputText
+                    id="hostname"
+                    label={hostname[platform]}
+                    placeholder={placeholder[platform].hostname}
+                    tooltip={placeholder[platform].tooltip}
+                    required
+                    bind:value={$createPlatform.hostname} />
+
                 <div class="u-flex u-gap-16 u-margin-block-start-8">
                     {#each suggestions as suggestion}
                         <Pill
@@ -179,7 +180,15 @@
                         </Pill>
                     {/each}
                 </div>
-            {/if}
-        </div>
+            </div>
+        {:else}
+            <InputText
+                id="key"
+                label={hostname[platform]}
+                placeholder={placeholder[platform].hostname}
+                tooltip={placeholder[platform].tooltip}
+                required
+                bind:value={$createPlatform.key} />
+        {/if}
     </FormList>
 </WizardStep>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes an issue where `hostname` was being passed on the create platform integration wizard, instead of `key`.

## Test Plan

Manual

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/4787

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes