### PR TITLE
Fix location of tooltip in collection table

### DIFF
--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/table.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/table.svelte
@@ -215,6 +215,7 @@
                             {@const formatted = formatColumn(document[column.id])}
                             <TableCell>
                                 <div
+                                    class="u-width-fit-content"
                                     use:tooltip={{
                                         content: formatted.whole,
                                         disabled: !formatted.truncated


### PR DESCRIPTION
Update size for<div> element to fit-content  in order for the tooltip will be in the correct location