### PR TITLE
fix: use singular instead of plural at file upload

### DIFF
--- a/src/lib/elements/forms/inputFile.svelte
+++ b/src/lib/elements/forms/inputFile.svelte
@@ -77,7 +77,7 @@
             </div>
             <div class="u-min-width-0 u-text-center">
                 <h5 class="upload-file-box-title heading-level-7 u-inline">
-                    <span class="is-only-desktop">Drag and drop files here to upload</span>
+                    <span class="is-only-desktop">Drag and drop a file here to upload</span>
                     <span class="is-not-desktop">Upload a File</span>
                 </h5>
                 {#if allowedFileExtensions?.length}


### PR DESCRIPTION
## What does this PR do?

As already described in the [issue](https://github.com/appwrite/appwrite/issues/5139), the plural of file is currently used. However, this is currently incorrect as only one file can be uploaded at a time. This pull request fixes this error by replacing the phrase “Drag and drop files here to upload” with “Drag and drop a file here to upload”.

## Test Plan

Just run build. 😉

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/5139

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes ✅