### PR TITLE
fix: enum attribute editable issue in overview modal

### DIFF
--- a/src/lib/elements/forms/inputTags.svelte
+++ b/src/lib/elements/forms/inputTags.svelte
@@ -89,7 +89,7 @@
                                     type="button"
                                     class="input-tag-delete-button"
                                     aria-label={`delete ${tag} tag`}
-                                    on:click={() => removeValue(tag)}>
+                                    on:click={() => !readonly && removeValue(tag)}>
                                     <span class="icon-x" aria-hidden="true" />
                                 </button>
                             </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It fixes the issue where enum attributes were editable in overview modal. 

## Test Plan

Tested manually by creating enum attribute in localhost and tried editing the enum input tag by writing or removing the tags.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/5009

### Have you read the [Contributing Guidelines on issues

Yes, I have read the contributing guidelines
