### PR TITLE
fix: hide backups column on self-hosted

### DIFF
--- a/src/routes/(console)/project-[project]/databases/store.ts
+++ b/src/routes/(console)/project-[project]/databases/store.ts
@@ -1,10 +1,11 @@
 import type { Column } from '$lib/helpers/types';
+import { isCloud } from '$lib/system';
 import { writable } from 'svelte/store';
 
 export const columns = writable<Column[]>([
     { id: '$id', title: 'Database ID', type: 'string', show: true, width: 150 },
     { id: 'name', title: 'Name', type: 'string', show: true, width: 120 },
-    { id: 'backup', title: 'Backups', type: 'string', show: true, width: 120 },
+    isCloud && { id: 'backup', title: 'Backups', type: 'string', show: true, width: 120 },
     { id: '$createdAt', title: 'Created', type: 'datetime', show: true, width: 120 },
     { id: '$updatedAt', title: 'Updated', type: 'datetime', show: true, width: 120 }
 ]);


### PR DESCRIPTION
## What does this PR do?

- hides backups column in databases table for self-hosted instances

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 