### PR TITLE
fix: hide modal on error

### DIFF
--- a/src/routes/console/project-[project]/messaging/message-[message]/sendModal.svelte
+++ b/src/routes/console/project-[project]/messaging/message-[message]/sendModal.svelte
@@ -75,7 +75,7 @@
             });
             show = false;
         } catch (error) {
-            show = false
+            show = false;
             addNotification({
                 message: error.message,
                 type: 'error'

--- a/src/routes/console/project-[project]/messaging/message-[message]/sendModal.svelte
+++ b/src/routes/console/project-[project]/messaging/message-[message]/sendModal.svelte
@@ -75,6 +75,7 @@
             });
             show = false;
         } catch (error) {
+            show = false
             addNotification({
                 message: error.message,
                 type: 'error'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR is to hide the send modal in the Message page if there is an error in sending a message

## Test Plan
Manual

## Related PRs and Issues
Fixes: #965 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
YES
