### PR TITLE
Fix: Update bundle ID field to services ID in Apple OAuth adapter

### DIFF
--- a/src/routes/console/project-[project]/auth/(providers)/appleOAuth.svelte
+++ b/src/routes/console/project-[project]/auth/(providers)/appleOAuth.svelte
@@ -53,8 +53,8 @@
         </p>
         <InputSwitch id="state" bind:value={enabled} label={enabled ? 'Enabled' : 'Disabled'} />
         <InputText
-            id="bundleID"
-            label="Bundle ID"
+            id="servicesID"
+            label="Services ID"
             autofocus={true}
             placeholder="com.company.appname"
             bind:value={appId} />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates bundle ID field to services ID in Apple OAuth adapter 

## Test Plan

![image](https://github.com/user-attachments/assets/42440ffd-7d49-4074-96bf-6b2c22932311)

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes