### PR TITLE
Partial prerendering of public pages for better core web vitals

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,6 +22,11 @@
         window.VERCEL_ANALYTICS_ID = import.meta.env.VERCEL_ANALYTICS_ID?.toString() ?? false;
     }
 
+    const prerenderedRoutes = ['/login', '/register', '/recover', '/invite'];
+    if (prerenderedRoutes.some((n) => $page.url.pathname.startsWith(n))) {
+        loading.set(false);
+    }
+
     onMount(async () => {
         if ($page.url.searchParams.has('migrate')) {
             const migrateData = $page.url.searchParams.get('migrate');
@@ -65,14 +70,7 @@
          * Handle initial load.
          */
         if (!$page.url.pathname.startsWith('/auth') && !$page.url.pathname.startsWith('/git')) {
-            const acceptedRoutes = [
-                '/login',
-                '/register',
-                '/recover',
-                '/invite',
-                '/card',
-                '/hackathon'
-            ];
+            const acceptedRoutes = prerenderedRoutes.concat(['/card', '/hackathon']);
             if ($user) {
                 if (
                     !$page.url.pathname.startsWith('/console') &&
@@ -106,20 +104,10 @@
 
     $: {
         if (browser) {
-            const isCloudClass = isCloud ? 'is-cloud' : '';
-            if ($app.theme === 'auto') {
-                const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)');
-                if (darkThemeMq.matches) {
-                    document.body.setAttribute('class', `theme-dark ${isCloudClass}`);
-                    $app.themeInUse = 'dark';
-                } else {
-                    document.body.setAttribute('class', `theme-light ${isCloudClass}`);
-                    $app.themeInUse = 'light';
-                }
-            } else {
-                document.body.setAttribute('class', `theme-${$app.theme} ${isCloudClass}`);
-                $app.themeInUse = $app.theme;
-            }
+            document.body.setAttribute(
+                'class',
+                `theme-${$app.themeInUse} ${isCloud ? 'is-cloud' : ''}`
+            );
         }
     }
 </script>

--- a/src/routes/invite/+page.js
+++ b/src/routes/invite/+page.js
@@ -1,0 +1,2 @@
+export const ssr = true;
+export const prerender = true;

--- a/src/routes/invite/+page.svelte
+++ b/src/routes/invite/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { browser } from '$app/environment';
     import { goto } from '$app/navigation';
     import { base } from '$app/paths';
     import { Button, Form, FormList, InputChoice } from '$lib/elements/forms';
@@ -43,53 +44,59 @@
     <title>Accept invite - Appwrite</title>
 </svelte:head>
 
+<!-- if browser checks allow us to partially prerender on the server to improve FCP and LCP -->
 <Unauthenticated>
-    <svelte:fragment slot="title">
-        {#if !userId || !secret || !membershipId || !teamId}
-            Invalid invite
-        {:else}
-            Invite
-        {/if}
+    <svelte:fragment slot="title"
+        ><span
+            >{#if browser}
+                {#if !userId || !secret || !membershipId || !teamId}
+                    Invalid invite
+                {:else}
+                    Invite
+                {/if}{/if}</span>
     </svelte:fragment>
-    <svelte:fragment>
-        {#if !userId || !secret || !membershipId || !teamId}
-            <Alert type="warning">
-                <svelte:fragment slot="title">The invite link is not valid</svelte:fragment>
-                Please ask the project owner to send you a new invite.
-            </Alert>
-            <div class="u-flex u-main-end u-margin-block-start-40">
-                <Button href={`${base}/register`}>Sign up to Appwrite</Button>
-            </div>
-        {:else}
-            <p class="text">You have been invited to join a team project on Appwrite</p>
-            <Form onSubmit={acceptInvite}>
-                <FormList>
-                    <InputChoice
-                        required
-                        bind:value={terms}
-                        id="terms"
-                        label="terms"
-                        showLabel={false}>
-                        By accepting the invitation, you agree to the <a
-                            class="link"
-                            href="https://appwrite.io/terms"
-                            target="_blank"
-                            rel="noopener noreferrer">Terms and Conditions</a>
-                        and
-                        <a
-                            class="link"
-                            href="https://appwrite.io/privacy"
-                            target="_blank"
-                            rel="noopener noreferrer">
-                            Privacy Policy</a
-                        >.</InputChoice>
-
-                    <div class="u-flex u-main-end u-gap-12">
-                        <Button secondary href={`${base}/login`}>Cancel</Button>
-                        <Button submit>Accept</Button>
+    <svelte:fragment
+        ><div>
+            {#if browser}
+                {#if !userId || !secret || !membershipId || !teamId}
+                    <Alert type="warning">
+                        <svelte:fragment slot="title">The invite link is not valid</svelte:fragment>
+                        Please ask the project owner to send you a new invite.
+                    </Alert>
+                    <div class="u-flex u-main-end u-margin-block-start-40">
+                        <Button href={`${base}/register`}>Sign up to Appwrite</Button>
                     </div>
-                </FormList>
-            </Form>
-        {/if}
+                {:else}
+                    <p class="text">You have been invited to join a team project on Appwrite</p>
+                    <Form onSubmit={acceptInvite}>
+                        <FormList>
+                            <InputChoice
+                                required
+                                bind:value={terms}
+                                id="terms"
+                                label="terms"
+                                showLabel={false}>
+                                By accepting the invitation, you agree to the <a
+                                    class="link"
+                                    href="https://appwrite.io/terms"
+                                    target="_blank"
+                                    rel="noopener noreferrer">Terms and Conditions</a>
+                                and
+                                <a
+                                    class="link"
+                                    href="https://appwrite.io/privacy"
+                                    target="_blank"
+                                    rel="noopener noreferrer">
+                                    Privacy Policy</a
+                                >.</InputChoice>
+
+                            <div class="u-flex u-main-end u-gap-12">
+                                <Button secondary href={`${base}/login`}>Cancel</Button>
+                                <Button submit>Accept</Button>
+                            </div>
+                        </FormList>
+                    </Form>
+                {/if}{/if}
+        </div>
     </svelte:fragment>
 </Unauthenticated>

--- a/src/routes/login/+page.js
+++ b/src/routes/login/+page.js
@@ -1,0 +1,2 @@
+export const ssr = true;
+export const prerender = true;

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { browser } from '$app/environment';
     import { goto, invalidate } from '$app/navigation';
     import { base } from '$app/paths';
     import {
@@ -74,49 +75,55 @@
     <title>Sign in - Appwrite</title>
 </svelte:head>
 
+<!-- if browser checks allow us to partially prerender on the server to improve FCP and LCP -->
 <Unauthenticated>
-    <svelte:fragment slot="title">Sign in</svelte:fragment>
+    <svelte:fragment slot="title"
+        >{#if browser}Sign in{/if}</svelte:fragment>
     <svelte:fragment>
-        <Form onSubmit={login}>
-            <FormList>
-                <InputEmail
-                    id="email"
-                    label="Email"
-                    placeholder="Email"
-                    autofocus={true}
-                    required={true}
-                    bind:value={mail} />
-                <InputPassword
-                    id="password"
-                    label="Password"
-                    placeholder="Password"
-                    required={true}
-                    meter={false}
-                    showPasswordButton={true}
-                    bind:value={pass} />
-                <FormItem>
-                    <Button fullWidth submit {disabled}>Sign in</Button>
-                </FormItem>
-                {#if isCloud}
-                    <span class="with-separators eyebrow-heading-3">or</span>
+        {#if browser}
+            <Form onSubmit={login}>
+                <FormList>
+                    <InputEmail
+                        id="email"
+                        label="Email"
+                        placeholder="Email"
+                        autofocus={true}
+                        required={true}
+                        bind:value={mail} />
+                    <InputPassword
+                        id="password"
+                        label="Password"
+                        placeholder="Password"
+                        required={true}
+                        meter={false}
+                        showPasswordButton={true}
+                        bind:value={pass} />
                     <FormItem>
-                        <Button github fullWidth on:click={onGithubLogin} {disabled}>
-                            <span class="icon-github" aria-hidden="true" />
-                            <span class="text">Sign in with GitHub</span>
-                        </Button>
+                        <Button fullWidth submit {disabled}>Sign in</Button>
                     </FormItem>
-                {/if}
-            </FormList>
-        </Form>
+                    {#if isCloud}
+                        <span class="with-separators eyebrow-heading-3">or</span>
+                        <FormItem>
+                            <Button github fullWidth on:click={onGithubLogin} {disabled}>
+                                <span class="icon-github" aria-hidden="true" />
+                                <span class="text">Sign in with GitHub</span>
+                            </Button>
+                        </FormItem>
+                    {/if}
+                </FormList>
+            </Form>
+        {/if}
     </svelte:fragment>
     <svelte:fragment slot="links">
-        <li class="inline-links-item">
-            <a href={`${base}/recover`}><span class="text">Forgot Password?</span></a>
-        </li>
-        <li class="inline-links-item">
-            <a href={`${base}/register${$page?.url?.search ?? ''}`}>
-                <span class="text">Sign Up</span>
-            </a>
-        </li>
+        {#if browser}
+            <li class="inline-links-item">
+                <a href={`${base}/recover`}><span class="text">Forgot Password?</span></a>
+            </li>
+            <li class="inline-links-item">
+                <a href={`${base}/register${$page?.url?.search ?? ''}`}>
+                    <span class="text">Sign Up</span>
+                </a>
+            </li>
+        {/if}
     </svelte:fragment>
 </Unauthenticated>

--- a/src/routes/recover/+page.js
+++ b/src/routes/recover/+page.js
@@ -1,0 +1,2 @@
+export const ssr = true;
+export const prerender = true;

--- a/src/routes/recover/+page.svelte
+++ b/src/routes/recover/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { browser } from '$app/environment';
     import { base } from '$app/paths';
     import {
         Button,
@@ -66,57 +67,61 @@
     <title>Recover - Appwrite</title>
 </svelte:head>
 
+<!-- if browser checks allow us to partially prerender on the server to improve FCP and LCP -->
 <Unauthenticated>
-    <svelte:fragment slot="title">Password Recovery</svelte:fragment>
-    <svelte:fragment>
-        {#if userId && secret}
-            <Form onSubmit={setPassword}>
-                <FormList>
-                    <InputPassword
-                        label="New password"
-                        placeholder="Enter password"
-                        id="password"
-                        autofocus={true}
-                        required={true}
-                        showPasswordButton={true}
-                        bind:value={password} />
-                    <InputPassword
-                        label="Confirm password"
-                        placeholder="Confirm password"
-                        id="confirm-password"
-                        required={true}
-                        showPasswordButton={true}
-                        bind:value={confirmPassword} />
+    <svelte:fragment slot="title"
+        >{#if browser}Password Recovery{/if}</svelte:fragment>
+    <svelte:fragment
+        >{#if browser}
+            {#if userId && secret}
+                <Form onSubmit={setPassword}>
+                    <FormList>
+                        <InputPassword
+                            label="New password"
+                            placeholder="Enter password"
+                            id="password"
+                            autofocus={true}
+                            required={true}
+                            showPasswordButton={true}
+                            bind:value={password} />
+                        <InputPassword
+                            label="Confirm password"
+                            placeholder="Confirm password"
+                            id="confirm-password"
+                            required={true}
+                            showPasswordButton={true}
+                            bind:value={confirmPassword} />
 
-                    <FormItem>
-                        <Button fullWidth submit>Update</Button>
-                    </FormItem>
-                </FormList>
-            </Form>
-        {:else}
-            <Form onSubmit={recover}>
-                <FormList>
-                    <InputEmail
-                        id="email"
-                        label="Email"
-                        placeholder="Email"
-                        autofocus={true}
-                        required={true}
-                        bind:value={email} />
+                        <FormItem>
+                            <Button fullWidth submit>Update</Button>
+                        </FormItem>
+                    </FormList>
+                </Form>
+            {:else}
+                <Form onSubmit={recover}>
+                    <FormList>
+                        <InputEmail
+                            id="email"
+                            label="Email"
+                            placeholder="Email"
+                            autofocus={true}
+                            required={true}
+                            bind:value={email} />
 
-                    <FormItem>
-                        <Button fullWidth submit>Recover</Button>
-                    </FormItem>
-                </FormList>
-            </Form>
-        {/if}
+                        <FormItem>
+                            <Button fullWidth submit>Recover</Button>
+                        </FormItem>
+                    </FormList>
+                </Form>
+            {/if}{/if}
     </svelte:fragment>
-    <svelte:fragment slot="links">
-        <li class="inline-links-item">
-            <a href={`${base}/login`}><span class="text">Sign in</span></a>
-        </li>
-        <li class="inline-links-item">
-            <a href={`${base}/register`}><span class="text">Sign Up</span></a>
-        </li>
+    <svelte:fragment slot="links"
+        >{#if browser}
+            <li class="inline-links-item">
+                <a href={`${base}/login`}><span class="text">Sign in</span></a>
+            </li>
+            <li class="inline-links-item">
+                <a href={`${base}/register`}><span class="text">Sign Up</span></a>
+            </li>{/if}
     </svelte:fragment>
 </Unauthenticated>

--- a/src/routes/register/+page.js
+++ b/src/routes/register/+page.js
@@ -1,0 +1,2 @@
+export const ssr = true;
+export const prerender = true;

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { browser } from '$app/environment';
     import { goto, invalidate } from '$app/navigation';
     import { base } from '$app/paths';
     import {
@@ -65,65 +66,72 @@
     <title>Sign up - Appwrite</title>
 </svelte:head>
 
+<!-- if browser checks allow us to partially prerender on the server to improve FCP and LCP -->
 <Unauthenticated>
-    <svelte:fragment slot="title">Sign up</svelte:fragment>
-    <svelte:fragment>
-        <Form onSubmit={register}>
-            <FormList>
-                <InputText
-                    id="name"
-                    label="Name"
-                    placeholder="Your name"
-                    autofocus
-                    required
-                    bind:value={name} />
-                <InputEmail
-                    id="email"
-                    label="Email"
-                    placeholder="Your email"
-                    required
-                    bind:value={mail} />
-                <InputPassword
-                    id="password"
-                    label="Password"
-                    placeholder="Your password"
-                    required
-                    showPasswordButton
-                    bind:value={pass} />
-                <InputChoice required value={terms} id="terms" label="terms" showLabel={false}>
-                    By registering, you agree that you have read, understand, and acknowledge our <a
-                        class="link"
-                        href="https://appwrite.io/privacy"
-                        target="_blank"
-                        rel="noopener noreferrer">
-                        Privacy Policy</a>
-                    and accept our
-                    <a
-                        class="link"
-                        href="https://appwrite.io/terms"
-                        target="_blank"
-                        rel="noopener noreferrer">General Terms of Use</a
-                    >.</InputChoice>
-                <FormItem>
-                    <Button fullWidth submit {disabled}>Sign up</Button>
-                </FormItem>
-                {#if isCloud}
-                    <span class="with-separators eyebrow-heading-3">or</span>
+    <svelte:fragment slot="title"
+        >{#if browser}Sign up{/if}</svelte:fragment>
+    <svelte:fragment
+        >{#if browser}
+            <Form onSubmit={register}>
+                <FormList>
+                    <InputText
+                        id="name"
+                        label="Name"
+                        placeholder="Your name"
+                        autofocus
+                        required
+                        bind:value={name} />
+                    <InputEmail
+                        id="email"
+                        label="Email"
+                        placeholder="Your email"
+                        required
+                        bind:value={mail} />
+                    <InputPassword
+                        id="password"
+                        label="Password"
+                        placeholder="Your password"
+                        required
+                        showPasswordButton
+                        bind:value={pass} />
+                    <InputChoice required value={terms} id="terms" label="terms" showLabel={false}>
+                        By registering, you agree that you have read, understand, and acknowledge
+                        our <a
+                            class="link"
+                            href="https://appwrite.io/privacy"
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            Privacy Policy</a>
+                        and accept our
+                        <a
+                            class="link"
+                            href="https://appwrite.io/terms"
+                            target="_blank"
+                            rel="noopener noreferrer">General Terms of Use</a
+                        >.</InputChoice>
                     <FormItem>
-                        <Button github fullWidth on:click={onGithubLogin} {disabled}>
-                            <span class="icon-github" aria-hidden="true" />
-                            <span class="text">Sign up with GitHub</span>
-                        </Button>
+                        <Button fullWidth submit {disabled}>Sign up</Button>
                     </FormItem>
-                {/if}
-            </FormList>
-        </Form>
+                    {#if isCloud}
+                        <span class="with-separators eyebrow-heading-3">or</span>
+                        <FormItem>
+                            <Button github fullWidth on:click={onGithubLogin} {disabled}>
+                                <span class="icon-github" aria-hidden="true" />
+                                <span class="text">Sign up with GitHub</span>
+                            </Button>
+                        </FormItem>
+                    {/if}
+                </FormList>
+            </Form>
+        {/if}
     </svelte:fragment>
     <svelte:fragment slot="links">
-        <li class="inline-links-item">
-            <span class="text">
-                Already got an account? <a class="link" href={`${base}/login`}>Sign in</a>
-            </span>
-        </li>
+        {#if browser}
+            <li class="inline-links-item">
+                <span class="text">
+                    Already got an account? <a class="link" href={`${base}/login`}>Sign in</a>
+                </span>
+            </li>
+        {/if}
     </svelte:fragment>
 </Unauthenticated>


### PR DESCRIPTION
Closes https://github.com/appwrite/console/issues/722

Previously it would display a blank white screen, followed by a loading widget, followed by the actual content.

Now it displays the left half of the content with the logo and title immediately and then the right half of the content with page-specific contents is filled in later.

Note that turning on SSR would be a more performant solution for the rest of the pages and not just the public facing ones I'm tweaking here. However, I understand there's a desire to run only a single process (PHP server) and avoid the operational overhead of introducing a Node server, so I've sent this PR as a solution instead.