### PR TITLE
Resolved: Bug Report: Incorrect Message When Updating Events For Functions #978

### DIFF
--- a/src/routes/console/project-[project]/functions/function-[function]/settings/updateEvents.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/settings/updateEvents.svelte
@@ -54,7 +54,7 @@
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({
-                message: 'Permissions have been updated',
+                message: 'Events have been updated',
                 type: 'success'
             });
             trackEvent(Submit.FunctionUpdateEvents);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This commit changes the text from "Permissions have been updated" to "Events have been updated"

## Test Plan

I just added and removed random events and they all had the correct message.

## Related PRs and Issues

https://github.com/appwrite/console/issues/978

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes