### PR TITLE
Fix incorrect link to migration docs for self-hosted to cloud

### DIFF
--- a/src/routes/console/project-[project]/settings/migrations/+page.svelte
+++ b/src/routes/console/project-[project]/settings/migrations/+page.svelte
@@ -235,7 +235,7 @@
             <p class="text">
                 Export data from your project to Appwrite Cloud. <a
                     class="link"
-                    href="https://appwrite.io/docs/migrations-local-to-cloud"
+                    href="https://appwrite.io/docs/migrations-self-hosted-to-cloud"
                     target="_blank"
                     rel="noopener noreferrer">
                     Learn more in our documentation.</a>
@@ -262,7 +262,7 @@
             <p class="text">
                 Export data from your project to a self-hosted instance. <a
                     class="link"
-                    href="https://appwrite.io/docs/migrations-cloud-to-local"
+                    href="https://appwrite.io/docs/migrations-cloud-to-self-hosted"
                     target="_blank"
                     rel="noopener noreferrer">
                     Learn more in our documentation.</a>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix incorrect link to migration docs for self-hosted to cloud

## Test Plan

Manual: 

<img width="1181" alt="image" src="https://github.com/appwrite/console/assets/1477010/d14705e4-385d-4e35-b3b3-0f85864d11a4">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes