### PR TITLE
Fix organization delete

### DIFF
--- a/src/routes/console/organization-[organization]/deleteOrganization.svelte
+++ b/src/routes/console/organization-[organization]/deleteOrganization.svelte
@@ -8,8 +8,8 @@
     import { base } from '$app/paths';
     import { Dependencies } from '$lib/constants';
     import { trackEvent } from '$lib/actions/analytics';
-    import { Query } from "@aw-labs/appwrite-console";
-    import { FormList, InputPassword, InputText } from "$lib/elements/forms/index.js";
+    import { Query } from '@aw-labs/appwrite-console';
+    import { FormList, InputPassword, InputText } from '$lib/elements/forms/index.js';
 
     export let showDelete = false;
 
@@ -19,12 +19,14 @@
     const deleteOrg = async () => {
         try {
             const projectList = await sdkForConsole.projects.list([
-                Query.equal('teamId', $organization.$id),
-            ])
+                Query.equal('teamId', $organization.$id)
+            ]);
 
-            await Promise.all(projectList.projects.map(async (project) => {
-                await sdkForConsole.projects.delete(project.$id, password);
-            }));
+            await Promise.all(
+                projectList.projects.map(async (project) => {
+                    await sdkForConsole.projects.delete(project.$id, password);
+                })
+            );
 
             await sdkForConsole.teams.delete($organization.$id);
 
@@ -53,8 +55,8 @@
 <Modal on:submit={deleteOrg} bind:show={showDelete} warning>
     <svelte:fragment slot="header">Delete Organization</svelte:fragment>
     <p>
-        Are you sure you want to delete <b>{$organization.name}</b>? All projects
-        and data associated with this organization will be deleted. This action is irreversible.
+        Are you sure you want to delete <b>{$organization.name}</b>? All projects and data
+        associated with this organization will be deleted. This action is irreversible.
     </p>
 
     <FormList>

--- a/src/routes/console/organization-[organization]/deleteOrganization.svelte
+++ b/src/routes/console/organization-[organization]/deleteOrganization.svelte
@@ -53,7 +53,7 @@
 <Modal on:submit={deleteOrg} bind:show={showDelete} warning>
     <svelte:fragment slot="header">Delete Organization</svelte:fragment>
     <p>
-        Are you sure you want to delete <b>{$organization.name}</b>? All projects ({$organization.total})
+        Are you sure you want to delete <b>{$organization.name}</b>? All projects
         and data associated with this organization will be deleted. This action is irreversible.
     </p>
 

--- a/src/routes/console/organization-[organization]/deleteOrganization.svelte
+++ b/src/routes/console/organization-[organization]/deleteOrganization.svelte
@@ -18,8 +18,6 @@
 
     const deleteOrg = async () => {
         try {
-            await sdkForConsole.teams.delete($organization.$id);
-
             const projectList = await sdkForConsole.projects.list([
                 Query.equal('teamId', $organization.$id),
             ])
@@ -27,6 +25,8 @@
             await Promise.all(projectList.projects.map(async (project) => {
                 await sdkForConsole.projects.delete(project.$id, password);
             }));
+
+            await sdkForConsole.teams.delete($organization.$id);
 
             addNotification({
                 type: 'success',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix organization delete not deleting projects by iterating the projects with the org team ID.

Requires adding a password input to the org delete modal. 
Org name input was added to make it consistent with the project delete


## Test Plan

Manual test

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/5006

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes