### PR TITLE
Fix: duplicate message on document delete in db

### DIFF
--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/delete.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/document-[document]/delete.svelte
@@ -111,12 +111,6 @@
                 Delete document from <span data-private>{$collection.name}</span>
             </InputChoice>
         </div>
-    {:else}
-        <p data-private>
-            Are you sure you want to delete <b
-                >the document from <span data-private>{$collection.name}</span></b
-            >?
-        </p>
     {/if}
 
     <svelte:fragment slot="footer">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It fixes the duplicate error message while a user tries to delete a document. An error of screenshot:
![image](https://github.com/appwrite/console/assets/7521349/e5234a48-6468-46dc-bb34-08098a25bada)


## Test Plan

- Try to delete a document from a collection
- It show the warning without the duplicate message

## Related PRs and Issues
[#6860](https://github.com/appwrite/appwrite/issues/6860)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes