### PR TITLE
Skip serviceworker cache install on oauth pages

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -23,7 +23,7 @@ sw.addEventListener('install', (event) => {
     }
 
     // Check if the page URL does not match the exclusion path
-    const shouldCache = !base.startsWith('/console/auth');
+    const shouldCache = !location.pathname.startsWith(`${base}/auth`);
     if (shouldCache) {
         event.waitUntil(addFilesToCache());
     }

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -22,7 +22,11 @@ sw.addEventListener('install', (event) => {
         await cache.addAll(ASSETS);
     }
 
-    event.waitUntil(addFilesToCache());
+    // Check if the page URL does not match the exclusion path
+    const shouldCache = !/\/console\/auth\/oauth2\/.*/.test(location.pathname);
+    if (shouldCache) {
+        event.waitUntil(addFilesToCache());
+    }
 });
 
 sw.addEventListener('activate', (event) => {

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -3,7 +3,7 @@
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
 
-import { build, files, version } from '$service-worker';
+import { build, files, version, base } from '$service-worker';
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
@@ -23,7 +23,7 @@ sw.addEventListener('install', (event) => {
     }
 
     // Check if the page URL does not match the exclusion path
-    const shouldCache = !/\/console\/auth\/oauth2\/.*/.test(location.pathname);
+    const shouldCache = !base.startsWith('/console/auth');
     if (shouldCache) {
         event.waitUntil(addFilesToCache());
     }


### PR DESCRIPTION
## What does this PR do?

Exclude the oauth domains from the service worker so no cache is initialised (since it's not needed)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅