### PR TITLE
fix: oauth settings page

### DIFF
--- a/src/lib/stores/oauth-providers.ts
+++ b/src/lib/stores/oauth-providers.ts
@@ -24,7 +24,7 @@ export type Providers = {
 
 const setProviders = (project: Models.Project): Provider[] => {
     return (
-        project?.providers.map((n) => {
+        project?.oAuthProviders.map((n) => {
             const p = n as Models.Provider & { key: string };
             let docs: Provider['docs'];
             let icon: Provider['icon'] = p.key.toLowerCase();


### PR DESCRIPTION
parameter name `provider` should be `oAuthProvider`

![error screenshot](https://cdn.discordapp.com/attachments/1106133431454277705/1195287691147882556/CleanShot_2024-01-12_at_09.46.232x.png)