### PR TITLE
fix: retry payment modal, method selection 

### DIFF
--- a/src/routes/console/organization-[organization]/billing/retryPaymentModal.svelte
+++ b/src/routes/console/organization-[organization]/billing/retryPaymentModal.svelte
@@ -30,8 +30,21 @@
     let paymentMethodId: string;
     let setAsDefault = false;
 
-    onMount(() => {
-        paymentMethodId = $organization.paymentMethodId;
+    onMount(async () => {
+        if (!$organization.paymentMethodId && !$organization.backupPaymentMethodId) {
+            paymentMethodId = $paymentMethods?.total ? $paymentMethods.paymentMethods[0].$id : null;
+        } else {
+            paymentMethodId = $organization.paymentMethodId
+                ? $organization.paymentMethodId
+                : $organization.backupPaymentMethodId;
+            // If the selected payment method does not belong to the current user, select the first one.
+            if (
+                $paymentMethods?.total &&
+                !$paymentMethods.paymentMethods.some((method) => method.$id === paymentMethodId)
+            ) {
+                paymentMethodId = $paymentMethods.paymentMethods[0].$id;
+            }
+        }
     });
 
     async function handleSubmit() {


### PR DESCRIPTION
This pull request fixes the issue where no method is selected when the organization paymentMethod belongs to someone else. The onMount function has been updated to handle the scenario where the organization does not have a payment method or a backup payment method. If neither is available, the first payment method from the list will be selected. Additionally, if the selected payment method does not belong to the current user, the first payment method will be selected instead.