### PR TITLE
fix: set visibility boolean to is-not-desktop

### DIFF
--- a/src/lib/layout/navigation.svelte
+++ b/src/lib/layout/navigation.svelte
@@ -158,7 +158,7 @@
                                 <span class="text">Storage</span>
                             </a>
                         </li>
-                        <li class="drop-list-item is-only-mobile">
+                        <li class="drop-list-item is-not-desktop">
                             <a
                                 class="drop-button"
                                 href={`${projectPath}/settings`}
@@ -197,7 +197,7 @@
                         <span class="text">Settings</span>
                     </a>
 
-                    <ul class="drop-list is-only-mobile">
+                    <ul class="drop-list is-not-desktop">
                         {#if isCloud && $organization?.billingPlan !== BillingPlan.SCALE}
                             <li class="drop-list-item">
                                 <button


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR fixes a navigation visibility issue. It makes all the navigation items visible in desktop, tablet and mobile view as expected.

## Test Plan

I tested in chrome browser visually/manually

## Related PRs and Issues

Closes #1008 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

Video of the changes:

https://github.com/appwrite/console/assets/67555014/bf162518-6628-4ac3-93ec-4a4669e2a5f4

