### PR TITLE
Update the date and time inputs to open on click

### DIFF
--- a/src/lib/elements/forms/inputDate.svelte
+++ b/src/lib/elements/forms/inputDate.svelte
@@ -75,6 +75,9 @@
             bind:value
             bind:this={element}
             on:invalid={handleInvalid}
+            on:click={function () {
+                this.showPicker();
+            }}
             style:--amount-of-buttons={isNullable ? 2.75 : 1}
             style:--button-size={isNullable ? '2rem' : '1rem'} />
         {#if isNullable}

--- a/src/lib/elements/forms/inputTime.svelte
+++ b/src/lib/elements/forms/inputTime.svelte
@@ -59,7 +59,10 @@
             class="input-text"
             bind:value
             bind:this={element}
-            on:invalid={handleInvalid} />
+            on:invalid={handleInvalid}
+            on:click={function () {
+                this.showPicker();
+            }} />
     </div>
     {#if error}
         <Helper type="warning">{error}</Helper>


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The default behavior is to open only when clicking the icon, but it may be difficult to click such a small icon. This change updates the input so that the picker opens when the input is clicked.

## Test Plan

https://github.com/appwrite/console/assets/1477010/bbcb6c5c-8e43-4886-a7a7-1da10fd4f868

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes