### PR TITLE
Show Message Status Column on Non Desktops

### DIFF
--- a/src/routes/console/project-[project]/messaging/+page.svelte
+++ b/src/routes/console/project-[project]/messaging/+page.svelte
@@ -176,7 +176,7 @@
                                         <ProviderType type={message.providerType} size="s" />
                                     </TableCellText>
                                 {:else if column.id === 'status'}
-                                    <TableCellText onlyDesktop title="Status">
+                                    <TableCellText title="Status">
                                         <span class="u-inline-flex u-gap-12 u-cross-center">
                                             <MessageStatusPill status={message.status} />
                                             {#if message.status === 'failed'}


### PR DESCRIPTION
## What does this PR do?

Shows the message status tab on non desktop devices too.

Fixes https://github.com/appwrite/console/issues/969

## Test Plan

Manual.

<img width="967" alt="Screenshot 2024-04-11 at 6 58 05 PM" src="https://github.com/appwrite/console/assets/20625965/d3e0a119-3d68-42b1-aaf2-b71e008d07e9">

## Related PRs and Issues

* #969.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.