### PR TITLE
fix setSelfSigned syntax for import step in android docs

### DIFF
--- a/src/routes/console/project-[project]/overview/platforms/wizard/android/step3.svelte
+++ b/src/routes/console/project-[project]/overview/platforms/wizard/android/step3.svelte
@@ -11,7 +11,7 @@ import io.appwrite.services.Account
 val client = Client(context)
     .setEndpoint("${endpoint}")
     .setProject("${project}")
-    .setSelfSigned(status: true) // For self signed certificates, only use for development`;
+    .setSelfSigned(true) // For self signed certificates, only use for development`;
 </script>
 
 <WizardStep>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)
The android docs had `.setSelfSigned(status: true)` which is the wrong syntax as suggested in the issue.


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)
https://github.com/appwrite/console/issues/999

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
Yes