### PR TITLE
Allow empty topic descriptions

### DIFF
--- a/src/routes/console/project-[project]/messaging/topics/create.svelte
+++ b/src/routes/console/project-[project]/messaging/topics/create.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import { Submit, trackEvent, trackError } from '$lib/actions/analytics';
-    import { Modal, CustomId } from '$lib/components';
+    import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
+    import { CustomId, Modal } from '$lib/components';
     import { Pill } from '$lib/elements';
-    import { InputText, Button, FormList } from '$lib/elements/forms';
+    import { Button, FormList, InputText } from '$lib/elements/forms';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { ID } from '@appwrite.io/console';
@@ -27,7 +27,7 @@
                 },
                 {
                     name,
-                    description,
+                    description: description || undefined,
                     topicId: id ?? ID.unique()
                 }
             );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Allow empty topic descriptions. We must pass undefined because the server won't accept an empty string. Undefined will make the server use the default value, which is an empty string.

## Test Plan

Manual

## Related PRs and Issues

Parent:

* https://github.com/appwrite/console/pull/712

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes