### PR TITLE
fix: create attribute modal null when selecting same time twice

### DIFF
--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/+page.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/+page.svelte
@@ -144,7 +144,7 @@
     {/if}
 </Container>
 
-<CreateAttribute bind:showCreate={showCreateAttribute} selectedOption={selectedAttribute} />
+<CreateAttribute bind:showCreate={showCreateAttribute} bind:selectedOption={selectedAttribute} />
 
 <style lang="scss">
     .heading-grid {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

fix: create attribute modal null when selecting same time twice

## Test Plan

Manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes