### PR TITLE
Fixed missing separator for keycodes comparison

### DIFF
--- a/src/lib/commandCenter/commands.ts
+++ b/src/lib/commandCenter/commands.ts
@@ -198,7 +198,7 @@ export const commandCenterKeyDownHandler = derived(
 
                 const commandKeyCodes = keys?.map((key) => key.toUpperCase().charCodeAt(0));
                 const allKeysPressed = commandKeyCodes
-                    ? recentKeyCodes.join('').includes(commandKeyCodes.join(''))
+                    ? recentKeyCodes.join(',').includes(commandKeyCodes.join(','))
                     : false;
 
                 if (allKeysPressed && isMetaPressed && isShiftPressed && isAltPressed) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the error where keypress codes overlap triggering unnecessary routes.

>In the console (select your project):
>- Hold or double-press the arrow UP key on your keyboard you'll go to the Storage page
>- double-press the arrow LEFT key on your keyboard you'll go out of the project to console/account page

This behavior is fixed.

## Test Plan

Tested based on the behavior mentioned in the Issue [https://github.com/appwrite/appwrite/issues/6205](https://github.com/appwrite/appwrite/issues/6205).

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/6205

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes