### PR TITLE
Can't close Execute function modal

### DIFF
--- a/src/lib/components/modal.svelte
+++ b/src/lib/components/modal.svelte
@@ -55,11 +55,13 @@
                         style="--button-size:1.5rem;"
                         aria-label="Close Modal"
                         title="Close Modal"
-                        on:click={() =>
-                            trackEvent('click_close_modal', {
-                                from: 'button'
-                            })}
-                        on:click={close}>
+                        on:click={() => {
+                             trackEvent('click_close_modal', {
+                                 from: 'button' 
+                             });
+                             close();
+                         }}>
+
                         <span class="icon-x" aria-hidden="true" />
                     </button>
                 {/if}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This pull request addresses an issue where the Execute function modal cannot be closed by clicking the 'x' at the top right.


 ## Reproduction Steps
Click "Execute now" from a function's Executions tab.
Attempt to close the modal by clicking the 'x' at the top right.




##Related PRs and Issues


Fixes:https://github.com/appwrite/appwrite/issues/7353

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.) yes