### PR TITLE
fix: auth templates on mobile screens

### DIFF
--- a/src/routes/(console)/project-[project]/auth/templates/emailTemplate.svelte
+++ b/src/routes/(console)/project-[project]/auth/templates/emailTemplate.svelte
@@ -130,7 +130,7 @@
                                 >here</a
                             >.
                         </p>
-                        <div class="u-margin-block-start-16 u-flex u-gap-8">
+                        <div class="u-margin-block-start-16 u-flex u-flex-wrap u-gap-8">
                             <slot />
                         </div>
                     </li>

--- a/src/routes/(console)/project-[project]/auth/templates/localeOptions.svelte
+++ b/src/routes/(console)/project-[project]/auth/templates/localeOptions.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <Box radius="small" class="u-flex u-gap-16 u-cross-center">
-    <div class="u-un-break-text">
+    <div class="u-un-break-text is-not-mobile">
         <span class="icon-translate" />
         <span class="text">Template language</span>
     </div>


### PR DESCRIPTION
## What does this PR do?

- hide language label on mobile
- wrap placeholders to stack on mobile

## Test Plan

### before:
<img width="414" alt="Bildschirmfoto 2024-09-02 um 16 34 12" src="https://github.com/user-attachments/assets/0da0ea20-de1b-4a99-b804-8cf9918a9262">

### after:
<img width="401" alt="Bildschirmfoto 2024-09-02 um 16 33 39" src="https://github.com/user-attachments/assets/45fd7e41-998e-484a-a2c8-385edf1a8254">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 