### PR TITLE
Mark form var text, not url

### DIFF
--- a/src/lib/stores/marketplace.ts
+++ b/src/lib/stores/marketplace.ts
@@ -698,7 +698,7 @@ export const marketplace: MarketplaceTemplate[] = [
                 value: '',
                 placeholder: 'smtp.mailgun.org',
                 required: true,
-                type: 'url'
+                type: 'text'
             },
             {
                 name: 'SMTP_PORT',


### PR DESCRIPTION
## What does this PR do?

Makes contact form template variable accept hostname instead of URL.

<img width="850" alt="CleanShot 2023-09-09 at 16 31 46@2x" src="https://github.com/appwrite/console/assets/19310830/721ffdd0-4c07-47ad-afa7-7fc53ecbd060">

## Test Plan

- [x] Manually on QA server

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes