### PR TITLE
Correct word break for Safari

### DIFF
--- a/src/lib/components/id.svelte
+++ b/src/lib/components/id.svelte
@@ -68,8 +68,3 @@
         </div>
     </div>
 </Copy>
-
-<style>
-    .text {
-    }
-</style>

--- a/src/lib/components/id.svelte
+++ b/src/lib/components/id.svelte
@@ -57,6 +57,7 @@
             style:white-space="nowrap"
             class="text u-line-height-1-5"
             style:overflow="hidden"
+            style:word-break="break-all"
             use:truncateText>
             <slot />
         </span>
@@ -67,3 +68,8 @@
         </div>
     </div>
 </Copy>
+
+<style>
+    .text {
+    }
+</style>


### PR DESCRIPTION
Before:
<img width="226" alt="image" src="https://github.com/user-attachments/assets/f9cf0823-19d5-4483-ad0e-aa247bbc8810">

After:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/1edb3481-a2e6-43ac-9332-c8873202f1bd">


## What does this PR do?

Fix word-break in Safari

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅