### PR TITLE
fix: disable last step button wizard after submission

### DIFF
--- a/src/lib/layout/wizard.svelte
+++ b/src/lib/layout/wizard.svelte
@@ -74,8 +74,13 @@
 
         wizard.setInterceptor(null);
         if (isLastStep) {
+            $wizard.nextDisabled = true;
             trackEvent('wizard_finish');
             dispatch('finish');
+            //Reactivate button in case there are errors
+            setTimeout(() => {
+                $wizard.nextDisabled = false;
+            }, 2000);
         } else {
             trackEvent('wizard_next');
             $wizard.step++;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Button in the last step of wizard is now disabled after click for 2 seconds to avoid multiple submissions

## Test Plan

Manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes