### PR TITLE
Don't show `redeploy` if build not ready

### DIFF
--- a/src/lib/helpers/load.ts
+++ b/src/lib/helpers/load.ts
@@ -21,7 +21,7 @@ export enum View {
 export function getView(url: URL, route: Page['route'], fallback: View): View {
     return (url.searchParams.get('view') ?? preferences.get(route).view) === View.Grid
         ? View.Grid
-        : View.Table ?? fallback;
+        : (View.Table ?? fallback);
 }
 
 export function getColumns(route: Page['route'], fallback: string[]): string[] {

--- a/src/lib/layout/unauthenticated.svelte
+++ b/src/lib/layout/unauthenticated.svelte
@@ -16,7 +16,7 @@
     export let coupon: Coupon = null;
 
     $: selectedCampaign = campaigns.get(coupon?.campaign ?? campaign);
-    $: variation = (coupon?.campaign ?? campaign ? selectedCampaign?.template : 'default') as
+    $: variation = ((coupon?.campaign ?? campaign) ? selectedCampaign?.template : 'default') as
         | 'default'
         | CampaignData['template'];
 

--- a/src/lib/stores/feedback.ts
+++ b/src/lib/stores/feedback.ts
@@ -71,8 +71,8 @@ export const feedbackData = createFeedbackDataStore();
 
 function createFeedbackStore() {
     const { subscribe, update } = writable<Feedback>({
-        elapsed: browser ? parseInt(localStorage.getItem('feedbackElapsed')) ?? 0 : 0,
-        visualized: browser ? parseInt(localStorage.getItem('feedbackVisualized')) ?? 0 : 0,
+        elapsed: browser ? (parseInt(localStorage.getItem('feedbackElapsed')) ?? 0) : 0,
+        visualized: browser ? (parseInt(localStorage.getItem('feedbackVisualized')) ?? 0) : 0,
         notification: false,
         type: 'general',
         show: false

--- a/src/routes/console/project-[project]/functions/function-[function]/+page.svelte
+++ b/src/routes/console/project-[project]/functions/function-[function]/+page.svelte
@@ -267,15 +267,18 @@
                                             <span class="icon-dots-horizontal" aria-hidden="true" />
                                         </button>
                                         <svelte:fragment slot="list">
-                                            <DropListItem
-                                                icon="refresh"
-                                                on:click={() => {
-                                                    selectedDeployment = deployment;
-                                                    showRedeploy = true;
-                                                    showDropdown = [];
-                                                }}>
-                                                Redeploy
-                                            </DropListItem>
+                                            {#if deployment.status === 'ready'}
+                                                <DropListItem
+                                                    icon="refresh"
+                                                    on:click={() => {
+                                                        selectedDeployment = deployment;
+                                                        showRedeploy = true;
+                                                        showDropdown = [];
+                                                    }}>
+                                                    Redeploy
+                                                </DropListItem>
+                                            {/if}
+
                                             {#if deployment.status === 'ready' && deployment.$id !== $func.deployment}
                                                 <DropListItem
                                                     icon="lightning-bolt"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

A build that is not ready doesn't have a Build ID to call redeploy on itself.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.