### PR TITLE
Show credit in billing estimates

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -165,7 +165,9 @@
                         <div
                             class="body-text-2 u-margin-inline-start-auto"
                             style="color: var(--web-green-500, #10B981)">
-                            -{formatCurrency(Math.min(availableCredit, currentInvoice?.amount))}
+                            -{formatCurrency(
+                                Math.min(availableCredit, currentInvoice?.amount ?? 0)
+                            )}
                         </div>
                     </CollapsibleItem>
                 {/if}
@@ -187,7 +189,7 @@
                             : formatCurrency(
                                   Math.max(
                                       (currentInvoice?.amount ?? 0) -
-                                          Math.min(availableCredit, currentInvoice?.amount),
+                                          Math.min(availableCredit, currentInvoice?.amount ?? 0),
                                       0
                                   )
                               )}


### PR DESCRIPTION
Before: (although there is credit available)
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/1ac715be-4da6-45a6-8f34-1b3cd49f16d6">


After:
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/96624843-8c43-46ad-91c6-ebb6c3c8088c">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅