### PR TITLE
Fix infinite loading of quickstart templates

### DIFF
--- a/src/lib/wizards/functions/cover.svelte
+++ b/src/lib/wizards/functions/cover.svelte
@@ -106,21 +106,22 @@
                                 </li>
                             {/each}
                         {:then response}
-                            {@const runtimes = response.runtimes}
-                            {#each quickStart.runtimes.filter((_template, index) => index < 6) as runtime}
-                                {@const runtimeDetail = runtimes.find(
-                                    (r) => r.$id === runtime.name
-                                )}
+                            {@const runtimes = new Map(response.runtimes.map((r) => [r.$id, r]))}
+                            {@const templates = quickStart.runtimes.filter((_template) =>
+                                runtimes.has(_template.name)
+                            )}
+                            {#each templates.slice(0, 6) as template}
+                                {@const runtimeDetail = runtimes.get(template.name)}
                                 <li>
                                     <button
                                         on:click={() => {
                                             trackEvent('click_connect_template', {
                                                 from: 'cover',
                                                 template: quickStart.id,
-                                                runtime: runtime.name
+                                                runtime: template.name
                                             });
                                         }}
-                                        on:click={() => connectTemplate(quickStart, runtime.name)}
+                                        on:click={() => connectTemplate(quickStart, template.name)}
                                         class="box u-width-full-line u-flex u-cross-center u-gap-8"
                                         style:--box-padding="1rem"
                                         style:--box-border-radius="var(--border-radius-small)">
@@ -128,9 +129,9 @@
                                             <img
                                                 style:--p-text-size="1.25rem"
                                                 src={`${base}/icons/${$app.themeInUse}/color/${
-                                                    runtime.name.split('-')[0]
+                                                    template.name.split('-')[0]
                                                 }.svg`}
-                                                alt={runtime.name} />
+                                                alt={template.name} />
                                         </div>
                                         <div class="body-text-2">
                                             {runtimeDetail.name}
@@ -139,7 +140,7 @@
                                 </li>
                             {/each}
 
-                            {#if quickStart.runtimes.length < 6}
+                            {#if templates.length < 6}
                                 <li
                                     use:tooltip={{
                                         content: 'More runtimes coming soon'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This happens when Appwrite deosn't have the runtime from the quickstart template enabled. This change:

1. filters the quickstart templates to only include enabled runtimes
2. only shows the "more" template card if there were more than 5 filtered templates

## Test Plan

With:

```
_APP_FUNCTIONS_RUNTIMES=node-16.0,php-8.0,python-3.9,ruby-3.0,java-16.0
```

![image](https://github.com/appwrite/console/assets/1477010/ac7a2450-45ae-4b32-a891-12b7218075f2)

With:

```
_APP_FUNCTIONS_RUNTIMES=
```

![image](https://github.com/appwrite/console/assets/1477010/523c98f7-3c2f-4d1f-9c41-975fe04fc114)

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/6090

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes