### PR TITLE
Fix 6248 copy button issue

### DIFF
--- a/src/lib/components/copyInput.svelte
+++ b/src/lib/components/copyInput.svelte
@@ -23,7 +23,11 @@
         }
     };
 </script>
-
+<style>
+    span.icon-duplicate {
+        cursor: pointer;
+    }
+</style>
 <div>
     <label class:u-hide={!showLabel} class="label" for={label}>{label}</label>
     <div class="input-text-wrapper" style="--amount-of-buttons:1">

--- a/src/lib/components/copyInput.svelte
+++ b/src/lib/components/copyInput.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
     import { tooltip } from '$lib/actions/tooltip';
     import { copy } from '$lib/helpers/copy';
-
     import { addNotification } from '$lib/stores/notifications';
-
     export let value: string;
     export let label: string = null;
     export let showLabel = false;
 
-    let content = 'Click to copy';
-
+    let content = 'Copy';
+    
     const handleCopy = async () => {
         const success = await copy(value);
 
@@ -33,18 +31,18 @@
     <div class="input-text-wrapper" style="--amount-of-buttons:1">
         <input {value} id={label} type="text" class="input-text" readonly />
         <div class="options-list">
-            <button
-                type="button"
-                class="options-list-button"
-                aria-label="Click to copy."
+           
+            <span 
+                class="icon-duplicate" aria-label="Copy"
                 on:click={handleCopy}
-                on:mouseenter={() => setTimeout(() => (content = 'Click to copy'))}
+                on:mouseenter={() => setTimeout(() => (content = 'Copy'))}
                 use:tooltip={{
                     content,
-                    hideOnClick: false
-                }}>
-                <span class="icon-duplicate" aria-hidden="true" />
-            </button>
+                    hideOnClick: false,
+                    appendTo: 'parent',
+                }}
+             />
+           
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses issue #6248 by resolving the problem encountered when clicking on the "Copy URI" button of any OAuth provider. The issue involved the incorrect display and partial hiding of the tooltip pop behind the dialog form

## Test Plan

To rectify this issue, I have utilized the appendTo property from tippy.js to attach the tooltip to the div that contains the input field. I conducted thorough testing of these changes by locally compiling the project, resulting in the following positive outcome:  cange it to i used append to and use assign appendto to parent and everything is same
