### PR TITLE
fix: handle empty growth endpoint

### DIFF
--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -5,6 +5,7 @@ import { page } from '$app/stores';
 import { user } from '$lib/stores/user';
 import { growthEndpoint, Mode } from '$lib/constants';
 
+const isDevelopment = import.meta.env.DEV || import.meta.env?.VERCEL_ENV === 'preview';
 const analytics = Analytics({
     app: 'appwrite',
     plugins: [
@@ -18,9 +19,15 @@ export function trackEvent(name: string, data: object = null): void {
     if (!isTrackingAllowed()) {
         return;
     }
+
     const path = get(page).route.id;
-    analytics.track(name, { ...data, path });
-    sendEventToGrowth(name, path, data);
+
+    if (isDevelopment) {
+        console.log(`[Analytics] Event ${name} ${path}`, data);
+    } else {
+        analytics.track(name, { ...data, path });
+        sendEventToGrowth(name, path, data);
+    }
 }
 
 export function trackPageView(path: string) {
@@ -28,9 +35,13 @@ export function trackPageView(path: string) {
         return;
     }
 
-    analytics.page({
-        path
-    });
+    if (isDevelopment) {
+        console.log(`[Analytics] Pageview ${path}`);
+    } else {
+        analytics.page({
+            path
+        });
+    }
 }
 
 function sendEventToGrowth(event: string, path: string, data: object = null): void {

--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -34,8 +34,9 @@ export function trackPageView(path: string) {
 }
 
 function sendEventToGrowth(event: string, path: string, data: object = null): void {
-    let email: string, name: string;
+    if (!growthEndpoint) return;
     const userStore = get(user);
+    let email: string, name: string;
     if (userStore) {
         email = userStore.email;
         name = userStore.name;

--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -5,7 +5,7 @@ import { page } from '$app/stores';
 import { user } from '$lib/stores/user';
 import { growthEndpoint, Mode } from '$lib/constants';
 
-const isDevelopment = import.meta.env.DEV || import.meta.env?.VERCEL_ENV === 'preview';
+const isDevelopment = import.meta.env.DEV || import.meta.env?.VERCEL_ENV?.toString() === 'preview';
 const analytics = Analytics({
     app: 'appwrite',
     plugins: [

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -60,6 +60,7 @@ function createFeedbackStore() {
             email?: string,
             value?: number
         ) => {
+            if (!growthEndpoint) return;
             const response = await fetch(`${growthEndpoint}/feedback`, {
                 method: 'POST',
                 headers: {


### PR DESCRIPTION
## What does this PR do?

- handles empty `VITE_APPWRITE_GROWTH_ENDPOINT` env variable

## Test Plan

- manual

## Related PRs and Issues

- none

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 