### PR TITLE
Update the OAuth2 success and failure pages

### DIFF
--- a/src/routes/auth/oauth2/failure/+page.svelte
+++ b/src/routes/auth/oauth2/failure/+page.svelte
@@ -2,20 +2,56 @@
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
     import { Heading } from '$lib/components';
-    import { onMount } from 'svelte';
 
-    onMount(async () => {
-        const project = $page.url.searchParams.get('project');
-        if (project) {
-            await goto(`appwrite-callback-${project}://${$page.url.search}`);
+    const project = $page.url.searchParams.get('project');
+    const link = `appwrite-callback-${project}://${$page.url.search}`;
+
+    const redirect = new Promise((resolve, reject) => {
+        if (!project) {
+            reject('no-project');
         }
+        // this timeout is needed because goto does not
+        // throw an exception if the redirect does not work
+        setTimeout(() => reject('timeout'), 500);
+        // goto will resolve on successful redirect
+        goto(link).then(resolve);
     });
 </script>
 
-<Heading tag="h1" size="1">Missing Redirect URL</Heading>
-<p class="text">
-    Your OAuth login flow is missing a proper redirect URL. Please check the
-    <a class="link" href="https://appwrite.io/docs/client/account?sdk=web#createOAuth2Session"
-        >OAuth docs</a>
-    and send request for new session with a valid callback URL.
-</p>
+{#await redirect then}
+    <article class="card u-padding-16">
+        <div class="u-flex u-flex-vertical u-gap-16">
+            <Heading tag="h1" size="4">Login failed</Heading>
+            <p class="text">You will be automatically redirected back to your app shortly.</p>
+            <p class="text">
+                If you are not redirected, please click on the following
+                <a class="link" href={`appwrite-callback-${project}://${$page.url.search}`}>link</a
+                >.
+            </p>
+        </div>
+    </article>
+{:catch}
+    <article class="card u-padding-16">
+        <div class="u-flex u-flex-vertical u-gap-16">
+            <Heading tag="h1" size="4">Missing Redirect URL</Heading>
+            <p class="text">
+                Your OAuth login flow is missing a proper redirect URL. Please check the
+                <a
+                    class="link"
+                    href="https://appwrite.io/docs/client/account?sdk=web#createOAuth2Session"
+                    >OAuth docs</a>
+                and send request for new session with a valid callback URL.
+            </p>
+        </div>
+    </article>
+{/await}
+
+<style lang="scss">
+    @import '@appwrite.io/pink/src/abstract/variables/_devices.scss';
+    // override padding for screens bigger than mobile
+    @media #{$break2open} {
+        article.card {
+            padding: 2rem !important;
+        }
+    }
+</style>

--- a/src/routes/auth/oauth2/success/+page.svelte
+++ b/src/routes/auth/oauth2/success/+page.svelte
@@ -2,20 +2,56 @@
     import { goto } from '$app/navigation';
     import { page } from '$app/stores';
     import { Heading } from '$lib/components';
-    import { onMount } from 'svelte';
 
-    onMount(async () => {
-        const project = $page.url.searchParams.get('project');
-        if (project) {
-            await goto(`appwrite-callback-${project}://${$page.url.search}`);
+    const project = $page.url.searchParams.get('project');
+    const link = `appwrite-callback-${project}://${$page.url.search}`;
+
+    const redirect = new Promise((resolve, reject) => {
+        if (!project) {
+            reject('no-project');
         }
+        // this timeout is needed because goto does not
+        // throw an exception if the redirect does not work
+        setTimeout(() => reject('timeout'), 500);
+        // goto will resolve on successful redirect
+        goto(link).then(resolve);
     });
 </script>
 
-<Heading tag="h1" size="1">Missing Redirect URL</Heading>
-<p class="text">
-    Your OAuth login flow is missing a proper redirect URL. Please check the
-    <a class="link" href="https://appwrite.io/docs/client/account?sdk=web#createOAuth2Session"
-        >OAuth docs</a>
-    and send request for new session with a valid callback URL.
-</p>
+{#await redirect then}
+    <article class="card u-padding-16">
+        <div class="u-flex u-flex-vertical u-gap-16">
+            <Heading tag="h1" size="4">You're now logged in</Heading>
+            <p class="text">You will be automatically redirected back to your app shortly.</p>
+            <p class="text">
+                If you are not redirected, please click on the following
+                <a class="link" href={`appwrite-callback-${project}://${$page.url.search}`}>link</a
+                >.
+            </p>
+        </div>
+    </article>
+{:catch}
+    <article class="card u-padding-16">
+        <div class="u-flex u-flex-vertical u-gap-16">
+            <Heading tag="h1" size="4">Missing Redirect URL</Heading>
+            <p class="text">
+                Your OAuth login flow is missing a proper redirect URL. Please check the
+                <a
+                    class="link"
+                    href="https://appwrite.io/docs/client/account?sdk=web#createOAuth2Session"
+                    >OAuth docs</a>
+                and send request for new session with a valid callback URL.
+            </p>
+        </div>
+    </article>
+{/await}
+
+<style lang="scss">
+    @import '@appwrite.io/pink/src/abstract/variables/_devices.scss';
+    // override padding for screens bigger than mobile
+    @media #{$break2open} {
+        article.card {
+            padding: 2rem !important;
+        }
+    }
+</style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

1. Update design to be more consistent with other pages, while still unbranded
2. Update sizing to be more mobile friendly as the original heading size was truncated on mobile
3. Show a different message when redirecting back to the app to clarify the login was successful
4. Close the window after redirecting so the user doesn't have to

Closes https://github.com/appwrite/appwrite/issues/3930

## Test Plan

Manual

### Light Mobile Redirect

![image](https://github.com/appwrite/console/assets/1477010/847a46fe-800d-4d08-9a61-a7c1160fd6c0)

### Light Desktop Missing Redirect URL

![image](https://github.com/appwrite/console/assets/1477010/fdc8c5fc-b4e8-45cc-bbe8-a9178692db56)

### Dark Mobile Redirect

![image](https://github.com/appwrite/console/assets/1477010/fccdb711-5c68-42a2-9fb0-04ed304de066)

### Dark Desktop Missing Redirect URL

![image](https://github.com/appwrite/console/assets/1477010/38bb0f18-ac13-47e7-8bc4-a517874a2ed8)

### Videos of the Redirect

#### Success

[success.webm](https://github.com/appwrite/console/assets/1477010/8eed4164-03d8-483b-8675-e198fffb8f71)

#### Failure

https://github.com/appwrite/console/assets/1477010/6ad10bd9-6c72-401f-b541-3b446f1b3bf2

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/3930

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes