### PR TITLE
fix - password doesn't reset after updating email

### DIFF
--- a/src/routes/console/account/updateEmail.svelte
+++ b/src/routes/console/account/updateEmail.svelte
@@ -25,6 +25,7 @@
                 type: 'success'
             });
             trackEvent(Submit.AccountUpdateEmail);
+            emailPassword = null;
         } catch (error) {
             addNotification({
                 message: error.message,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
The password field was not resetting after email update is successful which should ideally be resetting as mentioned in the issue. Set emailPassword as null after email is updated.

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)
#976 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
Yes