### PR TITLE
Fix button spacing

### DIFF
--- a/src/routes/console/project-[project]/functions/function-[function]/+page.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/+page.svelte
@@ -133,7 +133,7 @@
                 </svelte:fragment>
 
                 <svelte:fragment slot="actions">
-                    <div class="u-flex u-flex-wrap">
+                    <div class="u-flex u-flex-wrap u-gap-16">
                         <Button
                             text
                             href={`/console/project-${$page.params.project}/functions/function-${$page.params.function}/deployment-${activeDeployment.$id}`}>
@@ -141,14 +141,12 @@
                         </Button>
                         <Button
                             text
-                            class="u-margin-inline-end-16"
                             on:click={() => {
                                 selectedDeployment = activeDeployment;
                                 showRedeploy = true;
                             }}>
                             Redeploy
                         </Button>
-
                         <Button
                             secondary
                             on:click={() => ($execute = $func)}


### PR DESCRIPTION
Fixes that there is currently no spacing between the "Build logs" and "Redeploy" buttons for functions.