### PR TITLE
Fix flutter web as new platform option

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/wizard/flutter/step1.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/flutter/step1.svelte
@@ -19,7 +19,7 @@
         Linux = 'flutter-linux',
         Macos = 'flutter-macos',
         Windows = 'flutter-windows',
-        Web = 'flutter-web'
+        Web = 'web'
     }
 
     let platform: Platform = Platform.Android;


### PR DESCRIPTION
## What does this PR do?
When creating a new platform using flutter, the web option were throwing an error of "invalid platform type".

The error was because by the type "flutter-web" sent from console was while the backend expects only "web".

This commit fix #4803.

## Test Plan
I modified the enum Platform on file [step1.svelte](https://github.com/appwrite/console/compare/main...ianmaciel:console:feat-4803-fix-flutter_web_as_new_platform?expand=1#diff-690543a5a38a509bf32bbba24157cf6e945445c2c871ba10d9f30be9bd6358e4). To make sure it fixed the issue, I started the server locally (using docker, and configuring my env endpoint to https://localhost/v1) and tried to create a new platform using "Flutter web".

At this time, the requested were sent as expected (using the type "web" instead of "flutter-web"), and I could create my platform.

![image](https://user-images.githubusercontent.com/1381078/211628322-7060830b-390f-4c10-b1a7-03c374fe2c61.png)

![image](https://user-images.githubusercontent.com/1381078/211628388-044caa44-02e0-45b8-8c1f-ec63a5e00157.png)

## Related PRs and Issues

[(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)
](https://github.com/appwrite/appwrite/issues/4803)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes