### PR TITLE
Override padding spacing

### DIFF
--- a/src/routes/(console)/project-[project]/updateVariables.svelte
+++ b/src/routes/(console)/project-[project]/updateVariables.svelte
@@ -198,7 +198,7 @@
     <svelte:fragment slot="aside">
         <div class="u-flex u-flex-vertical-mobile u-main-space-between u-gap-16">
             <ul class="buttons-list">
-                <li class="buttons-list-item">
+                <li class="buttons-list-item padding-start">
                     <Button text on:click={() => (showEditorModal = true)}>
                         <span class="icon-code" />
                         <span class="text">Editor</span>
@@ -375,3 +375,9 @@
         {variableList}
         bind:show={showVariablesUpload} />
 {/if}
+
+<style>
+    .padding-start {
+        margin-left: -1rem;
+    }
+</style>


### PR DESCRIPTION

## What does this PR do?
Before:
![image](https://github.com/user-attachments/assets/16b9335e-ddd2-40b9-ab96-f14c12778de7)

After:
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/f928a9ef-525a-4f45-8f81-6d097fb08233">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅