### PR TITLE
Update template configuration to show supported runtimes

### DIFF
--- a/src/lib/wizards/functions/steps/templateConfiguration.svelte
+++ b/src/lib/wizards/functions/steps/templateConfiguration.svelte
@@ -38,7 +38,7 @@
         Supported runtimes:
         <br />
         <div class="u-inline-flex u-flex-wrap u-margin-block-start-8 u-gap-8">
-            {#each $template.runtimes as runtime}
+            {#each $template.runtimes.sort((r1, r2) => r1.name.localeCompare(r2.name)) as runtime}
                 <Pill>{runtime.name}</Pill>
             {/each}
         </div>

--- a/src/lib/wizards/functions/steps/templateConfiguration.svelte
+++ b/src/lib/wizards/functions/steps/templateConfiguration.svelte
@@ -33,6 +33,15 @@
     <svelte:fragment slot="title">{$template.name}</svelte:fragment>
     <svelte:fragment slot="subtitle">
         {$template.tagline}
+        <br />
+        <br />
+        Supported runtimes:
+        <br />
+        <div class="u-inline-flex u-flex-wrap u-margin-block-start-8 u-gap-8">
+            {#each $template.runtimes as runtime}
+                <Pill>{runtime.name}</Pill>
+            {/each}
+        </div>
     </svelte:fragment>
     <FormList>
         <InputText


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There are times when people jump into creating the function without reading the template details. Because templates only support certain runtime versions, it's important to show the supported runtimes in the wizard or else the developer will be confused why their enabled incompatible runtime doesn't show in the Runtime dropdown.

## Test Plan

Manual:

<img width="1168" alt="image" src="https://github.com/appwrite/console/assets/1477010/8e210f51-25e1-4ace-813d-0b2925249287">

Simulated w/ lots of runtimes:

<img width="1156" alt="image" src="https://github.com/appwrite/console/assets/1477010/77e98013-3a04-46ac-b947-0fce18eb9a73">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes