### PR TITLE
feat: plausible analytics for self-hosted environments

### DIFF
--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -51,13 +51,13 @@ const analytics = Analytics({
     app: 'appwrite',
     plugins: isCloud
         ? [
-              plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.CLOUD}`),
+              plausible(PLAUSIBLE_DOMAINS.CLOUD),
               googleTagManager({
                   containerId: [VARS.GOOGLE_TAG || 'GTM-P3T9TBV']
               })
           ]
         : [
-              plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.SELF_HOSTED}`),
+              plausible(PLAUSIBLE_DOMAINS.SELF_HOSTED),
               googleAnalytics({
                   measurementIds: [VARS.GOOGLE_ANALYTICS || 'G-R4YJ9JN8L4']
               })

--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -38,17 +38,24 @@ function plausible(domain: string): AnalyticsPlugin {
     };
 }
 
+const PLAUSIBLE_DOMAINS = {
+    CLOUD: 'cloud.appwrite.io',
+    GLOBAL: 'console.appwrite',
+    SELF_HOSTED: 'self-hosted.appwrite'
+};
+
 const analytics = Analytics({
     app: 'appwrite',
     plugins:
         isCloud && browser
             ? [
-                  plausible('cloud.appwrite.io'),
+                  plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.CLOUD}`),
                   googleTagManager({
                       containerId: [VARS.GOOGLE_TAG || 'GTM-P3T9TBV']
                   })
               ]
             : [
+                  plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.SELF_HOSTED}`),
                   googleAnalytics({
                       measurementIds: [VARS.GOOGLE_ANALYTICS || 'G-R4YJ9JN8L4']
                   })

--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -10,9 +10,12 @@ import { AppwriteException } from '@appwrite.io/console';
 import { browser } from '$app/environment';
 
 function plausible(domain: string): AnalyticsPlugin {
+    if (!browser) return { name: 'analytics-plugin-plausible' };
+
     const instance = Plausible({
         domain
     });
+
     return {
         name: 'analytics-plugin-plausible',
         page: ({ payload }) => {
@@ -46,21 +49,19 @@ const PLAUSIBLE_DOMAINS = {
 
 const analytics = Analytics({
     app: 'appwrite',
-    plugins: browser
-        ? isCloud
-            ? [
-                  plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.CLOUD}`),
-                  googleTagManager({
-                      containerId: [VARS.GOOGLE_TAG || 'GTM-P3T9TBV']
-                  })
-              ]
-            : [
-                  plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.SELF_HOSTED}`),
-                  googleAnalytics({
-                      measurementIds: [VARS.GOOGLE_ANALYTICS || 'G-R4YJ9JN8L4']
-                  })
-              ]
-        : []
+    plugins: isCloud
+        ? [
+              plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.CLOUD}`),
+              googleTagManager({
+                  containerId: [VARS.GOOGLE_TAG || 'GTM-P3T9TBV']
+              })
+          ]
+        : [
+              plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.SELF_HOSTED}`),
+              googleAnalytics({
+                  measurementIds: [VARS.GOOGLE_ANALYTICS || 'G-R4YJ9JN8L4']
+              })
+          ]
 });
 
 export function trackEvent(name: string, data: object = null): void {

--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -46,8 +46,8 @@ const PLAUSIBLE_DOMAINS = {
 
 const analytics = Analytics({
     app: 'appwrite',
-    plugins:
-        isCloud && browser
+    plugins: browser
+        ? isCloud
             ? [
                   plausible(`${PLAUSIBLE_DOMAINS.GLOBAL},${PLAUSIBLE_DOMAINS.CLOUD}`),
                   googleTagManager({
@@ -60,6 +60,7 @@ const analytics = Analytics({
                       measurementIds: [VARS.GOOGLE_ANALYTICS || 'G-R4YJ9JN8L4']
                   })
               ]
+        : []
 });
 
 export function trackEvent(name: string, data: object = null): void {

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -9,7 +9,6 @@ export const VARS = {
         | string
         | undefined,
     CONSOLE_MODE: import.meta.env?.VITE_CONSOLE_MODE?.toString() as string | undefined,
-    VERCEL_ENV: import.meta.env?.VITE_VERCEL_ENV?.toString() as string | undefined,
     GOOGLE_ANALYTICS: import.meta.env?.VITE_GA_PROJECT?.toString() as string | undefined,
     GOOGLE_TAG: import.meta.env?.VITE_GTM_PROJECT?.toString() as string | undefined
 };
@@ -17,7 +16,7 @@ export const VARS = {
 export const ENV = {
     DEV: import.meta.env.DEV,
     PROD: import.meta.env.PROD,
-    PREVIEW: VARS.VERCEL_ENV === 'preview',
+    PREVIEW: import.meta.env?.VERCEL === '1',
     TEST: !!import.meta.env?.VITEST
 };
 


### PR DESCRIPTION
## What does this PR do?

- add plausible analytics to self-hosted environments in order to replace google in the long term
- report to `console.appwrite` for both cloud and self-hosted
- report to `self-hosted.appwrite` for self-hosted
- prevent sending analytics on vercel deployments

## Test Plan

- manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 