### PR TITLE
Fix default messages and topics columns

### DIFF
--- a/src/lib/components/viewSelector.svelte
+++ b/src/lib/components/viewSelector.svelte
@@ -31,12 +31,15 @@
         } else {
             const prefs = preferences.get($page.route);
 
-            columns.set(
-                $columns.map((column) => {
-                    column.show = prefs.columns?.includes(column.id) ?? true;
-                    return column;
-                })
-            );
+            // Override the shown columns only if a preference was set
+            if (prefs?.columns) {
+                columns.set(
+                    $columns.map((column) => {
+                        column.show = prefs.columns?.includes(column.id) ?? true;
+                        return column;
+                    })
+                );
+            }
         }
 
         columns.subscribe((ctx) => {

--- a/src/routes/console/project-[project]/messaging/+page.svelte
+++ b/src/routes/console/project-[project]/messaging/+page.svelte
@@ -34,12 +34,14 @@
     import FailedModal from './failedModal.svelte';
     import MessageStatusPill from './messageStatusPill.svelte';
     import ProviderType from './providerType.svelte';
-    import { columns, showCreate } from './store';
+    import { showCreate } from './store';
     import { sdk } from '$lib/stores/sdk';
     import { invalidate } from '$app/navigation';
     import { trackEvent, Submit, trackError } from '$lib/actions/analytics';
     import { Dependencies } from '$lib/constants';
     import { addNotification } from '$lib/stores/notifications';
+    import type { Column } from '$lib/helpers/types';
+    import { writable } from 'svelte/store';
 
     export let data: PageData;
     let selected: string[] = [];
@@ -50,6 +52,14 @@
     let showCreateDropdownMobile = false;
     let showCreateDropdownDesktop = false;
     let showCreateDropdownEmpty = false;
+    const columns = writable<Column[]>([
+        { id: '$id', title: 'Message ID', type: 'string', show: true, width: 140 },
+        { id: 'message', title: 'Message', type: 'string', show: false, filter: false, width: 140 },
+        { id: 'providerType', title: 'Type', type: 'string', show: true, width: 100 },
+        { id: 'status', title: 'Status', type: 'string', show: true, width: 120 },
+        { id: 'scheduledAt', title: 'Scheduled at', type: 'datetime', show: true, width: 120 },
+        { id: 'deliveredAt', title: 'Delivered at', type: 'datetime', show: false, width: 120 }
+    ]);
 
     const project = $page.params.project;
 

--- a/src/routes/console/project-[project]/messaging/store.ts
+++ b/src/routes/console/project-[project]/messaging/store.ts
@@ -1,17 +1,7 @@
-import type { Column } from '$lib/helpers/types';
 import type { Models } from '@appwrite.io/console';
 import { writable } from 'svelte/store';
 
 export const showCreate = writable(false);
-
-export const columns = writable<Column[]>([
-    { id: '$id', title: 'Message ID', type: 'string', show: true, width: 140 },
-    { id: 'message', title: 'Message', type: 'string', show: false, filter: false, width: 140 },
-    { id: 'providerType', title: 'Type', type: 'string', show: true, width: 100 },
-    { id: 'status', title: 'Status', type: 'string', show: true, width: 120 },
-    { id: 'scheduledAt', title: 'Scheduled at', type: 'datetime', show: true, width: 120 },
-    { id: 'deliveredAt', title: 'Delivered at', type: 'datetime', show: false, width: 120 }
-]);
 
 export const targetsById = writable<Record<string, Models.Target>>({});
 export const topicsById = writable<Record<string, Models.Topic>>({});

--- a/src/routes/console/project-[project]/messaging/topics/+page.svelte
+++ b/src/routes/console/project-[project]/messaging/topics/+page.svelte
@@ -16,14 +16,33 @@
     import { base } from '$app/paths';
     import type { Models } from '@appwrite.io/console';
     import type { PageData } from './$types';
-    import { columns, showCreate } from './store';
+    import { showCreate } from './store';
     import { View } from '$lib/helpers/load';
     import { Filters, hasPageQueries } from '$lib/components/filters';
     import Table from './table.svelte';
+    import type { Column } from '$lib/helpers/types';
+    import { writable } from 'svelte/store';
 
     export let data: PageData;
 
     const project = $page.params.project;
+    const columns = writable<Column[]>([
+        { id: '$id', title: 'Topic ID', type: 'string', show: true, width: 140 },
+        { id: 'name', title: 'Name', type: 'string', show: true, width: 140 },
+        { id: 'emailTotal', title: 'Email Subscribers', type: 'integer', show: false, width: 140 },
+        { id: 'smsTotal', title: 'SMS Subscribers', type: 'integer', show: false, width: 140 },
+        { id: 'pushTotal', title: 'Push Subscribers', type: 'integer', show: false, width: 140 },
+        {
+            id: 'total',
+            title: 'Subscribers',
+            type: 'integer',
+            show: true,
+            filter: false,
+            width: 140
+        },
+        { id: '$createdAt', title: 'Created', type: 'datetime', show: true, width: 140 }
+    ]);
+
     const topicCreated = async (event: CustomEvent<Models.Team<Record<string, unknown>>>) => {
         await goto(`${base}/console/project-${project}/messaging/topics/topic-${event.detail.$id}`);
     };
@@ -73,7 +92,7 @@
         </div>
     </div>
     {#if data.topics.total}
-        <Table {data} />
+        <Table columns={$columns} {data} />
 
         <PaginationWithLimit
             name="Topics"

--- a/src/routes/console/project-[project]/messaging/topics/store.ts
+++ b/src/routes/console/project-[project]/messaging/topics/store.ts
@@ -1,14 +1,3 @@
-import type { Column } from '$lib/helpers/types';
 import { writable } from 'svelte/store';
 
 export const showCreate = writable(false);
-
-export const columns = writable<Column[]>([
-    { id: '$id', title: 'Topic ID', type: 'string', show: true, width: 140 },
-    { id: 'name', title: 'Name', type: 'string', show: true, width: 140 },
-    { id: 'emailTotal', title: 'Email Subscribers', type: 'integer', show: false, width: 140 },
-    { id: 'smsTotal', title: 'SMS Subscribers', type: 'integer', show: false, width: 140 },
-    { id: 'pushTotal', title: 'Push Subscribers', type: 'integer', show: false, width: 140 },
-    { id: 'total', title: 'Subscribers', type: 'integer', show: true, filter: false, width: 140 },
-    { id: '$createdAt', title: 'Created', type: 'datetime', show: true, width: 140 }
-]);

--- a/src/routes/console/project-[project]/messaging/topics/table.svelte
+++ b/src/routes/console/project-[project]/messaging/topics/table.svelte
@@ -16,13 +16,14 @@
     } from '$lib/elements/table';
     import { addNotification } from '$lib/stores/notifications';
     import type { PageData } from './$types';
-    import { columns } from './store';
     import { project } from '$routes/console/project-[project]/store';
     import { invalidate } from '$app/navigation';
     import { Dependencies } from '$lib/constants';
     import { sdk } from '$lib/stores/sdk';
     import { toLocaleDateTime } from '$lib/helpers/date';
+    import type { Column } from '$lib/helpers/types';
 
+    export let columns: Column[];
     export let data: PageData;
 
     let selectedIds: string[] = [];
@@ -62,7 +63,7 @@
         <TableCellHeadCheck
             bind:selected={selectedIds}
             pageItemsIds={data.topics.topics.map((d) => d.$id)} />
-        {#each $columns as column}
+        {#each columns as column}
             {#if column.show}
                 <TableCellHead width={column.width}>{column.title}</TableCellHead>
             {/if}
@@ -74,10 +75,10 @@
                 href={`${base}/console/project-${$project.$id}/messaging/topics/topic-${topic.$id}`}>
                 <TableCellCheck bind:selectedIds id={topic.$id} />
 
-                {#each $columns as column (column.id)}
+                {#each columns as column (column.id)}
                     {#if column.show}
                         {#if column.id === '$id'}
-                            {#key $columns}
+                            {#key column.id}
                                 <TableCell title={column.title} width={column.width}>
                                     <Id value={topic.$id}>{topic.$id}</Id>
                                 </TableCell>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* Prevent <ViewSelector> from forcing all columns to be shown
* Localize columns stores so that the defaults reset properly

## Test Plan

1. Change columns
2. Delete preferences from local storage
3. Browse to the page again
4. Confirm the columns are reset back to the expected default

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes