### PR TITLE
Feat #1127 added selection to files

### DIFF
--- a/src/routes/(console)/project-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/(console)/project-[project]/storage/bucket-[bucket]/+page.svelte
@@ -16,6 +16,7 @@
         DropListLink,
         Empty,
         EmptySearch,
+        FloatingActionBar,
         PaginationWithLimit,
         SearchQuery
     } from '$lib/components';
@@ -30,7 +31,9 @@
         TableCellText,
         TableHeader,
         TableRow,
-        TableRowLink
+        TableRowLink,
+        TableCellHeadCheck,
+        TableCellCheck
     } from '$lib/elements/table';
     import { toLocaleDate } from '$lib/helpers/date';
     import {
@@ -56,6 +59,7 @@
     let showDelete = false;
     let showDropdown = [];
     let selectedFile: Models.File = null;
+    let selected: string[] = [];
 
     const projectId = $page.params.project;
     const bucketId = $page.params.bucket;
@@ -143,6 +147,9 @@
     {#if data.files.total}
         <Table>
             <TableHeader>
+                <TableCellHeadCheck
+                    bind:selected
+                    pageItemsIds={data.files.files.map((f) => f.$id)} />
                 <TableCellHead>Filename</TableCellHead>
                 <TableCellHead onlyDesktop width={140}>Type</TableCellHead>
                 <TableCellHead onlyDesktop width={100}>Size</TableCellHead>
@@ -186,6 +193,7 @@
                     {:else}
                         <TableRowLink
                             href={`${base}/project-${projectId}/storage/bucket-${bucketId}/file-${file.$id}`}>
+                            <TableCellCheck bind:selectedIds={selected} id={file.$id} />
                             <TableCell title="Name">
                                 <div class="u-flex u-gap-12 u-cross-center">
                                     <Avatar size={32} src={getPreview(file.$id)} name={file.name} />
@@ -267,8 +275,50 @@
             target="file"
             on:click={() => wizard.start(Create)} />
     {/if}
+
+    <FloatingActionBar show={selected.length > 0}>
+        <div class="u-flex u-cross-center u-main-space-between actions">
+            <div class="u-flex u-cross-center u-gap-8">
+                <span class="indicator body-text-2 u-bold">{selected.length}</span>
+                <p>
+                    <span class="is-only-desktop">
+                        {selected.length > 1 ? 'collections' : 'collection'}
+                    </span>
+                    selected
+                </p>
+            </div>
+
+            <div class="u-flex u-cross-center u-gap-8">
+                <Button text on:click={() => (selected = [])}>Cancel</Button>
+                <Button
+                    secondary
+                    on:click={() => {
+                        showDelete = true;
+                        selectedFile = null;
+                    }}>
+                    <p>Delete</p>
+                </Button>
+            </div>
+        </div>
+    </FloatingActionBar>
 </Container>
 
-{#if selectedFile}
-    <DeleteFile file={selectedFile} bind:showDelete on:deleted={fileDeleted} />
-{/if}
+<DeleteFile
+    singleFile={selectedFile}
+    bind:multipleFiles={selected}
+    {bucketId}
+    bind:showDelete
+    on:deleted={fileDeleted} />
+
+<style lang="scss">
+    .actions {
+        .indicator {
+            border-radius: 0.25rem;
+            background: hsl(var(--color-information-100));
+            color: hsl(var(--color-neutral-0));
+
+            padding: 0rem 0.375rem;
+            display: inline-block;
+        }
+    }
+</style>

--- a/src/routes/(console)/project-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/(console)/project-[project]/storage/bucket-[bucket]/+page.svelte
@@ -282,7 +282,7 @@
                 <span class="indicator body-text-2 u-bold">{selected.length}</span>
                 <p>
                     <span class="is-only-desktop">
-                        {selected.length > 1 ? 'collections' : 'collection'}
+                        file{selected.length > 1 ? 's' : ''}
                     </span>
                     selected
                 </p>

--- a/src/routes/(console)/project-[project]/storage/bucket-[bucket]/deleteFile.svelte
+++ b/src/routes/(console)/project-[project]/storage/bucket-[bucket]/deleteFile.svelte
@@ -47,7 +47,7 @@
     headerDivider={false}>
     <p data-private>
         Are you sure you want to delete <b
-            >{!singleFile ? `${multipleFiles.length} files` : singleFile.name}</b
+            >{!singleFile ? `${multipleFiles.length} file${multipleFiles.length > 1 ? 's' : ''}` : singleFile.name}</b
         >?
     </p>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[project]/storage/bucket-[bucket]/deleteFile.svelte
+++ b/src/routes/(console)/project-[project]/storage/bucket-[bucket]/deleteFile.svelte
@@ -7,20 +7,26 @@
     import type { Models } from '@appwrite.io/console';
     import { createEventDispatcher } from 'svelte';
 
-    export let file: Models.File;
+    export let singleFile: Models.File;
+    export let multipleFiles: string[];
     export let showDelete = false;
+    export let bucketId: string;
 
     const dispatch = createEventDispatcher();
 
     const deleteFile = async () => {
+        const promises = !singleFile
+            ? multipleFiles.map((fileId) => sdk.forProject.storage.deleteFile(bucketId, fileId))
+            : [await sdk.forProject.storage.deleteFile(bucketId, singleFile.$id)];
+        showDelete = false;
         try {
-            await sdk.forProject.storage.deleteFile(file.bucketId, file.$id);
-            showDelete = false;
-            dispatch('deleted', file);
+            await Promise.all(promises);
+            dispatch('deleted');
             addNotification({
                 type: 'success',
-                message: `${file.name} has been deleted`
+                message: `${!singleFile ? multipleFiles.length : singleFile.name} has been deleted`
             });
+            multipleFiles = [];
             trackEvent(Submit.FileDelete);
         } catch (error) {
             addNotification({
@@ -39,7 +45,11 @@
     icon="exclamation"
     state="warning"
     headerDivider={false}>
-    <p data-private>Are you sure you want to delete <b>{file.name}</b>?</p>
+    <p data-private>
+        Are you sure you want to delete <b
+            >{!singleFile ? `${multipleFiles.length} files` : singleFile.name}</b
+        >?
+    </p>
     <svelte:fragment slot="footer">
         <Button text on:click={() => (showDelete = false)}>Cancel</Button>
         <Button secondary submit>Delete</Button>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes #1127, which says about adding selection to buckets and files so that multiple files/buckets can be deleted at once. In this PR, code is done to be able to delete multiple files in a bucket.

## Test Plan

Navigate to any bucket that has 1 or more files. You will find checkbox inthe  very first column of the files table. You can select multiple files using those checkboxes, and delete multiple files at once

![image](https://github.com/user-attachments/assets/99a04a96-18be-4ff8-a6b5-842c8a0e9f3c)
![image](https://github.com/user-attachments/assets/e9815a3f-ef28-4232-8252-50c2b64676ff)



## Related PRs and Issues

NA

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes