### PR TITLE
feat: add downgrade alerts

### DIFF
--- a/src/routes/console/organization-[organization]/billing/+page.svelte
+++ b/src/routes/console/organization-[organization]/billing/+page.svelte
@@ -95,9 +95,8 @@
     {/if}
     {#if $organization?.billingPlanDowngrade}
         <Alert type="info" class="common-section">
-            Your organization will change to a Starter plan once your current billing cycle ends on {toLocaleDate(
-                $organization.billingNextInvoiceDate
-            )}.
+            Your organization will change to a Starter plan once your current billing cycle ends and
+            your invoice is paid on {toLocaleDate($organization.billingNextInvoiceDate)}.
         </Alert>
     {/if}
     <div class="common-section">

--- a/src/routes/console/wizard/cloudOrganizationChangeTier/confirmDetails.svelte
+++ b/src/routes/console/wizard/cloudOrganizationChangeTier/confirmDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Box, CreditCardBrandImage } from '$lib/components';
+    import { Alert, Box, CreditCardBrandImage } from '$lib/components';
     import { CouponInput } from '$lib/components/billing';
     import { BillingPlan } from '$lib/constants';
     import { FormList, InputSelect, InputTextarea } from '$lib/elements/forms';
@@ -7,7 +7,7 @@
     import { formatCurrency } from '$lib/helpers/numbers';
     import { WizardStep } from '$lib/layout';
     import type { Coupon } from '$lib/sdk/billing';
-    import { plansInfo } from '$lib/stores/billing';
+    import { plansInfo, tierToPlan } from '$lib/stores/billing';
     import { organization } from '$lib/stores/organization';
     import { sdk } from '$lib/stores/sdk';
     import {
@@ -58,17 +58,33 @@
             Your feedback is important to us and helps us improve the services Appwrite offers.
             Please let us know if there is a specific reason for changing your plan.
         </svelte:fragment>
-        <FormList>
+
+        <Alert>
+            <svelte:fragment slot="title"
+                >Your {tierToPlan($organization.billingPlan).name} plan subscription will end on {toLocaleDate(
+                    $organization.billingCurrentInvoiceDate
+                )}</svelte:fragment>
+            <p class="text">
+                Following the payment of your final invoice on {toLocaleDate(
+                    $organization.billingCurrentInvoiceDate
+                )}, your organization will switch to the {tierToPlan(
+                    $changeOrganizationTier.billingPlan
+                ).name} plan. Until then, you can continue to use the resources available to the {tierToPlan(
+                    $organization.billingPlan
+                ).name} plan.
+            </p>
+        </Alert>
+        <FormList class="u-margin-block-start-24">
             <InputSelect
                 id="reason"
-                label="What made you decide to change your plan?*"
+                label="Reason for plan change"
                 placeholder="Select one"
                 required
                 options={feedbackDowngradeOptions}
                 bind:value={$changeOrganizationTier.feedbackDowngradeReason} />
             <InputTextarea
                 id="comment"
-                label="Your feedback here"
+                label="If you would like to elaborate, please do so here"
                 placeholder="Enter feedback"
                 bind:value={$changeOrganizationTier.feedbackMessage} />
         </FormList>

--- a/src/routes/console/wizard/cloudOrganizationChangeTier/confirmDetails.svelte
+++ b/src/routes/console/wizard/cloudOrganizationChangeTier/confirmDetails.svelte
@@ -62,11 +62,11 @@
         <Alert>
             <svelte:fragment slot="title"
                 >Your {tierToPlan($organization.billingPlan).name} plan subscription will end on {toLocaleDate(
-                    $organization.billingCurrentInvoiceDate
+                    $organization.billingNextInvoiceDate
                 )}</svelte:fragment>
             <p class="text">
                 Following the payment of your final invoice on {toLocaleDate(
-                    $organization.billingCurrentInvoiceDate
+                    $organization.billingNextInvoiceDate
                 )}, your organization will switch to the {tierToPlan(
                     $changeOrganizationTier.billingPlan
                 ).name} plan. Until then, you can continue to use the resources available to the {tierToPlan(


### PR DESCRIPTION
Add an inline alert to the change plan/downgrade confirmation step in the modal to make it more clear that plan subscriptions will end after payment of their last invoice/completion of the current billing cycle.