### PR TITLE
Remove Retry Option for Verified Domains

### DIFF
--- a/src/lib/pages/domains/index.svelte
+++ b/src/lib/pages/domains/index.svelte
@@ -147,11 +147,15 @@
                                 <span class="icon-dots-horizontal" aria-hidden="true" />
                             </Button>
                             <svelte:fragment slot="list">
-                                <DropListItem icon="refresh" on:click={() => openRetry(domain, i)}>
-                                    {domain.status === 'unverfied'
-                                        ? 'Retry generation'
-                                        : 'Retry verification'}
-                                </DropListItem>
+                                {#if domain.status !== 'verified'}
+                                    <DropListItem
+                                        icon="refresh"
+                                        on:click={() => openRetry(domain, i)}>
+                                        {domain.status === 'unverfied'
+                                            ? 'Retry generation'
+                                            : 'Retry verification'}
+                                    </DropListItem>
+                                {/if}
                                 <DropListItem
                                     icon="trash"
                                     on:click={() => {

--- a/src/lib/pages/domains/index.svelte
+++ b/src/lib/pages/domains/index.svelte
@@ -151,7 +151,7 @@
                                     <DropListItem
                                         icon="refresh"
                                         on:click={() => openRetry(domain, i)}>
-                                        {domain.status === 'unverfied'
+                                        {domain.status === 'unverified'
                                             ? 'Retry generation'
                                             : 'Retry verification'}
                                     </DropListItem>
@@ -183,7 +183,7 @@
 <Delete bind:showDelete bind:selectedDomain {dependency} />
 <Modal bind:show={showRetry} headerDivider={false} bind:error={retryError} size="big">
     <svelte:fragment slot="title">
-        Retry {$domain.status === 'unverfied' ? 'certificate generation' : 'verification'}
+        Retry {$domain.status === 'unverified' ? 'certificate generation' : 'verification'}
     </svelte:fragment>
     <Retry on:error={(e) => (retryError = e.detail)} />
     <svelte:fragment slot="footer">

--- a/src/lib/pages/domains/wizard/retry.svelte
+++ b/src/lib/pages/domains/wizard/retry.svelte
@@ -21,7 +21,7 @@
             invalidate(Dependencies.FUNCTION_DOMAINS);
             addNotification({
                 message:
-                    $domain.status === 'unverfied'
+                    $domain.status === 'unverified'
                         ? 'Domain certificate has been generated successfully'
                         : 'Domain has been verified successfully',
                 type: 'success'


### PR DESCRIPTION
## What does this PR do?

Don't show `Retry Verification` if the domain is already verified.

Fixes https://github.com/appwrite/console/issues/1016

## Test Plan

Manual.

<img width="1259" alt="domain unverified" src="https://github.com/appwrite/console/assets/20625965/8c600cb1-4083-447e-9ea4-854eb3ade140">

<img width="1255" alt="domain verified" src="https://github.com/appwrite/console/assets/20625965/259644ae-6650-44be-ab8e-09608048a71c">

## Related PRs and Issues

* #1016 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.