### PR TITLE
Prevent footer from covering dropdown

### DIFF
--- a/src/lib/layout/wizard.svelte
+++ b/src/lib/layout/wizard.svelte
@@ -187,7 +187,7 @@
                     <svelte:component this={component} />
                 {/if}
             {/each}
-            <div class="u-z-index-20 form-footer">
+            <div class="u-z-index-5 form-footer">
                 <div class="u-flex u-main-end u-gap-12">
                     {#if !isLastStep && currentStep?.optional}
                         <Button text on:click={() => dispatch('finish')}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The z-index was set to 20 to prevent the language indicator for code sample from showing, but this caused other things to be hidden.

Since the language tag has a z-index of 2, we can make the footer have a z-index of 5 so it covers the language tag, but doesn't cover a dropdown

Fixes https://github.com/appwrite/console/issues/1249

## Test Plan

Manually checked dropdown:

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/87aec869-9f90-44f7-ab25-228bd0d170a2">

Manually checked language tag:

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/4a74ae3a-e943-4178-8599-4eba32dc8c04">


## Related PRs and Issues

Related issue:

* https://github.com/appwrite/console/issues/1249

Previous issue:

* https://github.com/appwrite/console/issues/1071

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes