### PR TITLE
Fix document IDs not updating when switching between collections

### DIFF
--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/table.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/table.svelte
@@ -157,9 +157,11 @@
                 <TableCellCheck bind:selectedIds={selectedDb} id={document.$id} />
 
                 <TableCell width={150}>
-                    <Id value={document.$id}>
-                        {document.$id}
-                    </Id>
+                    {#key document.$id}
+                        <Id value={document.$id}>
+                            {document.$id}
+                        </Id>
+                    {/key}
                 </TableCell>
 
                 {#each $columns as column}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Ensure document IDs are destroyed and recreated so the text is updated

Fixes https://github.com/appwrite/appwrite/issues/6497

## Test Plan

Manual:

https://github.com/appwrite/console/assets/1477010/6ca4e674-dff7-401c-a93f-bc435ffea565

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/6497

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes