### PR TITLE
Mark entrypoint as required for manual function creation

### DIFF
--- a/src/lib/wizards/functions/steps/configuration.svelte
+++ b/src/lib/wizards/functions/steps/configuration.svelte
@@ -22,7 +22,8 @@
             label="Entrypoint"
             id="entrypoint"
             placeholder="Entrypoint"
-            bind:value={$createFunction.entrypoint} />
+            bind:value={$createFunction.entrypoint}
+            required />
         <Collapsible>
             <CollapsibleItem>
                 <svelte:fragment slot="title">Build commands</svelte:fragment>

--- a/src/routes/console/project-[project]/functions/function-[function]/createManual.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/createManual.svelte
@@ -75,7 +75,8 @@
             label="Entrypoint"
             id="entrypoint"
             placeholder="Entrypoint"
-            bind:value={entrypoint} />
+            bind:value={entrypoint}
+            required />
         {#if $func.version !== 'v3'}
             <Alert type="info">
                 <svelte:fragment slot="title">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Mark entrypoint as required for manual function creation because when user creates a function from console, the first deployments gets created automatically. If they don't specify entrypoint in function creation, it would throw server error.

## Test Plan

Tested manually

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes