### PR TITLE
Fix: empty zip, non-prefilled state

### DIFF
--- a/src/routes/console/account/payments/addressModal.svelte
+++ b/src/routes/console/account/payments/addressModal.svelte
@@ -47,7 +47,7 @@
                 address,
                 city,
                 state,
-                zip,
+                zip ? zip : undefined,
                 address2 ? address2 : undefined
             );
             trackEvent(Submit.BillingAddressCreate);

--- a/src/routes/console/account/payments/editAddressModal.svelte
+++ b/src/routes/console/account/payments/editAddressModal.svelte
@@ -22,6 +22,10 @@
 
     onMount(async () => {
         const countryList = await sdk.forProject.locale.listCountries();
+        const locale = await sdk.forProject.locale.get();
+        if (locale.countryCode) {
+            country = locale.countryCode;
+        }
         options = countryList.countries.map((country) => {
             return {
                 value: country.code,
@@ -38,7 +42,7 @@
                 selectedAddress.streetAddress,
                 selectedAddress.city,
                 selectedAddress.state,
-                selectedAddress.postalCode,
+                selectedAddress.postalCode ? selectedAddress.postalCode : undefined,
                 selectedAddress.addressLine2 ? selectedAddress.addressLine2 : undefined
             );
             await invalidate(Dependencies.ADDRESS);

--- a/src/routes/console/account/payments/editAddressModal.svelte
+++ b/src/routes/console/account/payments/editAddressModal.svelte
@@ -24,7 +24,7 @@
         const countryList = await sdk.forProject.locale.listCountries();
         const locale = await sdk.forProject.locale.get();
         if (locale.countryCode) {
-            country = locale.countryCode;
+            selectedAddress.country = locale.countryCode;
         }
         options = countryList.countries.map((country) => {
             return {

--- a/src/routes/console/changeOrganizationTierCloud.svelte
+++ b/src/routes/console/changeOrganizationTierCloud.svelte
@@ -96,7 +96,9 @@
                         $changeOrganizationTier.billingAddress.streetAddress,
                         $changeOrganizationTier.billingAddress.city,
                         $changeOrganizationTier.billingAddress.state,
-                        $changeOrganizationTier.billingAddress.postalCode,
+                        $changeOrganizationTier.billingAddress.postalCode
+                            ? $changeOrganizationTier.billingAddress.postalCode
+                            : undefined,
                         $changeOrganizationTier.billingAddress.addressLine2
                             ? $changeOrganizationTier.billingAddress.addressLine2
                             : undefined

--- a/src/routes/console/createOrganizationCloud.svelte
+++ b/src/routes/console/createOrganizationCloud.svelte
@@ -49,7 +49,9 @@
                     $createOrganization.billingAddress.streetAddress,
                     $createOrganization.billingAddress.city,
                     $createOrganization.billingAddress.state,
-                    $createOrganization.billingAddress.postalCode,
+                    $createOrganization.billingAddress.postalCode
+                        ? $createOrganization.billingAddress.postalCode
+                        : undefined,
                     $createOrganization.billingAddress.addressLine2
                         ? $createOrganization.billingAddress.addressLine2
                         : undefined

--- a/src/routes/console/organization-[organization]/billing/replaceAddress.svelte
+++ b/src/routes/console/organization-[organization]/billing/replaceAddress.svelte
@@ -27,6 +27,7 @@
             label: 'United States'
         }
     ];
+
     onMount(async () => {
         addresses = await sdk.forConsole.billing.listAddresses();
 
@@ -61,8 +62,8 @@
                     streetAddress,
                     city,
                     state,
-                    postalCode,
-                    addressLine2
+                    postalCode ? postalCode : undefined,
+                    addressLine2 ? postalCode : undefined
                 );
                 await sdk.forConsole.billing.setBillingAddress($organization.$id, address.$id);
 


### PR DESCRIPTION
## What does this PR do?

State didn't prefil when you add new second address:

![CleanShot 2023-12-19 at 21 01 19@2x](https://github.com/appwrite/console/assets/19310830/8fec6191-86d1-45b3-ad8a-239e38bbd763)

Empty ZIP or address2 sometimes caused error, now they don't:

![CleanShot 2023-12-19 at 21 01 39@2x](https://github.com/appwrite/console/assets/19310830/ca093cb8-b6b1-418a-a2f0-9f63111f4f54)


## Test Plan

Manual QA

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes