### PR TITLE
Revert "Update template configuration to show supported runtimes"

### DIFF
--- a/src/lib/wizards/functions/steps/templateConfiguration.svelte
+++ b/src/lib/wizards/functions/steps/templateConfiguration.svelte
@@ -33,15 +33,6 @@
     <svelte:fragment slot="title">{$template.name}</svelte:fragment>
     <svelte:fragment slot="subtitle">
         {$template.tagline}
-        <br />
-        <br />
-        Supported runtimes:
-        <br />
-        <div class="u-inline-flex u-flex-wrap u-margin-block-start-8 u-gap-8">
-            {#each $template.runtimes.sort((r1, r2) => r1.name.localeCompare(r2.name)) as runtime}
-                <Pill>{runtime.name}</Pill>
-            {/each}
-        </div>
     </svelte:fragment>
     <FormList>
         <InputText


### PR DESCRIPTION
Reverts appwrite/console#547

This wasn't approved by Design. In addition, Design has come up with a better way to present this information.