### PR TITLE
fix: console organization project count limit

### DIFF
--- a/src/routes/console/organization-[organization]/+page.ts
+++ b/src/routes/console/organization-[organization]/+page.ts
@@ -17,7 +17,7 @@ export const load: PageLoad = async ({ params, url, route, depends, parent }) =>
         projects: await sdk.forConsole.projects.list([
             Query.offset(offset),
             Query.equal('teamId', params.organization),
-            Query.limit(CARD_LIMIT),
+            Query.limit(limit),
             Query.orderDesc('')
         ])
     };


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes the bug [#7356](https://github.com/appwrite/appwrite/issues/7356) console won't show more than 6 projects even though the limit is more than 6.

## Test Plan



## Related PRs and Issues

Fixes [#7356](https://github.com/appwrite/appwrite/issues/7356) 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes