### PR TITLE
Increase limit for shown number of collections in sidepanel

### DIFF
--- a/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/+layout.ts
+++ b/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/+layout.ts
@@ -12,7 +12,10 @@ export const load: LayoutLoad = async ({ params, depends }) => {
     try {
         const [collection, allCollections] = await Promise.all([
             sdk.forProject.databases.getCollection(params.database, params.collection),
-            sdk.forProject.databases.listCollections(params.database, [Query.orderDesc('')])
+            sdk.forProject.databases.listCollections(params.database, [
+                Query.orderDesc(''),
+                Query.limit(100)
+            ])
         ]);
 
         return {


### PR DESCRIPTION
## What does this PR do?
Set a non-default (25) limit for the number of shown collections in the side panel next to a collection detail view

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅