### PR TITLE
Fix: Use `error` for notification types on an error.

### DIFF
--- a/src/routes/console/organization-[organization]/wizard/step2.svelte
+++ b/src/routes/console/organization-[organization]/wizard/step2.svelte
@@ -30,7 +30,7 @@
             });
         } catch (error) {
             addNotification({
-                type: 'success',
+                type: 'error',
                 message: 'Something went wrong, please try again later'
             });
         }
@@ -52,7 +52,7 @@
             });
         } catch (error) {
             addNotification({
-                type: 'success',
+                type: 'error',
                 message: 'Something went wrong, please try again later'
             });
         }


### PR DESCRIPTION
## What does this PR do?

Fixes the wrong notification type used.

## Test Plan

NA.

## Related PRs and Issues

NA.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.