### PR TITLE
Fix 6248 copy button issue

### DIFF
--- a/src/lib/components/copyInput.svelte
+++ b/src/lib/components/copyInput.svelte
@@ -25,6 +25,7 @@
     span.icon-duplicate {
         cursor: pointer;
     }
+    
 </style>
 <div>
     <label class:u-hide={!showLabel} class="label" for={label}>{label}</label>

--- a/src/lib/components/copyInput.svelte
+++ b/src/lib/components/copyInput.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
     import { tooltip } from '$lib/actions/tooltip';
     import { copy } from '$lib/helpers/copy';
-
     import { addNotification } from '$lib/stores/notifications';
-
     export let value: string;
     export let label: string = null;
     export let showLabel = false;
 
-    let content = 'Click to copy';
-
+    let content = 'Copy';
+    
     const handleCopy = async () => {
         const success = await copy(value);
 
@@ -23,24 +21,28 @@
         }
     };
 </script>
-
+<style>
+    span.icon-duplicate {
+        cursor: pointer;
+    }
+</style>
 <div>
     <label class:u-hide={!showLabel} class="label" for={label}>{label}</label>
     <div class="input-text-wrapper" style="--amount-of-buttons:1">
         <input {value} id={label} type="text" class="input-text" readonly />
         <div class="options-list">
-            <button
-                type="button"
-                class="options-list-button"
-                aria-label="Click to copy."
+           
+            <span 
+                class="icon-duplicate" aria-label="Copy"
                 on:click={handleCopy}
-                on:mouseenter={() => setTimeout(() => (content = 'Click to copy'))}
+                on:mouseenter={() => setTimeout(() => (content = 'Copy'))}
                 use:tooltip={{
                     content,
-                    hideOnClick: false
-                }}>
-                <span class="icon-duplicate" aria-hidden="true" />
-            </button>
+                    hideOnClick: false,
+                    appendTo: 'parent',
+                }}
+             />
+           
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

##What does this PR accomplish?
This PR addresses issue #6248 by resolving the problem encountered when clicking on the "Copy URI" button of any OAuth provider. The issue involved the incorrect display and partial hiding of the tooltip pop behind the dialog form

## Test Plan

To address this issue, I used the appendTo property from tippy.js and assigned it to the parent element containing the input field. I rigorously tested these modifications by locally compiling the project, and the results remained consistent

