### PR TITLE
Fix Failing `Github` Install on Preview Instances

### DIFF
--- a/src/routes/console/project-[project]/settings/GitInstallationModal.svelte
+++ b/src/routes/console/project-[project]/settings/GitInstallationModal.svelte
@@ -2,7 +2,6 @@
     import Modal from '$lib/components/modal.svelte';
     import Button from '$lib/elements/forms/button.svelte';
     import { sdk } from '$lib/stores/sdk';
-    import { goto } from '$app/navigation';
     import { page } from '$app/stores';
 
     export let showGitInstall: boolean;
@@ -15,7 +14,7 @@
         target.searchParams.set('success', redirect.toString());
         target.searchParams.set('failure', redirect.toString());
         target.searchParams.set('mode', 'admin');
-        goto(target);
+        return target;
     }
 </script>
 
@@ -23,7 +22,7 @@
     <p>Select a provider to import an existing git repositories.</p>
 
     <div class="u-flex u-cross-center u-flex-vertical u-gap-16">
-        <Button on:click={connectGitHub} fullWidth secondary>
+        <Button href={connectGitHub().toString()} fullWidth secondary>
             <span class="icon-github" aria-hidden="true" />
             <span class="text">GitHub</span>
         </Button>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes below error when running Console locally or on the Coolify preview instances -
```
Error: Cannot use `goto` with an external URL. Use `window.location = URL_HERE`.
```

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.