### PR TITLE
Hide pagination in topics/targets modals

### DIFF
--- a/src/routes/console/project-[project]/messaging/topicsModal.svelte
+++ b/src/routes/console/project-[project]/messaging/topicsModal.svelte
@@ -145,29 +145,22 @@
                         </div>
                     </div>
                 {:else if search}
-                    <div class="u-flex-vertical u-gap-8">
-                        <EmptySearch hidePagination>
-                            <div class="common-section">
-                                <div class="u-text-center common-section">
-                                    <b class="body-text-2 u-bold"
-                                        >Sorry we couldn't find "{search}"</b>
-                                    <p>There are no topics that match your search.</p>
-                                </div>
-                                <div class="u-flex u-gap-16 common-section u-main-center">
-                                    <Button
-                                        external
-                                        href="https://appwrite.io/docs/products/messaging/topics"
-                                        text>Documentation</Button>
-                                    <Button secondary on:click={() => (search = '')}
-                                        >Clear search</Button>
-                                </div>
+                    <EmptySearch hidePagination>
+                        <div class="common-section">
+                            <div class="u-text-center common-section">
+                                <b class="body-text-2 u-bold">Sorry we couldn't find "{search}"</b>
+                                <p>There are no topics that match your search.</p>
                             </div>
-                        </EmptySearch>
-                        <div class="u-flex u-main-space-between u-cross-center">
-                            <p class="text">Total results: {totalResults}</p>
-                            <PaginationInline limit={5} bind:offset sum={totalResults} hidePages />
+                            <div class="u-flex u-gap-16 common-section u-main-center">
+                                <Button
+                                    external
+                                    href="https://appwrite.io/docs/products/messaging/topics"
+                                    text>Documentation</Button>
+                                <Button secondary on:click={() => (search = '')}
+                                    >Clear search</Button>
+                            </div>
                         </div>
-                    </div>
+                    </EmptySearch>
                 {:else}
                     <EmptySearch hidePagination>
                         <div class="common-section">

--- a/src/routes/console/project-[project]/messaging/userTargetsModal.svelte
+++ b/src/routes/console/project-[project]/messaging/userTargetsModal.svelte
@@ -226,29 +226,22 @@
                         </div>
                     </div>
                 {:else if search}
-                    <div class="u-flex-vertical u-gap-8">
-                        <EmptySearch hidePagination>
-                            <div class="common-section">
-                                <div class="u-text-center common-section">
-                                    <b class="body-text-2 u-bold"
-                                        >Sorry we couldn't find "{search}"</b>
-                                    <p>There are no Users that match your search.</p>
-                                </div>
-                                <div class="u-flex u-gap-16 common-section u-main-center">
-                                    <Button
-                                        external
-                                        href="https://appwrite.io/docs/products/auth/accounts"
-                                        text>Documentation</Button>
-                                    <Button secondary on:click={() => (search = '')}
-                                        >Clear search</Button>
-                                </div>
+                    <EmptySearch hidePagination>
+                        <div class="common-section">
+                            <div class="u-text-center common-section">
+                                <b class="body-text-2 u-bold">Sorry we couldn't find "{search}"</b>
+                                <p>There are no Users that match your search.</p>
                             </div>
-                        </EmptySearch>
-                        <div class="u-flex u-main-space-between u-cross-center">
-                            <p class="text">Total results: {totalResults}</p>
-                            <PaginationInline limit={5} bind:offset sum={totalResults} hidePages />
+                            <div class="u-flex u-gap-16 common-section u-main-center">
+                                <Button
+                                    external
+                                    href="https://appwrite.io/docs/products/auth/accounts"
+                                    text>Documentation</Button>
+                                <Button secondary on:click={() => (search = '')}
+                                    >Clear search</Button>
+                            </div>
                         </div>
-                    </div>
+                    </EmptySearch>
                 {:else}
                     <EmptySearch hidePagination>
                         <div class="common-section">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Hide if searching results in 0 results.

## Test Plan

Manual

Topics modal:

<img width="729" alt="image" src="https://github.com/appwrite/console/assets/1477010/f0f6e06e-8c90-4b63-a150-bccfaef5aa75">

Targets modal:

<img width="756" alt="image" src="https://github.com/appwrite/console/assets/1477010/072f08cd-823d-42bd-92f3-8d6a95b949ac">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes