### PR TITLE
fix: bad modals on safari

### DIFF
--- a/src/lib/elements/forms/inputText.svelte
+++ b/src/lib/elements/forms/inputText.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { SvelteComponent, onMount } from 'svelte';
+    import { SvelteComponent, onMount, tick } from 'svelte';
     import { FormItem, FormItemPart, Helper, Label } from '.';
     import NullCheckbox from './nullCheckbox.svelte';
     import TextCounter from './textCounter.svelte';
@@ -30,8 +30,9 @@
     let error: string;
     let show = false;
 
-    onMount(() => {
+    onMount(async () => {
         if (element && autofocus) {
+            await tick();
             element.focus();
         }
     });

--- a/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/attributes/edit.svelte
+++ b/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/attributes/edit.svelte
@@ -65,19 +65,19 @@
     }
 </script>
 
-{#if selectedAttribute}
-    <Modal {error} size="big" bind:show={showEdit} onSubmit={submit} icon={option?.icon}>
-        <svelte:fragment slot="title">
-            <div class="u-flex u-cross-center u-gap-8">
-                {option?.name}
-                {#if option?.type === 'relationship'}
-                    <div class="tag eyebrow-heading-3">
-                        <span class="text u-x-small">Beta</span>
-                    </div>
-                {/if}
-            </div>
-        </svelte:fragment>
-        <FormList>
+<Modal {error} size="big" bind:show={showEdit} onSubmit={submit} icon={option?.icon}>
+    <svelte:fragment slot="title">
+        <div class="u-flex u-cross-center u-gap-8">
+            {option?.name}
+            {#if option?.type === 'relationship'}
+                <div class="tag eyebrow-heading-3">
+                    <span class="text u-x-small">Beta</span>
+                </div>
+            {/if}
+        </div>
+    </svelte:fragment>
+    <FormList>
+        {#if selectedAttribute}
             {#if selectedAttribute?.type !== 'relationship'}
                 <InputText
                     id="key"
@@ -93,10 +93,10 @@
                     bind:data={selectedAttribute}
                     on:close={() => (option = null)} />
             {/if}
-        </FormList>
-        <svelte:fragment slot="footer">
-            <Button secondary on:click={() => (showEdit = false)}>Cancel</Button>
-            <Button submit disabled={deepEqual(currentAttr, selectedAttribute)}>Update</Button>
-        </svelte:fragment>
-    </Modal>
-{/if}
+        {/if}
+    </FormList>
+    <svelte:fragment slot="footer">
+        <Button secondary on:click={() => (showEdit = false)}>Cancel</Button>
+        <Button submit disabled={deepEqual(currentAttr, selectedAttribute)}>Update</Button>
+    </svelte:fragment>
+</Modal>

--- a/tests/unit/elements/inputText.test.ts
+++ b/tests/unit/elements/inputText.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { InputText } from '../../../src/lib/elements/forms';
+import { tick } from 'svelte';
 
 test('shows text input', () => {
     const { getByText, getByLabelText } = render(InputText, { id: 'input', label: 'input' });
@@ -24,9 +25,9 @@ test('shows text input - disabled', () => {
     expect(getByLabelText('input')).toBeDisabled();
 });
 
-test('shows text input - autofocus', () => {
+test('shows text input - autofocus', async () => {
     const { getByLabelText } = render(InputText, { id: 'input', label: 'input', autofocus: true });
-
+	await tick();
     expect(getByLabelText('input')).toHaveFocus();
 });
 

--- a/tests/unit/elements/inputText.test.ts
+++ b/tests/unit/elements/inputText.test.ts
@@ -27,7 +27,7 @@ test('shows text input - disabled', () => {
 
 test('shows text input - autofocus', async () => {
     const { getByLabelText } = render(InputText, { id: 'input', label: 'input', autofocus: true });
-	await tick();
+    await tick();
     expect(getByLabelText('input')).toHaveFocus();
 });
 


### PR DESCRIPTION
## What does this PR do?

- looks like safari doesnt like user input like `autofocus` and doesnt initially place the dialog in the center

fixes:
- #1403 
- #1412 
- #1462 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 