### PR TITLE
fix-6003: Added updating hostname option for flutter webapp

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/[platform]/+page@project-[project].svelte
+++ b/src/routes/console/project-[project]/overview/platforms/[platform]/+page@project-[project].svelte
@@ -33,7 +33,8 @@
         'flutter-android': FlutterAndroid,
         'flutter-linux': FlutterLinux,
         'flutter-macos': FlutterMacOs,
-        'flutter-windows': FlutterWindows
+        'flutter-windows': FlutterWindows,
+        'flutter-web': Web
     };
 
     let showDelete = false;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds an option to update the hostname for flutter web app platform.

## Test Plan

Flutter Web platform did not have the UI to update hostname, as 'flutter-web' type did not exist in the update hostname component. So, I just added the type and now I am able to update the hostname.

## Related PRs and Issues

[Appwrite Issue #6003](https://github.com/appwrite/appwrite/issues/6003)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes