### PR TITLE
Avoid redirect on Password Recovery

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -70,7 +70,13 @@
             '/hackathon',
             '/mfa'
         ];
-        const acceptedAuthenticatedRoutes = ['/console', '/invite', '/card', '/hackathon'];
+        const acceptedAuthenticatedRoutes = [
+            '/console',
+            '/invite',
+            '/card',
+            '/hackathon',
+            '/recover'
+        ];
 
         const pathname = $page.url.pathname;
         const user = $page.data.account as Models.User<Record<string, string>>;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -17,6 +17,9 @@ export const load: LayoutLoad = async ({ depends, url }) => {
         url.searchParams.delete('forceRedirect');
     }
 
+    // logged-in user can recover-password!
+    if (url.pathname === '/recover') return {};
+
     try {
         const account = await sdk.forConsole.account.get<{ organization?: string }>();
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -17,9 +17,6 @@ export const load: LayoutLoad = async ({ depends, url }) => {
         url.searchParams.delete('forceRedirect');
     }
 
-    // logged-in user can recover-password!
-    if (url.pathname === '/recover') return {};
-
     try {
         const account = await sdk.forConsole.account.get<{ organization?: string }>();
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue where if the user is logged-in and attempts to recover password but is redirected to the dashboard as soon as they click on the password reset link.

## Test Plan

Manual.


## Related PRs and Issues

* https://github.com/appwrite/console/issues/1153

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.