### PR TITLE
fix: update Documentation hyperlink on empty sessions page

### DIFF
--- a/src/routes/console/account/sessions/[[page]]/+page.svelte
+++ b/src/routes/console/account/sessions/[[page]]/+page.svelte
@@ -115,7 +115,7 @@
                     <Button
                         external
                         secondary
-                        href="https://appwrite.io/docs/server/auth?sdk=nodejs-default#usersGetsessions">
+                        href="https://appwrite.io/docs/client/account#accountCreateEmailSession">
                         Documentation
                     </Button>
                 </div>

--- a/src/routes/console/project-[project]/auth/user-[user]/sessions/[[page]]/+page.svelte
+++ b/src/routes/console/project-[project]/auth/user-[user]/sessions/[[page]]/+page.svelte
@@ -90,7 +90,7 @@
                 <Button
                     external
                     secondary
-                    href="https://appwrite.io/docs/server/auth?sdk=nodejs-default#usersGetSessions">
+                    href="https://appwrite.io/docs/client/account#accountCreateEmailSession">
                     Documentation
                 </Button>
             </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Previously the Documentation button on an empty session page pointed to https://appwrite.io/docs/server/auth?sdk=nodejs-default#usersGetSessions which does not exist. This commit fixes that by redirecting the user to https://appwrite.io/docs/client/account#accountCreateEmailSession

## Test Plan
- Manually tested on the Auth > Users > Session Page

## Related PRs and Issues
https://github.com/appwrite/appwrite/issues/5189

### Have you read the [Contributing Guidelines on issues] Yes