### PR TITLE
Dropdown for secure protocol for custom smtp

### DIFF
--- a/src/routes/console/project-[project]/settings/smtp/+page.svelte
+++ b/src/routes/console/project-[project]/settings/smtp/+page.svelte
@@ -23,6 +23,7 @@
     import { organization } from '$lib/stores/organization';
     import { wizard } from '$lib/stores/wizard';
     import ChangeOrganizationTierCloud from '$routes/console/changeOrganizationTierCloud.svelte';
+    import InputSelect from '$lib/elements/forms/inputSelect.svelte';
 
     let enabled = false;
     let senderName: string;
@@ -32,7 +33,13 @@
     let port: number;
     let username: string;
     let password: string;
-    let secure = false;
+    let secure: string;
+
+    const options = [
+        { value: 'tls', label: 'TLS' },
+        { value: 'ssl', label: 'SSL' },
+        { value: '', label: 'None' }
+    ];
 
     onMount(() => {
         enabled = $project.smtpEnabled ?? false;
@@ -43,7 +50,7 @@
         port = $project.smtpPort;
         username = $project.smtpUsername;
         password = $project.smtpPassword;
-        secure = $project.smtpSecure === 'tls';
+        secure = $project.smtpSecure === 'tls' ? 'tls' : $project.smtpSecure === 'ssl' ? 'ssl' : '';
     });
 
     async function updateSmtp() {
@@ -68,7 +75,7 @@
                 port ? port : undefined,
                 username ? username : undefined,
                 password ? password : undefined,
-                secure ? 'tls' : undefined
+                secure ? secure : undefined
             );
 
             invalidate(Dependencies.PROJECT);
@@ -97,7 +104,7 @@
             port: $project.smtpPort,
             username: $project.smtpUsername,
             password: $project.smtpPassword,
-            secure: $project.smtpSecure === 'tls'
+            secure: $project.smtpSecure
         }
     );
 
@@ -109,7 +116,7 @@
         port = undefined;
         username = undefined;
         password = undefined;
-        secure = false;
+        secure = undefined;
     }
 </script>
 
@@ -189,10 +196,12 @@
                                 label="Password"
                                 bind:value={password}
                                 placeholder="Enter password" />
-
-                            <InputChoice bind:value={secure} id="tls" label="TLS secure protocol">
-                                Enable if TLS is supported on your SMTP server.
-                            </InputChoice>
+                            <InputSelect
+                                id="tls"
+                                label="Secure protocol"
+                                placeholder="Select protocol"
+                                bind:value={secure}
+                                {options} />
                         {/if}
                     </FormList>
                 {/if}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Currently we only allowed TLS as secure protocol for SMTP. This PR adds dropdown to set secure protocol to SSL or TLS or none in custom SMTP settings.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/7051
https://github.com/appwrite/appwrite/pull/7674

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)