### PR TITLE
Fixed `Extraneous argument label 'status:' in call` for Apple App setup

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/wizard/apple/step3.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/apple/step3.svelte
@@ -10,7 +10,7 @@
 let client = Client()
     .setEndpoint("${endpoint}")
     .setProject("${project}")
-    .setSelfSigned(status: true) // For self signed certificates, only use for development`;
+    .setSelfSigned(true) // For self signed certificates, only use for development`;
 
     let showAlert = true;
 </script>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Provides a fix for [issue #467](https://github.com/appwrite/console/issues/467), where the code snippet for setting up the `Client` on an Apple native app using Swift is throwing the following error: `Extraneous argument label 'status:' in call`.

## Test Plan

Copy this code into an Apple Xcode project (Swift), paste the following code snippet modified in this PR:

```swift
import Appwrite

let client = Client()
    .setEndpoint("http://localhost:3000/v1")
    .setProject("6496fd6f36368405265d")
    .setSelfSigned(true) // For self signed certificates, only use for development
```

Made sure it doesn't throw the `Extraneous argument label 'status:' in call` error by the compiler.

## Related PRs and Issues

Provides a fix for [issue #467](https://github.com/appwrite/console/issues/467).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.