### PR TITLE
feat (auth): user session limit section & Password history on auth security

### DIFF
--- a/src/routes/console/project-[project]/auth/security/+page.svelte
+++ b/src/routes/console/project-[project]/auth/security/+page.svelte
@@ -21,7 +21,7 @@
     let period = writable('s');
     let btnActive = false;
     let maxSessions = $project.authMaxSessions ?? 10;
-    let passwordHistory = $project.passwordHistory ?? 0;
+    let passwordHistory = $project.authPasswordHistory ?? 0;
 
     let options = [
         { label: 'days', value: 'd' },

--- a/src/routes/console/project-[project]/auth/security/+page.svelte
+++ b/src/routes/console/project-[project]/auth/security/+page.svelte
@@ -21,6 +21,7 @@
     let period = writable('s');
     let btnActive = false;
     let maxSessions = $project.authMaxSessions ?? 10;
+    let passwordHistory = $project.passwordHistory ?? 0;
 
     let options = [
         { label: 'days', value: 'd' },
@@ -84,19 +85,49 @@
     }
     async function updateSessionsLimit() {
         try {
-
             const path = '/projects/' + projectId + '/auth/max-sessions';
             const uri = new URL(sdkForConsole.client.config.endpoint + path);
-            await sdkForConsole.client.call('patch', uri, {
-                'content-type': 'application/json',
-            }, {
-                limit: maxSessions
-            });
+            await sdkForConsole.client.call(
+                'patch',
+                uri,
+                {
+                    'content-type': 'application/json'
+                },
+                {
+                    limit: maxSessions
+                }
+            );
             addNotification({
                 type: 'success',
                 message: 'Sessions limit has been updated'
             });
             trackEvent('submit_sessions_limit_update');
+        } catch (error) {
+            addNotification({
+                type: 'error',
+                message: error.message
+            });
+        }
+    }
+    async function updatePasswordHistoryLimit() {
+        try {
+            const path = '/projects/' + projectId + '/auth/password-history';
+            const uri = new URL(sdkForConsole.client.config.endpoint + path);
+            await sdkForConsole.client.call(
+                'patch',
+                uri,
+                {
+                    'content-type': 'application/json'
+                },
+                {
+                    limit: passwordHistory
+                }
+            );
+            addNotification({
+                type: 'success',
+                message: 'Password history limit has been updated'
+            });
+            trackEvent('submit_password_history_limit_update');
         } catch (error) {
             addNotification({
                 type: 'error',
@@ -225,17 +256,35 @@
     <Form on:submit={updateSessionsLimit}>
         <CardGrid>
             <Heading tag="h2" size="6">Session Limit</Heading>
-            <p>
-                Maximum number of active sessions allowed per user.
-            </p>
+            <p>Maximum number of active sessions allowed per user.</p>
             <svelte:fragment slot="aside">
-                    <ul>
-                        <InputNumber id="max-session" label="Limit" bind:value={maxSessions} />
-                    </ul>
+                <ul>
+                    <InputNumber id="max-session" label="Limit" bind:value={maxSessions} />
+                </ul>
             </svelte:fragment>
-    
+
             <svelte:fragment slot="actions">
                 <Button disabled={maxSessions === $project.authMaxSessions} submit>Update</Button>
+            </svelte:fragment>
+        </CardGrid>
+    </Form>
+
+    <Form on:submit={updatePasswordHistoryLimit}>
+        <CardGrid>
+            <Heading tag="h2" size="6">Password History</Heading>
+            <p>
+                Maximum nubmer of password history to save for a user. 0 for disabling the password
+                history.
+            </p>
+            <svelte:fragment slot="aside">
+                <ul>
+                    <InputNumber id="max-session" label="Limit" bind:value={passwordHistory} />
+                </ul>
+            </svelte:fragment>
+
+            <svelte:fragment slot="actions">
+                <Button disabled={passwordHistory === $project.passwordHistory} submit
+                    >Update</Button>
             </svelte:fragment>
         </CardGrid>
     </Form>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Add section to set number of sessions limit on Auth, under Security tab

![image](https://user-images.githubusercontent.com/6360216/206971644-3ca83999-9e28-4119-bdac-8a5e57a343cb.png)

- Add section to set the password history limit on Auth, under security tab

![image](https://user-images.githubusercontent.com/6360216/208837702-340394e5-0604-4bd4-a459-dd797e8c3c6d.png)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/4831

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)