### PR TITLE
Improve Bucket Limits Message

### DIFF
--- a/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.svelte
@@ -124,7 +124,7 @@
                 <p class="text">
                     <button class="link" type="button" on:click|preventDefault={upgradeMethod}
                         >Upgrade</button>
-                    for additional storage.
+                    for additional storage resources.
                 </p>
             {:else}
                 <p class="text">

--- a/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.svelte
@@ -113,10 +113,15 @@
         </svelte:fragment>
         <svelte:fragment slot="tooltip" let:limit let:tier let:upgradeMethod>
             {#if tier === 'Starter'}
+                <p class="u-bold">The {tier} plan has limits</p>
+                <ul>
+                    <li>{limit}GB total file storage</li>
+                    <li>
+                        {Math.floor(parseInt(maxFileSize.value))}{maxFileSize.unit} file upload size
+                        limit
+                    </li>
+                </ul>
                 <p class="text">
-                    You are limited to <b>{limit}GB</b> of total storage and maximum upload file
-                    size limit of <b>{Math.floor(parseInt(maxFileSize.value))}{maxFileSize.unit}</b>
-                    on the {tier} plan.
                     <button class="link" type="button" on:click|preventDefault={upgradeMethod}
                         >Upgrade</button>
                     for additional storage.

--- a/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/console/project-[project]/storage/bucket-[bucket]/+page.svelte
@@ -114,9 +114,9 @@
         <svelte:fragment slot="tooltip" let:limit let:tier let:upgradeMethod>
             {#if tier === 'Starter'}
                 <p class="text">
-                    You are limited to {limit} GB of total storage and {Math.floor(
-                        parseInt(maxFileSize.value)
-                    )}{maxFileSize.unit} on the {tier} plan.
+                    You are limited to <b>{limit}GB</b> of total storage and maximum upload file
+                    size limit of <b>{Math.floor(parseInt(maxFileSize.value))}{maxFileSize.unit}</b>
+                    on the {tier} plan.
                     <button class="link" type="button" on:click|preventDefault={upgradeMethod}
                         >Upgrade</button>
                     for additional storage.


### PR DESCRIPTION
## What does this PR do?

This PR fixes the ambiguous file size shown on bucket limits without specifying the type of the size limit.

## Test Plan

Manual -

<img width="527" alt="Screenshot 2024-04-29 at 4 29 35 PM" src="https://github.com/appwrite/console/assets/20625965/c404c499-d4fd-401f-8f7c-204cc7a9bf51">

## Related PRs and Issues

NA.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.