### PR TITLE
Use longGeneric instead of longOffset for time zone name

### DIFF
--- a/src/routes/console/project-[project]/messaging/wizard/step3.svelte
+++ b/src/routes/console/project-[project]/messaging/wizard/step3.svelte
@@ -24,7 +24,7 @@
         hour: 'numeric',
         minute: 'numeric',
         hourCycle: 'h23',
-        timeZoneName: 'longOffset'
+        timeZoneName: 'longGeneric'
     };
 
     async function beforeSubmit() {


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

longOffset shows the time zone as "GMT-08:00" which may be confusing or force the user to think for a second before realizing that it's their local timezone. longGeneric shows the time zone as "Pacific Time" which should be clearer.

## Test Plan

Manual:

<img width="758" alt="image" src="https://github.com/appwrite/console/assets/1477010/8d485fce-5848-4b95-8e22-48dd36ef9e00">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes