### PR TITLE
Make size show as required when adding string attribute

### DIFF
--- a/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/attributes/string.svelte
+++ b/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/attributes/string.svelte
@@ -72,7 +72,12 @@
     $: handleDefaultState($required || $array);
 </script>
 
-<InputNumber id="size" label="Size" placeholder="Enter size" bind:value={data.size} />
+<InputNumber
+    id="size"
+    label="Size"
+    placeholder="Enter size"
+    bind:value={data.size}
+    required={true} />
 {#if data.size >= 50}
     <InputTextarea
         id="default"


### PR DESCRIPTION
## What does this PR do?
Before size didn't show as required (but it is): 
<img width="660" alt="image" src="https://github.com/user-attachments/assets/6a244776-6a6d-4614-97aa-73e0cd000cc9">

After:
<img width="652" alt="image" src="https://github.com/user-attachments/assets/1923bcbf-676e-4dff-9eb2-dfd71509728a">

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅