### PR TITLE
fixed the binding of flags to show create modals

### DIFF
--- a/src/routes/console/project-[project]/databases/+page.svelte
+++ b/src/routes/console/project-[project]/databases/+page.svelte
@@ -38,7 +38,7 @@
 
     {#if data.databases.total}
         {#if data.view === 'grid'}
-            <Grid {data} />
+            <Grid {data} bind:showCreate />
         {:else}
             <Table {data} />
         {/if}

--- a/src/routes/console/project-[project]/databases/database-[database]/+page.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/+page.svelte
@@ -25,7 +25,7 @@
 
     {#if data.collections.total}
         {#if data.view === 'grid'}
-            <Grid {data} />
+            <Grid {data} {showCreate} />
         {:else}
             <Table {data} />
         {/if}

--- a/src/routes/console/project-[project]/databases/database-[database]/grid.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/grid.svelte
@@ -3,16 +3,17 @@
     import { page } from '$app/stores';
     import { CardContainer, GridItem1, Id } from '$lib/components';
     import { Pill } from '$lib/elements';
+    import type { Writable } from 'svelte/store';
     import type { PageData } from './$types';
     export let data: PageData;
-    export let showCreate = false;
+    export let showCreate: Writable<boolean>;
     const projectId = $page.params.project;
     const databaseId = $page.params.database;
 </script>
 
 <CardContainer
     total={data.collections.total}
-    on:click={() => (showCreate = true)}
+    on:click={() => ($showCreate = true)}
     event="collection">
     {#each data.collections.collections as collection}
         <GridItem1

--- a/src/routes/console/project-[project]/databases/grid.svelte
+++ b/src/routes/console/project-[project]/databases/grid.svelte
@@ -4,7 +4,7 @@
     import { CardContainer, GridItem1, Id } from '$lib/components';
     import type { PageData } from './$types';
     export let data: PageData;
-    export let showCreate = false;
+    export let showCreate: boolean;
     const project = $page.params.project;
 </script>
 


### PR DESCRIPTION
This branch was created just for the page that shows databases, but the same issue showed in the collections page.

The PR fixes an issue where the “create new database/collection” in the grid view doesn’t actually open the modal to perform the respective action.

The fix was relative simple. The bindings seemed to be done incorrectly, and all I did was fix these bindings.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR closes https://github.com/appwrite/appwrite/issues/5992

## Test Plan

Manual testing along with scripts.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/5992

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes ✅