### PR TITLE
fix: account state waterfall

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -13,9 +13,10 @@ export const ssr = false;
 export const load: LayoutLoad = async ({ depends, url }) => {
     depends(Dependencies.ACCOUNT);
 
-    redirectTo.set(url.searchParams.get('forceRedirect') || null);
-
-    url.searchParams.delete('forceRedirect');
+    if (url.searchParams.has('forceRedirect')) {
+        redirectTo.set(url.searchParams.get('forceRedirect') || null);
+        url.searchParams.delete('forceRedirect');
+    }
 
     try {
         const account = await sdk.forConsole.account.get<{ organization?: string }>();


### PR DESCRIPTION
## What does this PR do?

- the force redirect logic triggers the data loading on every navigation for the account
- this pr wraps it in a condition to prevent thath

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 