### PR TITLE
Reset the file uploader on logout

### DIFF
--- a/src/lib/helpers/logout.ts
+++ b/src/lib/helpers/logout.ts
@@ -3,10 +3,12 @@ import { goto, invalidate } from '$app/navigation';
 import { Dependencies } from '$lib/constants';
 import { Submit, trackEvent } from '$lib/actions/analytics';
 import { base } from '$app/paths';
+import { uploader } from '$lib/stores/uploader';
 
 export async function logout() {
     await sdk.forConsole.account.deleteSession('current');
     await invalidate(Dependencies.ACCOUNT);
+    uploader.reset();
     trackEvent(Submit.AccountLogout);
     await goto(`${base}/login`);
 }


### PR DESCRIPTION
## What does this PR do?
When switching account (logout and log back in) without refreshing the page, the history of uploaded files remained in the javascript state, and could therefore show up. In this PR this behaviour is fixed.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅