### PR TITLE
Add Messaging Events to Builder Modal

### DIFF
--- a/src/lib/components/eventModal.svelte
+++ b/src/lib/components/eventModal.svelte
@@ -249,7 +249,7 @@
     <slot />
     <div>
         <p class="u-text">Choose a service</p>
-        <div class="u-flex u-gap-8 u-margin-block-start-8">
+        <div class="u-flex u-gap-8 u-margin-block-start-8 u-flex-wrap">
             {#each available.services as service}
                 <Pill
                     disabled={showInput}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -343,6 +343,26 @@ export const eventServices: Array<EventService> = [
             { name: 'update', attributes: ['email', 'name', 'password', 'status', 'prefs'] },
             { name: 'delete' }
         ]
+    },
+    {
+        name: 'providers',
+        resources: [],
+        actions: [{ name: 'create' }, { name: 'update' }, { name: 'delete' }]
+    },
+    {
+        name: 'topics',
+        resources: [
+            {
+                name: 'subscribers',
+                actions: [{ name: 'create' }, { name: 'delete' }]
+            }
+        ],
+        actions: [{ name: 'create' }, { name: 'update' }, { name: 'delete' }]
+    },
+    {
+        name: 'messages',
+        resources: [],
+        actions: [{ name: 'create' }, { name: 'update' }, { name: 'delete' }]
     }
 ];
 


### PR DESCRIPTION
## What does this PR do?

Adds messaging support to the events builder modal.

## Test Plan

Manual, See -

<img src="https://github.com/appwrite/console/assets/20625965/fc3a173a-6f42-491d-a6be-740f08b3ead6" height=350 />

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/7833

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.