### PR TITLE
Remove extra slash in invite url because base already includes it

### DIFF
--- a/src/routes/(console)/organization-[organization]/createMember.svelte
+++ b/src/routes/(console)/organization-[organization]/createMember.svelte
@@ -18,7 +18,7 @@
 
     const dispatch = createEventDispatcher();
 
-    const url = `${$page.url.origin}/${base}/invite`;
+    const url = `${$page.url.origin}${base}/invite`;
     $: plan = $plansInfo?.get($organization?.billingPlan);
 
     let email: string, name: string, error: string;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Remove extra slash in invite url because base already includes it

## Test Plan

Manually checked the payload doesn't have an extra slash:

<img width="834" alt="image" src="https://github.com/user-attachments/assets/3e2c19a7-d18f-47d1-b616-ee60c08cc1ee">

Manually checked the email body:

<img width="694" alt="image" src="https://github.com/user-attachments/assets/f589dbd0-b134-4a1b-a700-aaf4f41ac376">

## Related PRs and Issues

* https://github.com/appwrite/console/pull/1332

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes