### PR TITLE
fix: session modal was not closed after successful deletion

### DIFF
--- a/src/routes/console/project-[project]/auth/user-[user]/deleteSession.svelte
+++ b/src/routes/console/project-[project]/auth/user-[user]/deleteSession.svelte
@@ -15,6 +15,7 @@
         try {
             await sdk.forProject.users.deleteSession($page.params.user, selectedSessionId);
             await invalidate(Dependencies.SESSIONS);
+            showDelete = false;
             addNotification({
                 type: 'success',
                 message: 'Session has been deleted'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In this PR I am closing the session delete modal after a successful API call.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
YES