### PR TITLE
Ensure we fetch all projects for usage breakdown

### DIFF
--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.ts
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.ts
@@ -1,5 +1,5 @@
 import { sdk } from '$lib/stores/sdk';
-import { Query } from '@appwrite.io/console';
+import { Query, type Models } from '@appwrite.io/console';
 import type { PageLoad } from './$types';
 import type { Organization } from '$lib/stores/organization';
 import type { Invoice } from '$lib/sdk/billing';
@@ -48,22 +48,33 @@ export const load: PageLoad = async ({ params, parent }) => {
         sdk.forConsole.teams.listMemberships(params.organization)
     ]);
 
-    const queries: string[] = [];
-
+    const projectNames: { [key: string]: Models.Project } = {};
     if (usage?.projects?.length > 0) {
-        queries.push(
-            Query.equal(
-                '$id',
-                usage.projects.map((p) => p.projectId)
-            )
-        );
-    }
+        // in batches of 100 (the max number of values in a query)
+        const requests = [];
+        const chunk = 100;
+        for (let i = 0; i < usage.projects.length; i += chunk) {
+            const queries = [
+                Query.limit(chunk),
+                Query.equal(
+                    '$id',
+                    usage.projects.slice(i, i + chunk).map((p) => p.projectId)
+                )
+            ];
+            requests.push(sdk.forConsole.projects.list(queries));
+        }
 
-    const projectNames = await sdk.forConsole.projects.list(queries);
+        const responses = await Promise.all(requests);
+        for (const response of responses) {
+            for (const project of response.projects) {
+                projectNames[project.$id] = project;
+            }
+        }
+    }
 
     return {
         organizationUsage: usage,
-        projectNames: projectNames.projects,
+        projectNames,
         invoices,
         currentInvoice,
         organizationMembers

--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/ProjectBreakdown.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/ProjectBreakdown.svelte
@@ -21,10 +21,6 @@
     export let projects: OrganizationUsage['projects'];
     export let metric: Metric;
 
-    function getProjectName(projectId: string): string {
-        return data.projectNames.find((project) => project.$id === projectId)?.name;
-    }
-
     function getProjectUsageLink(projectId: string): string {
         return `${base}/project-${projectId}/settings/usage`;
     }
@@ -69,7 +65,7 @@
                 {#each groupByProject(metric).sort((a, b) => b.usage - a.usage) as project}
                     <TableRow>
                         <TableCellText title="Project" style="padding-left: 0;">
-                            {getProjectName(project.projectId)}
+                            {data.projectNames[project.projectId]?.name ?? 'Unknown'}
                         </TableCellText>
                         <TableCellText title="Usage">{format(project.usage)}</TableCellText>
                         {#if $canSeeProjects}


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Before this, we tried to fetch all projects in a single query. However, this fails if there are more than 100 projects because the maximum number of values that can be included in a query is 100.

Furthermore, the default limit for projects returned by `projects.list()` is 25.

This PR ensures all projects are fetched by chunking the project IDs and passing the chunk amount as a limit in the query.

While it is possible to use `projects.get()` instead of `projects.list()`, the excessive number of network requests ends up being slower and more overwhelming than using `projects.list()`.

## Test Plan

Before the change, trying to view the usage of an org with more than 100 projects results in projects appearing as undefined:

<img width="860" alt="image" src="https://github.com/user-attachments/assets/33158fcc-ef97-4bec-97d5-9558186da858">

This PR ensures they're all fetched so it's not undefined:

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/5296daa5-ce3a-47f6-82da-fbca4fa9f1f3">

## Related PRs and Issues

* https://github.com/appwrite/appwrite/pull/8802

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)