### PR TITLE
Implementing the OAuth2 provider for 42 School in Appwrite

### DIFF
--- a/src/lib/stores/oauth-providers.ts
+++ b/src/lib/stores/oauth-providers.ts
@@ -74,6 +74,9 @@ const setProviders = (project: Models.Project): Provider[] => {
                 case 'facebook':
                     docs = 'https://developers.facebook.com/';
                     break;
+                case 'fortytwo':
+                    docs = 'https://api.intra.42.fr/apidoc/';
+                    break;
                 case 'github':
                     docs = 'https://developer.github.com';
                     break;

--- a/static/icons/dark/color/fortytwo.svg
+++ b/static/icons/dark/color/fortytwo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 28.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<polygon id="polygon5" class="st0" points="3,15 9.6,15 9.6,18.3 12.9,18.3 12.9,12.3 6.3,12.3 12.9,5.7 9.6,5.7 3,12.3 "/>
+<polygon id="polygon7" class="st0" points="14.4,9 17.7,5.7 14.4,5.7 "/>
+<polygon id="polygon9" class="st0" points="17.7,9 14.4,12.3 14.4,15.6 17.7,15.6 17.7,12.3 21,9 21,5.7 17.7,5.7 "/>
+<polygon id="polygon11" class="st0" points="21,12.3 17.7,15.6 21,15.6 "/>
+</svg>

--- a/static/icons/dark/grayscale/fortytwo.svg
+++ b/static/icons/dark/grayscale/fortytwo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 28.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#C4C6D7;}
+</style>
+<polygon id="polygon5" class="st0" points="3,15 9.6,15 9.6,18.3 12.9,18.3 12.9,12.3 6.3,12.3 12.9,5.7 9.6,5.7 3,12.3 "/>
+<polygon id="polygon7" class="st0" points="14.4,9 17.7,5.7 14.4,5.7 "/>
+<polygon id="polygon9" class="st0" points="17.7,9 14.4,12.3 14.4,15.6 17.7,15.6 17.7,12.3 21,9 21,5.7 17.7,5.7 "/>
+<polygon id="polygon11" class="st0" points="21,12.3 17.7,15.6 21,15.6 "/>
+</svg>

--- a/static/icons/light/color/fortytwo.svg
+++ b/static/icons/light/color/fortytwo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 28.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<polygon id="polygon5" points="3,15 9.6,15 9.6,18.3 12.9,18.3 12.9,12.3 6.3,12.3 12.9,5.7 9.6,5.7 3,12.3 "/>
+<polygon id="polygon7" points="14.4,9 17.7,5.7 14.4,5.7 "/>
+<polygon id="polygon9" points="17.7,9 14.4,12.3 14.4,15.6 17.7,15.6 17.7,12.3 21,9 21,5.7 17.7,5.7 "/>
+<polygon id="polygon11" points="21,12.3 17.7,15.6 21,15.6 "/>
+</svg>

--- a/static/icons/light/grayscale/fortytwo.svg
+++ b/static/icons/light/grayscale/fortytwo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 28.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#373B4D;}
+</style>
+<polygon id="polygon5" class="st0" points="3,15 9.6,15 9.6,18.3 12.9,18.3 12.9,12.3 6.3,12.3 12.9,5.7 9.6,5.7 3,12.3 "/>
+<polygon id="polygon7" class="st0" points="14.4,9 17.7,5.7 14.4,5.7 "/>
+<polygon id="polygon9" class="st0" points="17.7,9 14.4,12.3 14.4,15.6 17.7,15.6 17.7,12.3 21,9 21,5.7 17.7,5.7 "/>
+<polygon id="polygon11" class="st0" points="21,12.3 17.7,15.6 21,15.6 "/>
+</svg>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements the OAuth2 provider for 42 School in Appwrite, allowing users to authenticate with their 42 School credentials and access Appwrite's features seamlessly.

## Test Plan

1. Set up a development environment with Appwrite.
2. Configure the OAuth2 provider for 42 School in the Appwrite dashboard.
3. Attempt to authenticate with 42 School credentials through the Appwrite authentication flow.
4. Verify successful authentication and access to Appwrite's features.

## Related PRs and Issues

- [Related issue](https://github.com/appwrite/console/issues/945)
- [PR for @appwrite/appwrite](https://github.com/appwrite/appwrite/pull/7775)
- [Issue for @appwrite/appwrite](https://github.com/appwrite/appwrite/issues/7773)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

## Demonstration

https://github.com/appwrite/appwrite/assets/63407055/6d3090b3-df7f-4359-8333-3c194111ad4d
