### PR TITLE
Fix the allowed extensions for uploading .env files

### DIFF
--- a/src/routes/console/project-[project]/uploadVariablesModal.svelte
+++ b/src/routes/console/project-[project]/uploadVariablesModal.svelte
@@ -85,7 +85,7 @@
         {/if}
     </div>
 
-    <InputFile bind:files allowedFileExtensions={['.env']} />
+    <InputFile bind:files />
 
     <svelte:fragment slot="footer">
         <Button text on:click={() => (show = false)}>Cancel</Button>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It should not include the leading dot because the InputFile component adds the leading prefix so including the leading dot results in an extra dot like:

![image](https://github.com/appwrite/console/assets/1477010/4d3818e1-1b75-4f3c-8dcb-90aa423be806)

## Test Plan

Before the change, .env files were not selectable:

![Screen Shot 2023-11-20 at 10 06 07 AM](https://github.com/appwrite/console/assets/1477010/0274164c-56f7-47df-83d4-8964c2e54f58)

and trying to drag a .env file into the modal results in:

![image](https://github.com/appwrite/console/assets/1477010/d321ef82-99a0-4bf6-a752-e6d2015962f1)

After the change, I can now select any file including .env files.

<img width="861" alt="image" src="https://github.com/appwrite/console/assets/1477010/62ca15e0-5e5e-4448-b80d-d84d366cf0cc">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes