### PR TITLE
Update links for the cron syntax pointing to the Schedule section

### DIFF
--- a/src/routes/console/project-[project]/functions/function-[function]/settings/updateSchedule.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/settings/updateSchedule.svelte
@@ -58,7 +58,7 @@
         <Heading tag="h6" size="7" id="schedule">Schedule</Heading>
         <p>
             Set a Cron schedule to trigger your function. Leave blank for no schedule. <a
-                href="https://appwrite.io/docs/products/functions/execution"
+                href="https://appwrite.io/docs/products/functions/execution#schedule"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="link">

--- a/src/routes/console/project-[project]/functions/wizard/step4.svelte
+++ b/src/routes/console/project-[project]/functions/wizard/step4.svelte
@@ -8,7 +8,7 @@
     <svelte:fragment slot="title">Schedule</svelte:fragment>
     <svelte:fragment slot="subtitle">
         Set a Cron schedule to trigger your function. Leave blank for no schedule. <a
-            href="https://appwrite.io/docs/products/functions/quick-start"
+            href="https://appwrite.io/docs/products/functions/execution#schedule"
             target="_blank"
             rel="noopener noreferrer"
             class="link">More details on Cron syntax here</a


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR is updating links for the cron syntax and pointing to the schedule section.

Fixes https://github.com/appwrite/appwrite/issues/7209

## Test Plan

The links about the cron syntax on:

[Function settings](https://github.com/appwrite/console/blob/855163a1ec51823851a48bed971a545750de3cba/src/routes/console/project-%5Bproject%5D/functions/function-%5Bfunction%5D/settings/updateSchedule.svelte#L60-L65)
[Function wizard](https://github.com/appwrite/console/blob/855163a1ec51823851a48bed971a545750de3cba/src/routes/console/project-%5Bproject%5D/functions/wizard/step4.svelte#L10-L15)

now link to the [Schedule](https://appwrite.io/docs/products/functions/execution#schedule) section of the docs.

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/7209

