### PR TITLE
Fix Policy and Terms Page

### DIFF
--- a/src/lib/layout/footer.svelte
+++ b/src/lib/layout/footer.svelte
@@ -25,12 +25,12 @@
                 </div>
             </li>
             <li class="inline-links-item">
-                <a href="https://appwrite.io/policy/terms" target="_blank" rel="noreferrer">
+                <a href="https://appwrite.io/terms" target="_blank" rel="noreferrer">
                     <span class="text">Terms</span>
                 </a>
             </li>
             <li class="inline-links-item">
-                <a href="https://appwrite.io/policy/privacy" target="_blank" rel="noreferrer">
+                <a href="https://appwrite.io/privacy" target="_blank" rel="noreferrer">
                     <span class="text">Privacy</span>
                 </a>
             </li>

--- a/src/routes/invite/+page.svelte
+++ b/src/routes/invite/+page.svelte
@@ -72,13 +72,13 @@
                         showLabel={false}>
                         By accepting the invitation, you agree to the <a
                             class="link"
-                            href="https://appwrite.io/policy/terms"
+                            href="https://appwrite.io/terms"
                             target="_blank"
                             rel="noopener noreferrer">Terms and Conditions</a>
                         and
                         <a
                             class="link"
-                            href="https://appwrite.io/policy/privacy"
+                            href="https://appwrite.io/privacy"
                             target="_blank"
                             rel="noopener noreferrer">
                             Privacy Policy</a

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -82,14 +82,14 @@
                 <InputChoice required value={terms} id="terms" label="terms" showLabel={false}>
                     By registering, you agree that you have read, understand, and acknowledge our <a
                         class="link"
-                        href="https://appwrite.io/policy/privacy"
+                        href="https://appwrite.io/privacy"
                         target="_blank"
                         rel="noopener noreferrer">
                         Privacy Policy</a>
                     and accept our
                     <a
                         class="link"
-                        href="https://appwrite.io/policy/terms"
+                        href="https://appwrite.io/terms"
                         target="_blank"
                         rel="noopener noreferrer">General Terms of Use</a
                     >.</InputChoice>

--- a/src/routes/register/invite/[slug]/+page.svelte
+++ b/src/routes/register/invite/[slug]/+page.svelte
@@ -124,14 +124,14 @@
                 <InputChoice required value={terms} id="terms" label="terms" showLabel={false}>
                     By registering, you agree that you have read, understand, and acknowledge our <a
                         class="link"
-                        href="https://appwrite.io/policy/privacy"
+                        href="https://appwrite.io/privacy"
                         target="_blank"
                         rel="noopener noreferrer">
                         Privacy Policy</a>
                     and accept our
                     <a
                         class="link"
-                        href="https://appwrite.io/policy/terms"
+                        href="https://appwrite.io/terms"
                         target="_blank"
                         rel="noopener noreferrer">General Terms of Use</a
                     >.</InputChoice>


### PR DESCRIPTION
## What does this PR do?

On register page, and some footer links, the url for policy and terms page are incorrect. 

That's why it was giving 404 error. It corrects the url's from `/policy/privacy` ->`/privacy' and 'policy/terms` -> `/terms`.

***IMPORTANT*** 
The Terms and Conditions page is not built completely yet! [View](https://appwrite.io/terms)

## Test Plan

I have verified the final behaviour by running out the flow of visiting both pages through register page and footer links.
Executed `npm run format` to preserve the style of code.

## Related PRs and Issues

Solves https://github.com/appwrite/appwrite/issues/6485 and https://github.com/appwrite/website/issues/191

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes