### PR TITLE
Fixed the wizard footer overlapping with Language indicator

### DIFF
--- a/src/lib/layout/wizard.svelte
+++ b/src/lib/layout/wizard.svelte
@@ -187,7 +187,7 @@
                     <svelte:component this={component} />
                 {/if}
             {/each}
-            <div class="form-footer">
+            <div class="u-z-index-20 form-footer">
                 <div class="u-flex u-main-end u-gap-12">
                     {#if !isLastStep && currentStep?.optional}
                         <Button text on:click={() => dispatch('finish')}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR resolves the issue related to the wizard footer which is overlapping with the language indicator component. This is related to [appwrite/console/issues/1071](https://github.com/appwrite/console/issues/1071)


## Related PRs and Issues

[appwrite/console/issues/1071](https://github.com/appwrite/console/issues/1071)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes