### PR TITLE
fix: Bucket ui card alignment issue

### DIFF
--- a/src/lib/components/cardContainer.svelte
+++ b/src/lib/components/cardContainer.svelte
@@ -20,7 +20,7 @@
 
 <ul
     class="grid-box common-section u-margin-block-start-32"
-    style={`--grid-gap:1.5rem; --grid-item-size:${total > 3 ? '22rem' : '25rem'};`}
+    style={`--grid-gap: ${total > 3 ? '1.5rem' : '2.5rem'}; --grid-item-size:${total > 3 ? '22rem' : '25rem'};`}
     data-private>
     <slot />
 


### PR DESCRIPTION

## What does this PR do?

The cards visible on buckets tab previously looked like this when the media query applied to max-width: 767.99px

![appwrite2](https://github.com/appwrite/console/assets/125039325/d88decbb-94b9-4abc-bfa1-e03cbc96d0e7)

Now it looks like this: 

![appwrite1](https://github.com/appwrite/console/assets/125039325/664e0f52-1d08-46d2-baad-6556613dbbdd)

## Test Plan

Tested with self hosted instance, since the card component was used in various places e.g Projects, buckets, so I had to put a condition not to break any other changes, Have tested for projects tab and buckets tab

## Related PRs and Issues

fixes #1044 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes