### PR TITLE
Ensure active tab is selected despite trailing slash

### DIFF
--- a/src/lib/helpers/load.ts
+++ b/src/lib/helpers/load.ts
@@ -44,17 +44,18 @@ export function isTabSelected(
     basePath: string,
     tabs: TabElement[]
 ) {
+    const currentPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
     if (!tab?.hasChildren) {
-        return tab.href === pathname;
+        return tab.href === currentPath;
     } else {
-        if (tab.href === pathname) return true;
+        if (tab.href === currentPath) return true;
 
         if (tab.href === basePath) {
-            if (!tabs.some((t) => pathname.includes(t.href) && t.href !== tab.href)) {
-                return pathname.includes(tab.href);
+            if (!tabs.some((t) => currentPath.includes(t.href) && t.href !== tab.href)) {
+                return currentPath.includes(tab.href);
             }
         } else {
-            return pathname.includes(tab.href);
+            return currentPath.includes(tab.href);
         }
     }
 }

--- a/tests/unit/helpers/load.test.ts
+++ b/tests/unit/helpers/load.test.ts
@@ -1,0 +1,53 @@
+import { isTabSelected } from '$lib/helpers/load';
+
+describe('isTabSelected()', () => {
+    const tabs = {
+        a: { href: '/a', title: 'A' },
+        b: { href: '/b', title: 'B' },
+        c: { href: '/c', title: 'C', hasChildren: true }
+    };
+    const tabsArray = Object.values(tabs);
+
+    const tests = [
+        {
+            name: 'tab is selected',
+            tab: tabs.a,
+            pathname: '/a',
+            basePath: '/',
+            tabs: tabsArray,
+            expected: true
+        },
+        {
+            name: 'tab is not selected',
+            tab: tabs.b,
+            pathname: '/a',
+            basePath: '/',
+            tabs: tabsArray,
+            expected: false
+        },
+        {
+            name: 'tab with children is selected',
+            tab: tabs.c,
+            pathname: '/c/id',
+            basePath: '/',
+            tabs: tabsArray,
+            expected: true
+        },
+        {
+            name: 'tab is selected despite trailing slash',
+            tab: tabs.b,
+            pathname: '/b/',
+            basePath: '/',
+            tabs: tabsArray,
+            expected: true
+        }
+    ];
+
+    tests.forEach((test) => {
+        it(test.name, () => {
+            expect(isTabSelected(test.tab, test.pathname, test.basePath, test.tabs)).toBe(
+                test.expected
+            );
+        });
+    });
+});


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix a bug where the active tab wasn't selected because the URL had a trailing slash.

## Test Plan

Added unit tests.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes