### PR TITLE
Show max length for sms and push messages

### DIFF
--- a/src/routes/console/project-[project]/messaging/wizard/pushFormList.svelte
+++ b/src/routes/console/project-[project]/messaging/wizard/pushFormList.svelte
@@ -99,6 +99,7 @@
                 id="message"
                 label="Message"
                 placeholder="Type here..."
+                maxlength={1000}
                 bind:value={$messageParams[MessagingProviderType.Push]['body']}>
             </InputTextarea>
             <!-- TODO: Add support for draft messages -->

--- a/src/routes/console/project-[project]/messaging/wizard/smsFormList.svelte
+++ b/src/routes/console/project-[project]/messaging/wizard/smsFormList.svelte
@@ -39,6 +39,7 @@
                 id="message"
                 label="Message"
                 placeholder="Type here..."
+                maxlength={900}
                 bind:value={$messageParams[$providerType]['content']}>
             </InputTextarea>
             <!-- TODO: Add support for draft messages -->


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Providing a limit will help clarify for the user so that they won't send a message which will then fail because of the limit.

Since the limit varies by provider, the Console is going to use the smallest limit out of all the providers.

## Test Plan

Manual:

<img width="754" alt="image" src="https://github.com/appwrite/console/assets/1477010/26662c30-35b9-4771-a3df-f1bf65846f70">

<img width="739" alt="image" src="https://github.com/appwrite/console/assets/1477010/0df000b6-75ea-44aa-a86e-87a228c4d0a7">


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes