### PR TITLE
Default name to 'Unknown' when creating support ticket

### DIFF
--- a/src/routes/(console)/supportWizard.svelte
+++ b/src/routes/(console)/supportWizard.svelte
@@ -41,7 +41,7 @@
             body: JSON.stringify({
                 subject: 'support',
                 email: $user.email,
-                firstName: $user?.name ?? '',
+                firstName: $user?.name || 'Unknown',
                 message: $supportData.message,
                 tags: ['cloud'],
                 customFields: [


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Growth server requires non-empty string so default to 'Unknown' if name is null or an empty string.

## Test Plan

Manually checked `"Unknown"` will be sent if user name is undefined, null, or empty string.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes