### PR TITLE
ci: dedicated stage image repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,11 +60,11 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: appwrite/console-cloud
+                  images: appwrite/console-cloud-stage
                   tags: |
-                      type=semver,pattern={{major}}.{{minor}}.{{patch}}-stage
-                      type=semver,pattern={{major}}.{{minor}}-stage
-                      type=semver,pattern={{major}}-stage
+                      type=semver,pattern={{major}}.{{minor}}.{{patch}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=semver,pattern={{major}}
             - name: Build and push Docker image
               id: push
               uses: docker/build-push-action@v6


### PR DESCRIPTION
## What does this PR do?

- sharing the same docker repository for both stage and prod cloud ended up in race conditions for `latest` and also appending `-stage` had conflicts with `-rc.XX` releases

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 