### PR TITLE
Update contributing guide for dev server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,16 @@ If you are worried or don’t know where to start, check out our next section ex
 
 ## Development
 
-Once you've created a project and installed dependencies with `npm install`, start a development server:
+Once you've created a project and installed dependencies with `npm install`, create a `.env` file using `.env.example` as a template.
+
+Finally, start a development server:
 
 ```bash
 npm run dev
 ```
+
+> **Note**
+> If http://localhost:3000 is blank and the browser console logs have a `TypeError: Failed to fetch dynamically imported module: http://localhost:3000/.svelte-kit/generated/nodes/0.js` error, try to turn off any ad blocker you have and reload the page ([reference](https://github.com/sveltejs/kit/issues/3308#issuecomment-1149942109)).
 
 ### Build
 


### PR DESCRIPTION
## What does this PR do?

Add step for creating .env file because without the file, `npm run dev` results in:

```
  VITE v3.2.1  ready in 568 ms

  ➜  Local:   http://127.0.0.1:3000/
  ➜  Network: use --host to expose
window is not defined
ReferenceError: window is not defined
    at /private/tmp/console/src/lib/stores/sdk.ts:16:61
    at async instantiateModule (file:///private/tmp/console/node_modules/vite/dist/node/chunks/dep-d29b4e33.js:54234:9)
window is not defined
ReferenceError: window is not defined
    at /private/tmp/console/src/lib/stores/sdk.ts:16:61
    at async instantiateModule (file:///private/tmp/console/node_modules/vite/dist/node/chunks/dep-d29b4e33.js:54234:9)
window is not defined
ReferenceError: window is not defined
    at /private/tmp/console/src/lib/stores/sdk.ts:16:61
    at async instantiateModule (file:///private/tmp/console/node_modules/vite/dist/node/chunks/dep-d29b4e33.js:54234:9)
```

Add note about adblocker because this error occurs with adblocker enabled:

```
TypeError: Failed to fetch dynamically imported module: http://localhost:3000/.svelte-kit/generated/nodes/0.js
```

## Test Plan

Manual

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes