### PR TITLE
fix: github redirect closing wizard

### DIFF
--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -30,8 +30,7 @@
      * Cancel navigation when wizard is open and triggered by popstate
      */
     beforeNavigate((n) => {
-        const external = n?.to?.url?.hostname !== globalThis?.location?.hostname;
-        if (external) return;
+        if (n.willUnload) return;
         if (!($wizard.show || $wizard.cover)) return;
         if (n.type === 'popstate') {
             n.cancel();


### PR DESCRIPTION
## What does this PR do?

- the check for an external navigation was inaccurate and is replaced by `willUnload`, that is true if the navigation goes to an external page


https://github.com/appwrite/console/assets/1759475/277b5ac3-5340-4cef-8717-e68804f7c61a



## Test Plan

- manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 