### PR TITLE
Fix empty auth user targets

### DIFF
--- a/src/routes/console/project-[project]/auth/user-[user]/targets/+page.svelte
+++ b/src/routes/console/project-[project]/auth/user-[user]/targets/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import { Button } from '$lib/elements/forms';
     import {
-        Empty,
         PaginationWithLimit,
         Heading,
         ViewSelector,
-        EmptyFilter
+        EmptyFilter,
+        EmptySearch
     } from '$lib/components';
     import { Container } from '$lib/layout';
     import type { PageData } from './$types';
@@ -104,12 +104,20 @@
             </Button>
         </EmptySearch> -->
     {:else}
-        <!-- TODO: update docs link -->
-        <Empty
-            single
-            on:click={() => (showAdd = true)}
-            href="https://appwrite.io/docs/references/cloud/client-web/teams"
-            target="subscriber" />
+        <EmptySearch hidePagination>
+            <div class="u-text-center">
+                <p>No targets are assigned to this user. Messages can not be sent to them.</p>
+                <p>
+                    Need a hand? Check out our <Button
+                        link
+                        external
+                        href="http://appwrite.io/docs/products/messaging/targets"
+                        text>
+                        documentation</Button
+                    >.
+                </p>
+            </div>
+        </EmptySearch>
     {/if}
 </Container>
 

--- a/src/routes/console/project-[project]/auth/user-[user]/targets/store.ts
+++ b/src/routes/console/project-[project]/auth/user-[user]/targets/store.ts
@@ -6,5 +6,5 @@ export const columns = writable<Column[]>([
     { id: 'target', title: 'Target', type: 'string', show: true, filter: false, width: 140 },
     { id: 'providerType', title: 'Type', type: 'string', show: true, filter: true, width: 80 },
     { id: 'provider', title: 'Provider', type: 'string', show: true, filter: false, width: 80 },
-    { id: '$createdAt', title: 'Created', type: 'string', show: true, width: 100 }
+    { id: '$createdAt', title: 'Created', type: 'datetime', show: true, width: 100 }
 ]);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

We don't support creating targets so the empty state
shouldn't open the create modal.

## Test Plan

Manual:

<img width="1210" alt="image" src="https://github.com/appwrite/console/assets/1477010/9ad6e0dc-28b7-40aa-96ba-a28cd75c8775">


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes