### PR TITLE
Clear validator when closing wizard

### DIFF
--- a/src/lib/stores/wizard.ts
+++ b/src/lib/stores/wizard.ts
@@ -1,11 +1,11 @@
 import { trackEvent } from '$lib/actions/analytics';
-import type { SvelteComponent } from 'svelte';
+import type { ComponentType } from 'svelte';
 import { writable } from 'svelte/store';
 
 export type WizardStore = {
     show: boolean;
     media?: string;
-    component?: typeof SvelteComponent;
+    component?: ComponentType;
     interceptor?: () => Promise<void>;
 };
 
@@ -20,7 +20,7 @@ function createWizardStore() {
     return {
         subscribe,
         set,
-        start: (component: typeof SvelteComponent, media: string = null) =>
+        start: (component: ComponentType, media: string = null) =>
             update((n) => {
                 n.show = true;
                 n.component = component;

--- a/src/lib/stores/wizard.ts
+++ b/src/lib/stores/wizard.ts
@@ -24,6 +24,7 @@ function createWizardStore() {
             update((n) => {
                 n.show = true;
                 n.component = component;
+                n.interceptor = null;
                 n.media = media;
                 trackEvent('wizard_start');
                 return n;
@@ -39,6 +40,7 @@ function createWizardStore() {
             update((n) => {
                 n.show = false;
                 n.component = null;
+                n.interceptor = null;
                 n.media = null;
 
                 return n;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Clear wizard interceptor on wizard start and close. Without doing this, an interceptor from a different wizard can run when a new wizard is opened causing incorrect validation.

Fixes [appwrite#4847](https://github.com/appwrite/appwrite/issues/4847)

## Test Plan

1. Open Add a web platform wizard
2. Cancel
3. Open API key wizard
4. Fill out name
5. Submit

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/4847

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes