### PR TITLE
Allow multiple 1 way relationships between collections

### DIFF
--- a/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/attributes/relationship.svelte
+++ b/src/routes/console/project-[project]/databases/database-[database]/collection-[collection]/attributes/relationship.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-    import { Query, type Models, RelationshipType, RelationMutate } from '@appwrite.io/console';
+    import { ID, Query, type Models, RelationshipType, RelationMutate } from '@appwrite.io/console';
     import { sdk } from '$lib/stores/sdk';
 
     export async function submitRelationship(
@@ -21,7 +21,7 @@
             data.relationType,
             data.twoWay,
             data.key,
-            data.twoWayKey,
+            data.twoWayKey ?? ID.unique(),
             data.onDelete
         );
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because two way key is not exposed or sent, the API defaults to the related collection's ID as the two way key. As such, if you try to add another one, it will fail because the two way key is already in use.

## Test Plan

Multiple many to one relationship attributes:

<img width="841" alt="image" src="https://github.com/appwrite/console/assets/1477010/0679632a-bae4-4c39-9155-1b35efd300a1">

Multiple one to one relationship attributes:

<img width="1674" alt="image" src="https://github.com/appwrite/console/assets/1477010/314d7c3b-b912-4c82-8257-8c1e64213e9a">

Multiple one to many:

<img width="1676" alt="image" src="https://github.com/appwrite/console/assets/1477010/8d21fb4f-1ac8-4922-b272-6097b643cca0">


## Related PRs and Issues

* appwrite/appwrite#8059

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes