### PR TITLE
Fix undefined error when submitting support ticket on account page

### DIFF
--- a/src/routes/console/supportWizard.svelte
+++ b/src/routes/console/supportWizard.svelte
@@ -1,21 +1,21 @@
 <script lang="ts">
-    import { Wizard } from '$lib/layout';
-    import { onDestroy } from 'svelte';
-    import { isSupportOnline, supportData } from './wizard/support/store';
-    import Step1 from './wizard/support/step1.svelte';
-    import type { WizardStepsType } from '$lib/layout/wizard.svelte';
-    import { user } from '$lib/stores/user';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
-    import { addNotification } from '$lib/stores/notifications';
-    import { wizard } from '$lib/stores/wizard';
-    import { VARS } from '$lib/system';
-    import { organization } from '$lib/stores/organization';
     import {
         localeTimezoneName,
         utcHourToLocaleHour,
         utcWeekDayToLocaleWeekDay,
         type WeekDay
     } from '$lib/helpers/date';
+    import { Wizard } from '$lib/layout';
+    import type { WizardStepsType } from '$lib/layout/wizard.svelte';
+    import { addNotification } from '$lib/stores/notifications';
+    import { organization } from '$lib/stores/organization';
+    import { user } from '$lib/stores/user';
+    import { wizard } from '$lib/stores/wizard';
+    import { VARS } from '$lib/system';
+    import { onDestroy } from 'svelte';
+    import Step1 from './wizard/support/step1.svelte';
+    import { isSupportOnline, supportData } from './wizard/support/store';
 
     onDestroy(() => {
         $supportData = {
@@ -47,7 +47,7 @@
                 customFields: [
                     { id: '41612', value: $supportData.category },
                     { id: '48493', value: $user?.name ?? '' },
-                    { id: '48492', value: $organization.$id ?? '' },
+                    { id: '48492', value: $organization?.$id ?? '' },
                     { id: '48491', value: $supportData?.project ?? '' },
                     { id: '48490', value: $user?.$id ?? '' }
                 ]


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When on the account page, no organization is set so organization is undefined. As such, an error like:

> Cannot read properties of undefined (reading '$id')

is thrown.

## Test Plan

Manually tested submitting a ticket from the account page:

<img width="1511" alt="image" src="https://github.com/appwrite/console/assets/1477010/8a20c44b-a99f-407b-8c3f-877c7e8074a0">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes