### PR TITLE
Fix: Optional SMTP pass

### DIFF
--- a/src/routes/console/project-[project]/settings/smtp/+page.svelte
+++ b/src/routes/console/project-[project]/settings/smtp/+page.svelte
@@ -182,14 +182,12 @@
                                 id="username"
                                 label="Username"
                                 bind:value={username}
-                                required
                                 placeholder="Enter username" />
                             <InputPassword
                                 showPasswordButton
                                 id="passwort"
                                 label="Password"
                                 bind:value={password}
-                                required
                                 placeholder="Enter password" />
 
                             <InputChoice bind:value={secure} id="tls" label="TLS secure protocol">


### PR DESCRIPTION
## What does this PR do?

Some SMTP providers might have no user&pass, they might use IP-based authentication.

It will also make local development easier, as this will allow you to connect to maildev (which has no user&pass)

## Test Plan

Manual QA, I can use maildev as custom SMTP. Email delivered properly to maildev, with no user&pass.

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes