### PR TITLE
Allow upgrade if current plan does not match the campaign plan

### DIFF
--- a/src/routes/(console)/apply-credit/+page.svelte
+++ b/src/routes/(console)/apply-credit/+page.svelte
@@ -108,7 +108,7 @@
                 );
             }
             // Upgrade existing org
-            else if (selectedOrg?.billingPlan === BillingPlan.FREE) {
+            else if (selectedOrg?.billingPlan === billingPlan) {
                 org = await sdk.forConsole.billing.updatePlan(
                     selectedOrg.$id,
                     billingPlan,

--- a/src/routes/(console)/apply-credit/+page.svelte
+++ b/src/routes/(console)/apply-credit/+page.svelte
@@ -108,7 +108,7 @@
                 );
             }
             // Upgrade existing org
-            else if (selectedOrg?.billingPlan === billingPlan) {
+            else if (selectedOrg?.billingPlan !== billingPlan) {
                 org = await sdk.forConsole.billing.updatePlan(
                     selectedOrg.$id,
                     billingPlan,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Update apply-credit flow to upgrade ORG is campaign billingPlan doesn't match the current billing plan, instead of only upgrading if free

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES