### PR TITLE
fix project id undefined error by disabling when not in project

### DIFF
--- a/src/routes/console/+layout.svelte
+++ b/src/routes/console/+layout.svelte
@@ -149,6 +149,7 @@
                         await goto(`/console/project-${$project.$id}/auth/security#${heading}`);
                         scrollBy({ top: -100 });
                     },
+                    disabled: !$project?.$id,
                     group: 'security',
                     icon: 'pencil'
                 }) as const
@@ -161,7 +162,8 @@
             callback: () => {
                 goto(`/console/project-${$project.$id}/settings`);
             },
-            disabled: isOnSettingsLayout && $page.url.pathname.endsWith('settings'),
+            disabled:
+                !$project?.$id || (isOnSettingsLayout && $page.url.pathname.endsWith('settings')),
             group: isOnSettingsLayout ? 'navigation' : 'settings',
             rank: isOnSettingsLayout ? 40 : -1
         },
@@ -172,7 +174,8 @@
             callback: () => {
                 goto(`/console/project-${$project.$id}/settings/domains`);
             },
-            disabled: isOnSettingsLayout && $page.url.pathname.includes('domains'),
+            disabled:
+                !$project?.$id || (isOnSettingsLayout && $page.url.pathname.includes('domains')),
             group: isOnSettingsLayout ? 'navigation' : 'settings',
             rank: isOnSettingsLayout ? 30 : -1
         },
@@ -182,7 +185,8 @@
             callback: () => {
                 goto(`/console/project-${$project.$id}/settings/webhooks`);
             },
-            disabled: isOnSettingsLayout && $page.url.pathname.includes('webhooks'),
+            disabled:
+                !$project?.$id || (isOnSettingsLayout && $page.url.pathname.includes('webhooks')),
             group: isOnSettingsLayout ? 'navigation' : 'settings',
 
             rank: isOnSettingsLayout ? 20 : -1
@@ -193,7 +197,8 @@
             callback: () => {
                 goto(`/console/project-${$project.$id}/settings/migrations`);
             },
-            disabled: isOnSettingsLayout && $page.url.pathname.includes('migrations'),
+            disabled:
+                !$project?.$id || (isOnSettingsLayout && $page.url.pathname.includes('migrations')),
             group: isOnSettingsLayout ? 'navigation' : 'settings',
 
             rank: isOnSettingsLayout ? 10 : -1
@@ -202,9 +207,10 @@
             label: 'Go to SMTP settings',
             keys: isOnSettingsLayout ? ['g', 's'] : undefined,
             callback: () => {
+                console.log('withing callback of go to smtp');
                 goto(`/console/project-${$project.$id}/settings/smtp`);
             },
-            disabled: isOnSettingsLayout && $page.url.pathname.includes('smtp'),
+            disabled: !$project?.$id || (isOnSettingsLayout && $page.url.pathname.includes('smtp')),
             group: isOnSettingsLayout ? 'navigation' : 'settings',
             rank: -1
         },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In the search options, the security and the settings section were not clickable as the callback functions were referencing `project.$id` which is undefined when the page url is not that of a project. Added condition to disable these options based on whether `project.$id` exists or not.

Fixes https://github.com/appwrite/console/issues/1042

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

- https://github.com/appwrite/console/issues/1042

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)