### PR TITLE
fixed issue that didn't allow a user to update a document when deleting elements in an array attribute

### DIFF
--- a/src/lib/helpers/object.ts
+++ b/src/lib/helpers/object.ts
@@ -36,3 +36,14 @@ export function deepEqual<T>(obj1: T, obj2: T): boolean {
 
     return true;
 }
+
+/**
+ * Creates a deep clone of the given object. This function uses the JSON methods for cloning,
+ * so it may not be suitable for objects with functions, symbols, or other non-JSON-safe data.
+ *
+ * @param obj the object to be cloned
+ * @returns a deep clone of the provided object
+ */
+export function deepClone<T>(obj: T): T {
+    return JSON.parse(JSON.stringify(obj));
+}

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/data/+page.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/data/+page.svelte
@@ -15,6 +15,7 @@
     import AttributeItem from '../attributeItem.svelte';
     import { symmetricDifference } from '$lib/helpers/array';
     import { isRelationship, isRelationshipToMany } from '../attributes/store';
+    import { deepClone } from '$lib/helpers/object';
 
     const databaseId = $page.params.database;
     const collectionId = $page.params.collection;
@@ -22,21 +23,23 @@
     const editing = true;
 
     const work = writable(
-        Object.keys($doc)
-            .filter((key) => {
-                return ![
-                    '$id',
-                    '$collection',
-                    '$collectionId',
-                    '$databaseId',
-                    '$createdAt',
-                    '$updatedAt'
-                ].includes(key);
-            })
-            .reduce((obj, key) => {
-                obj[key] = $doc[key];
-                return obj;
-            }, {}) as Models.Document
+        deepClone(
+            Object.keys($doc)
+                .filter((key) => {
+                    return ![
+                        '$id',
+                        '$collection',
+                        '$collectionId',
+                        '$databaseId',
+                        '$createdAt',
+                        '$updatedAt'
+                    ].includes(key);
+                })
+                .reduce((obj, key) => {
+                    obj[key] = $doc[key];
+                    return obj;
+                }, {}) as Models.Document
+        )
     );
 
     async function updateData() {

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/data/+page.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/data/+page.svelte
@@ -13,7 +13,7 @@
     import { collection, type Attributes } from '../../store';
     import { Container } from '$lib/layout';
     import AttributeItem from '../attributeItem.svelte';
-    import { difference, symmetricDifference } from '$lib/helpers/array';
+    import { symmetricDifference } from '$lib/helpers/array';
     import { isRelationship, isRelationshipToMany } from '../attributes/store';
 
     const databaseId = $page.params.database;
@@ -77,7 +77,7 @@
         const docAttribute = $doc?.[attribute.key];
 
         if (attribute.array) {
-            return !difference(Array.from(workAttribute), Array.from(docAttribute)).length;
+            return !symmetricDifference(Array.from(workAttribute), Array.from(docAttribute)).length;
         }
 
         if (isRelationship(attribute)) {

--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/data/+page.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/data/+page.svelte
@@ -22,25 +22,29 @@
     const documentId = $page.params.document;
     const editing = true;
 
-    const work = writable(
-        deepClone(
-            Object.keys($doc)
-                .filter((key) => {
-                    return ![
-                        '$id',
-                        '$collection',
-                        '$collectionId',
-                        '$databaseId',
-                        '$createdAt',
-                        '$updatedAt'
-                    ].includes(key);
-                })
-                .reduce((obj, key) => {
-                    obj[key] = $doc[key];
-                    return obj;
-                }, {}) as Models.Document
-        )
-    );
+    function initWork() {
+        const prohibitedKeys = [
+            '$id',
+            '$collection',
+            '$collectionId',
+            '$databaseId',
+            '$createdAt',
+            '$updatedAt'
+        ];
+
+        const filteredKeys = Object.keys($doc).filter((key) => {
+            return !prohibitedKeys.includes(key);
+        });
+
+        const result = filteredKeys.reduce((obj, key) => {
+            obj[key] = $doc[key];
+            return obj;
+        }, {});
+
+        return writable(deepClone(result as Models.Document));
+    }
+
+    const work = initWork();
 
     async function updateData() {
         try {


### PR DESCRIPTION
Use `symmetricDifference` instead of `difference`.
- `difference` only returns values that are present in the edited attributes, but not in the originally fetched attribute vales. This always ends up returning an empty array.
- I used `symmetricDifference` as it returns an intersection of `difference` from both sides and works perfectly for this use case, as the original attributes never change.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR closes https://github.com/appwrite/appwrite/issues/5476

## Test Plan

- In addition to the existing tests, I performed manual testing by adding and deleting elements in an array attribute. 
- I was going to change the way the `difference` function worked, but realized it was being used in other places, which broke things. I used the `symmetricDifference` function as it fits in perfectly for this use case.

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/5476

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes ✅