### PR TITLE
Hide Usage tab on self-hosted project settings page

### DIFF
--- a/src/lib/helpers/load.ts
+++ b/src/lib/helpers/load.ts
@@ -36,7 +36,7 @@ export function getQuery(url: URL): string | undefined {
     return url.searchParams.get('query') ?? undefined;
 }
 
-type TabElement = { href: string; title: string; hasChildren?: boolean };
+export type TabElement = { href: string; title: string; event: string; hasChildren?: boolean };
 
 export function isTabSelected(
     tab: TabElement,

--- a/src/routes/console/project-[project]/settings/header.svelte
+++ b/src/routes/console/project-[project]/settings/header.svelte
@@ -2,11 +2,13 @@
     import { page } from '$app/stores';
     import { Tab, Tabs } from '$lib/components';
     import { isTabSelected } from '$lib/helpers/load';
+    import type { TabElement } from '$lib/helpers/load';
     import { Cover, CoverTitle } from '$lib/layout';
+    import { isCloud } from '$lib/system';
 
     const projectId = $page.params.project;
     const path = `/console/project-${projectId}/settings`;
-    const tabs = [
+    const tabs: TabElement[] = [
         {
             href: path,
             title: 'Overview',
@@ -31,14 +33,17 @@
             href: `${path}/smtp`,
             title: 'SMTP',
             event: 'smtp'
-        },
-        {
+        }
+    ];
+
+    if (isCloud) {
+        tabs.push({
             href: `${path}/usage`,
             title: 'Usage',
             event: 'usage',
             hasChildren: true
-        }
-    ];
+        });
+    }
 </script>
 
 <Cover>


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The usage tab requires an API only available on cloud.

## Test Plan

Manual

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes