### PR TITLE
fix: Fix issue of truncate in id in documents page

### DIFF
--- a/src/lib/components/id.svelte
+++ b/src/lib/components/id.svelte
@@ -31,7 +31,7 @@
                 }
             }
         }
-        checkOverflow();
+        requestAnimationFrame(checkOverflow);
         window.addEventListener('resize', checkOverflow);
 
         return {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes the issue https://github.com/appwrite/appwrite/issues/5406
I tried debugging it and found out that after document is created and when the table updates with new document record, for that document, html node containing id scrollWidth and clientWidth properties were coming 0 and thats why truncateText function was not truncating this node's value

First solution which i tried was to delay it by some milliseconds after the node is rendered with setTimeout(() => checkOverflow(), 2), so that scrollWidth and clientWidth property values comes correct. But this is not good from performance perspective. So i found out we can use requestAnimationFrame which is very good from performance perspective. So I used it and it fixed the issue. Please review it and let me know if its a good solution. Thanks

## Test Plan

Manual testing in the console locally

## Before

https://user-images.githubusercontent.com/32243289/233837834-035f8207-07ad-49da-8e5b-899aa9da2398.mp4

## After

https://user-images.githubusercontent.com/32243289/233837843-fef34922-85c0-4ad2-9800-940ca8fff5f8.mp4

## Related PRs and Issues
Issue: https://github.com/appwrite/appwrite/issues/5406

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes
