### PR TITLE
Update filterable subscriber columns

### DIFF
--- a/src/routes/console/project-[project]/messaging/topics/topic-[topic]/subscribers/store.ts
+++ b/src/routes/console/project-[project]/messaging/topics/topic-[topic]/subscribers/store.ts
@@ -3,9 +3,9 @@ import { writable } from 'svelte/store';
 
 export const columns = writable<Column[]>([
     { id: '$id', title: 'Subscriber ID', type: 'string', show: true, width: 140 },
-    { id: 'userName', title: 'Name', type: 'string', show: true, width: 100 },
+    { id: 'userName', title: 'Name', type: 'string', show: true, filter: false, width: 100 },
     { id: 'targetId', title: 'Target ID', type: 'string', show: true, width: 140 },
     { id: 'target', title: 'Target', type: 'string', show: true, filter: false, width: 140 },
-    { id: 'type', title: 'Type', type: 'string', show: true, filter: false, width: 80 },
-    { id: '$createdAt', title: 'Created', type: 'string', show: true, width: 100 }
+    { id: 'type', title: 'Type', type: 'string', show: true, width: 80 },
+    { id: '$createdAt', title: 'Created', type: 'datetime', show: true, width: 100 }
 ]);


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Don't allow filtering on userName since the attribute isn't in the collection to be filtered.

Allow filtering on type since it is available and it would be userful.

Change $createdAt type to datetime to allow filtering by greater/less than.

## Test Plan

Filters show the columns:

<img width="1496" alt="image" src="https://github.com/appwrite/console/assets/1477010/1c229d6b-5c2d-4e58-8924-83b02359b533">

And I was able to manually filter on each column.

## Related PRs and Issues

Parent:

* https://github.com/appwrite/console/pull/712

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes