### PR TITLE
Fix: Added binding to 'Reply To' field in email template

### DIFF
--- a/src/routes/console/project-[project]/auth/templates/emailTemplate.svelte
+++ b/src/routes/console/project-[project]/auth/templates/emailTemplate.svelte
@@ -106,7 +106,11 @@
                     tooltip="Set up an SMTP server to edit the sender email"
                     placeholder="Enter sender email"
                     readonly={!isSmtpEnabled} />
-                <InputEmail id="replyTo" label="Reply to" placeholder="noreply@appwrite.io" />
+                <InputEmail
+                    bind:value={$emailTemplate.replyTo}
+                    id="replyTo"
+                    label="Reply to"
+                    placeholder="noreply@appwrite.io" />
                 {#if $$slots.default}
                     <li style="margin-block: 1rem;">
                         <p class="text">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes [appwrite/console#855](https://github.com/appwrite/console/issues/855)
## Test Plan
Verified the code changes by changing "Reply To" field and noticing the state change of update button ( it changes from disabled to enabled ).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes