### PR TITLE
Refactor: Table sticky scroll only when overflowing

### DIFF
--- a/src/lib/elements/table/tableScroll.svelte
+++ b/src/lib/elements/table/tableScroll.svelte
@@ -1,10 +1,30 @@
 <script lang="ts">
+    import type { Action } from 'svelte/action';
+
     export let isSticky = false;
+
+    const hasOverflow: Action<HTMLDivElement, (value: boolean) => void> = (node, callback) => {
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                callback(entry.contentRect.width < entry.target.scrollWidth);
+            }
+        });
+
+        observer.observe(node);
+
+        return {
+            destroy() {
+                observer.disconnect();
+            }
+        };
+    };
+
+    let isOverflowing = false;
 </script>
 
 <div class="table-with-scroll u-margin-block-start-32" data-private>
-    <div class="table-wrapper">
-        <table class="table" class:is-sticky-scroll={isSticky}>
+    <div class="table-wrapper" use:hasOverflow={(v) => (isOverflowing = v)}>
+        <table class="table" class:is-sticky-scroll={isSticky && isOverflowing}>
             <slot />
         </table>
     </div>

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -81,9 +81,14 @@
     .main-side {
         z-index: 25;
     }
+
     @media (max-width: 550.99px), (min-width: 551px) and (max-width: 1198.99px) {
         .main-side {
             top: 4.5rem;
         }
+    }
+
+    .main-content {
+        overflow: hidden;
     }
 </style>

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/[[page]]/+page.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/[[page]]/+page.svelte
@@ -91,7 +91,7 @@
         {#if data.documents.total}
             <TableScroll isSticky>
                 <TableHeader>
-                    <TableCellHead eyebrow={false}>Document ID</TableCellHead>
+                    <TableCellHead width={200} eyebrow={false}>Document ID</TableCellHead>
                     {#each columns as column}
                         <TableCellHead eyebrow={false}>{column.title}</TableCellHead>
                     {/each}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Makes table sticky scroll only activate when the content overflows

## Test Plan

Manual

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes