### PR TITLE
Fix 5204 CDN code sample script tag using self-closing syntax

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/wizard/web/step2.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/web/step2.svelte
@@ -14,10 +14,12 @@
 
     const example1 = `import { Client } from 'appwrite';`;
     const example2 =
-        `<script src="https://cdn.jsdelivr.net/npm/appwrite@${$versions['client-web']}" />
-<script>
+        `<script src="https://cdn.jsdelivr.net/npm/appwrite@${$versions['client-web']}"></script` +
+        `>\n` +
+        `<script>
     const { Client } = Appwrite;
-</script` + `>`; // Prevent svelte from processing the closing script tag
+</script` +
+        `>`; // Prevent svelte from processing the closing script tag
 </script>
 
 <WizardStep>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes [this issue](https://github.com/appwrite/appwrite/issues/5204) where the <script> tag was not following the standard closing tag practice in the code sample provided for the web platform.

## Test Plan

1. Create a web platform in a project.
2. Select the CDN option for installing AppWrite.

The code generated on the second step before the changes:
```
<script src="https://cdn.jsdelivr.net/npm/appwrite@11.0.0" />
<script>
    const { Client } = Appwrite;
</script>
```

After the changes:
```
<script src="https://cdn.jsdelivr.net/npm/appwrite@11.0.0"></script>
<script>
    const { Client } = Appwrite;
</script>
```

## Related PRs and Issues

Resolves [this issue](https://github.com/appwrite/appwrite/issues/5204).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.