### PR TITLE
Fix next execution showing n/a

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@stripe/stripe-js": "^3.4.0",
                 "ai": "^2.2.11",
                 "analytics": "^0.8.9",
+                "cron-parser": "^4.9.0",
                 "dayjs": "^1.11.9",
                 "deep-equal": "^2.2.2",
                 "dotenv": "^16.3.1",
@@ -4020,6 +4021,17 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/cron-parser": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+            "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+            "dependencies": {
+                "luxon": "^3.2.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7017,6 +7029,14 @@
             "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/luxon": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@stripe/stripe-js": "^3.4.0",
         "ai": "^2.2.11",
         "analytics": "^0.8.9",
+        "cron-parser": "^4.9.0",
         "dayjs": "^1.11.9",
         "deep-equal": "^2.2.2",
         "dotenv": "^16.3.1",

--- a/src/routes/console/project-[project]/functions/+page.svelte
+++ b/src/routes/console/project-[project]/functions/+page.svelte
@@ -1,24 +1,25 @@
 <script lang="ts">
     import { base } from '$app/paths';
     import { page } from '$app/stores';
-    import { Container, ContainerHeader } from '$lib/layout';
     import { tooltip } from '$lib/actions/tooltip';
+    import { registerCommands, updateCommandGroupRanks } from '$lib/commandCenter';
     import { CardContainer, Empty, GridItem1, Id, PaginationWithLimit } from '$lib/components';
     import { toLocaleDateTime } from '$lib/helpers/date';
+    import { Container, ContainerHeader } from '$lib/layout';
     import { app } from '$lib/stores/app';
+    import { isServiceLimited } from '$lib/stores/billing';
+    import { marketplace } from '$lib/stores/marketplace.js';
+    import { organization } from '$lib/stores/organization';
     import { wizard } from '$lib/stores/wizard';
-    import { onMount } from 'svelte';
     import Initial from '$lib/wizards/functions/cover.svelte';
-    import { registerCommands, updateCommandGroupRanks } from '$lib/commandCenter';
     import CreateTemplate from '$lib/wizards/functions/createTemplate.svelte';
     import {
         templateConfig as templateConfigStore,
         template as templateStore
     } from '$lib/wizards/functions/store.js';
-    import { marketplace } from '$lib/stores/marketplace.js';
+    import { parseExpression } from 'cron-parser';
+    import { onMount } from 'svelte';
     import { functionsList } from './store';
-    import { organization } from '$lib/stores/organization';
-    import { isServiceLimited } from '$lib/stores/billing';
 
     export let data;
 
@@ -106,7 +107,7 @@
                                     aria-hidden="true"
                                     use:tooltip={{
                                         content: `Next execution: 
-                                        ${toLocaleDateTime(func.schedule)}`
+                                        ${toLocaleDateTime(parseExpression(func.schedule, { utc: true }).next().toString())}`
                                     }} />
                             </li>
                         {/if}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In a previous version of Appwrite, there was a next attribute with the timestamp of when the function would be executed next. That was removed, but the Console has not been updated to show the correct timestamp.

This PR installs cron-parser package and uses it to convert the schedule to a human readable timestamp.

Fixes #851 

## Test Plan

With a schedule of `0 0 * * *`

### Before

<img width="647" alt="image" src="https://github.com/appwrite/console/assets/1477010/74949a7d-3b18-461a-95c9-9fc8b91898ab">

### After

<img width="782" alt="image" src="https://github.com/appwrite/console/assets/1477010/d10b88ea-9006-44f4-9dc8-21c49e1626cd">

This is correct because `0 0 * * *` is midnight UTC, which converts to 17:00 where I am (PT).

## Related PRs and Issues

* #851 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes