### PR TITLE
Hide overview card footer if message didn't fail

### DIFF
--- a/src/routes/console/project-[project]/messaging/message-[message]/overview.svelte
+++ b/src/routes/console/project-[project]/messaging/message-[message]/overview.svelte
@@ -32,7 +32,7 @@
     }
 </script>
 
-<CardGrid>
+<CardGrid hideFooter={$message.status != 'failed'}>
     <div class="grid-1-2-col-1 u-flex u-cross-center u-gap-16" data-private>
         <ProviderType type={$message.providerType} size="l">
             <Heading tag="h6" size="7">{providerType}</Heading>
@@ -51,15 +51,13 @@
     </svelte:fragment>
 
     <svelte:fragment slot="actions">
-        {#if $message.status === 'failed'}
-            <Button
-                secondary
-                on:click={(e) => {
-                    e.preventDefault();
-                    errors = $message.deliveryErrors;
-                    showFailed = true;
-                }}>View logs</Button>
-        {/if}
+        <Button
+            secondary
+            on:click={(e) => {
+                e.preventDefault();
+                errors = $message.deliveryErrors;
+                showFailed = true;
+            }}>View logs</Button>
     </svelte:fragment>
 </CardGrid>
 


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Since there's only 1 button that may not show, we need to hide the footer or else there will be a big empty space.

## Test Plan

Before change:

<img width="1271" alt="image" src="https://github.com/appwrite/console/assets/1477010/a007700d-61a5-4588-beb6-b38c281c14f3">

After change:

<img width="1249" alt="image" src="https://github.com/appwrite/console/assets/1477010/e0bb8920-ad53-4f7d-a4bf-142b522da257">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes