### PR TITLE
Show Available Runtime When Only One Exists for Templates

### DIFF
--- a/src/lib/wizards/functions/steps/templateConfiguration.svelte
+++ b/src/lib/wizards/functions/steps/templateConfiguration.svelte
@@ -25,6 +25,10 @@
                 return allowedRuntimes.includes(runtime.value);
             });
 
+        if (options.length == 1) {
+            $templateConfig.runtime = options[0].value;
+        }
+
         return options;
     }
 </script>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Shows a default selected runtime value in the input selector when only one of the supported runtime is available when building a template function.

## Test Plan

Manual -

<img width="928" alt="Screenshot 2024-04-06 at 3 37 25 PM" src="https://github.com/appwrite/console/assets/20625965/615f6d88-e24e-4874-9aaa-76bb12edc272">

## Related PRs and Issues

#1011.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.