### PR TITLE
Prevent duplicate create subscriber calls

### DIFF
--- a/src/lib/elements/forms/inputDate.svelte
+++ b/src/lib/elements/forms/inputDate.svelte
@@ -71,7 +71,7 @@
             {max}
             autocomplete={autocomplete ? 'on' : 'off'}
             type="date"
-            style={disabled ? "" : "cursor: pointer;"}
+            style={disabled ? '' : 'cursor: pointer;'}
             class="input-text"
             bind:value
             bind:this={element}

--- a/src/lib/elements/forms/inputTime.svelte
+++ b/src/lib/elements/forms/inputTime.svelte
@@ -57,7 +57,7 @@
             autocomplete={autocomplete ? 'on' : 'off'}
             type="time"
             class="input-text"
-            style={disabled ? "" : "cursor: pointer;"}
+            style={disabled ? '' : 'cursor: pointer;'}
             bind:value
             bind:this={element}
             on:invalid={handleInvalid}

--- a/src/routes/console/project-[project]/messaging/topics/topic-[topic]/subscribers/+page.svelte
+++ b/src/routes/console/project-[project]/messaging/topics/topic-[topic]/subscribers/+page.svelte
@@ -46,9 +46,14 @@
         const targetIds = Object.keys($targetsById).filter(
             (targetId) => !(targetId in subscribersByTargetId)
         );
-        const promises = targetIds.map((targetId) =>
-            sdk.forProject.messaging.createSubscriber($page.params.topic, ID.unique(), targetId)
-        );
+        const promises = targetIds.map(async (targetId) => {
+            const subscriber = await sdk.forProject.messaging.createSubscriber(
+                $page.params.topic,
+                ID.unique(),
+                targetId
+            );
+            subscribersByTargetId[targetId] = subscriber;
+        });
 
         try {
             await Promise.all(promises);


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Update subscribersByTargetId with created subscribers so subsequent addTarget() calls won't add the same targets again.

## Test Plan

Manual

## Related PRs and Issues

Parent:

* #850 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes