### PR TITLE
Replace sorting by $createdAt with natural order

### DIFF
--- a/src/routes/console/account/organizations/+page.ts
+++ b/src/routes/console/account/organizations/+page.ts
@@ -15,7 +15,7 @@ export const load: PageLoad = async ({ url, route }) => {
         organizations: await sdk.forConsole.teams.list([
             Query.offset(offset),
             Query.limit(limit),
-            Query.orderDesc('$createdAt')
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/organization-[organization]/+page.ts
+++ b/src/routes/console/organization-[organization]/+page.ts
@@ -15,7 +15,8 @@ export const load: PageLoad = async ({ params, url, route }) => {
         projects: await sdk.forConsole.projects.list([
             Query.offset(offset),
             Query.equal('teamId', params.organization),
-            Query.limit(CARD_LIMIT)
+            Query.limit(CARD_LIMIT),
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/project-[project]/auth/+page.ts
+++ b/src/routes/console/project-[project]/auth/+page.ts
@@ -16,7 +16,7 @@ export const load: PageLoad = async ({ url, route }) => {
         search,
         page,
         users: await sdk.forProject.users.list(
-            [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')],
+            [Query.limit(limit), Query.offset(offset), Query.orderDesc('')],
             search
         )
     };

--- a/src/routes/console/project-[project]/auth/teams/+page.ts
+++ b/src/routes/console/project-[project]/auth/teams/+page.ts
@@ -16,7 +16,7 @@ export const load: PageLoad = async ({ url, route }) => {
         search,
         page,
         teams: await sdk.forProject.teams.list(
-            [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')],
+            [Query.limit(limit), Query.offset(offset), Query.orderDesc('')],
             search
         )
     };

--- a/src/routes/console/project-[project]/auth/teams/team-[team]/members/+page.ts
+++ b/src/routes/console/project-[project]/auth/teams/team-[team]/members/+page.ts
@@ -18,7 +18,7 @@ export const load: PageLoad = async ({ params, depends, url, route }) => {
         limit,
         memberships: await sdk.forProject.teams.listMemberships(
             teamId,
-            [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')],
+            [Query.limit(limit), Query.offset(offset), Query.orderDesc('')],
             search
         )
     };

--- a/src/routes/console/project-[project]/databases/+page.ts
+++ b/src/routes/console/project-[project]/databases/+page.ts
@@ -17,7 +17,7 @@ export const load: PageLoad = async ({ url, route }) => {
         databases: await sdk.forProject.databases.list([
             Query.limit(limit),
             Query.offset(offset),
-            Query.orderDesc('$createdAt')
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/project-[project]/databases/database-[database]/+page.ts
+++ b/src/routes/console/project-[project]/databases/database-[database]/+page.ts
@@ -17,7 +17,7 @@ export const load: PageLoad = async ({ params, url, route }) => {
         collections: await sdk.forProject.databases.listCollections(params.database, [
             Query.limit(limit),
             Query.offset(offset),
-            Query.orderDesc('$createdAt')
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/+layout.ts
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/+layout.ts
@@ -19,7 +19,7 @@ export const load: LayoutLoad = async ({ params, depends }) => {
             ),
             subNavigation: SubNavigation,
             allCollections: await sdk.forProject.databases.listCollections(params.database, [
-                Query.orderDesc('$createdAt')
+                Query.orderDesc('')
             ])
         };
     } catch (e) {

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/+page.ts
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/+page.ts
@@ -18,7 +18,7 @@ export const load: PageLoad = async ({ params, depends, url, route }) => {
         documents: await sdk.forProject.databases.listDocuments(
             params.database,
             params.collection,
-            [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')]
+            [Query.limit(limit), Query.offset(offset), Query.orderDesc('')]
         )
     };
 };

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/attributes/relationship.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/attributes/relationship.svelte
@@ -74,7 +74,7 @@
         if (search) {
             const collections = await sdk.forProject.databases.listCollections(
                 databaseId,
-                [Query.orderDesc('$createdAt')],
+                [Query.orderDesc('')],
                 search
             );
             return collections;

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/attributes/relationship.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/attributes/relationship.svelte
@@ -61,7 +61,7 @@
             const documents = await sdk.forProject.databases.listDocuments(
                 databaseId,
                 attribute.relatedCollection,
-                [Query.startsWith('$id', search), Query.orderDesc('$createdAt')]
+                [Query.startsWith('$id', search), Query.orderDesc('')]
             );
             return documents;
         } else {

--- a/src/routes/console/project-[project]/functions/+page.ts
+++ b/src/routes/console/project-[project]/functions/+page.ts
@@ -13,6 +13,10 @@ export const load: PageLoad = async ({ url, depends, route }) => {
     return {
         offset,
         limit,
-        functions: await sdk.forProject.functions.list([Query.limit(limit), Query.offset(offset)])
+        functions: await sdk.forProject.functions.list([
+            Query.limit(limit),
+            Query.offset(offset),
+            Query.orderDesc('')
+        ])
     };
 };

--- a/src/routes/console/project-[project]/functions/function-[function]/+page.ts
+++ b/src/routes/console/project-[project]/functions/function-[function]/+page.ts
@@ -15,7 +15,8 @@ export const load: PageLoad = async ({ params, depends, url, route }) => {
         limit,
         deployments: await sdk.forProject.functions.listDeployments(params.function, [
             Query.limit(limit),
-            Query.offset(offset)
+            Query.offset(offset),
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/project-[project]/functions/function-[function]/executions/+page.ts
+++ b/src/routes/console/project-[project]/functions/function-[function]/executions/+page.ts
@@ -15,7 +15,8 @@ export const load: PageLoad = async ({ params, depends, url, route }) => {
         limit,
         executions: await sdk.forProject.functions.listExecutions(params.function, [
             Query.limit(limit),
-            Query.offset(offset)
+            Query.offset(offset),
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/project-[project]/storage/+page.ts
+++ b/src/routes/console/project-[project]/storage/+page.ts
@@ -15,7 +15,7 @@ export const load: PageLoad = async ({ url, route }) => {
         buckets: await sdk.forProject.storage.listBuckets([
             Query.limit(limit),
             Query.offset(offset),
-            Query.orderDesc('$createdAt')
+            Query.orderDesc('')
         ])
     };
 };

--- a/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.ts
+++ b/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.ts
@@ -17,7 +17,7 @@ export const load: PageLoad = async ({ params, depends, url, route }) => {
         search,
         files: await sdk.forProject.storage.listFiles(
             params.bucket,
-            [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')],
+            [Query.limit(limit), Query.offset(offset), Query.orderDesc('')],
             search
         )
     };


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

By sorting on Query.orderDesc(''), results are still ordered by newest results first, but the performance is much better than sorting by $createdAt.

## Test Plan

Manual

## Related PRs and Issues

Previous PR where we removed `Query.orderDesc('$createdAt')` due to performance:

* https://github.com/appwrite/console/pull/458

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes