### PR TITLE
add: relation attribute info in attribute type

### DIFF
--- a/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/attributes/+page.svelte
+++ b/src/routes/(console)/project-[project]/databases/database-[database]/collection-[collection]/attributes/+page.svelte
@@ -46,6 +46,13 @@
         email = 'mail',
         enum = 'view-list'
     }
+
+    const relationTypeMap = {
+        oneToOne: 'one-to-one',
+        oneToMany: 'one-to-many',
+        manyToOne: 'many-to-one',
+        manyToMany: 'many-to-many'
+    }
 </script>
 
 <Container>
@@ -121,15 +128,15 @@
                         <TableCellText onlyDesktop title="Type">
                             {#if 'format' in attribute && attribute.format}
                                 <span class="u-capitalize">{attribute.format}</span>
+                            {:else if isRelationship(attribute)}
+                            <span class="u-capitalize">{relationTypeMap[attribute.relationType]}</span>
+                            <span>
+                                with <a
+                                    href={`${base}/project-${projectId}/databases/database-${databaseId}/collection-${attribute?.relatedCollection}`}
+                                    ><b data-private>{attribute?.key}</b></a>
+                            </span>
                             {:else}
                                 <span class="u-capitalize">{attribute.type}</span>
-                                {#if isRelationship(attribute)}
-                                    <span>
-                                        with <a
-                                            href={`${base}/project-${projectId}/databases/database-${databaseId}/collection-${attribute?.relatedCollection}`}
-                                            ><b data-private>{attribute?.key}</b></a>
-                                    </span>
-                                {/if}
                             {/if}
                             <span>
                                 {attribute.array ? '[]' : ''}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes #1488. Within attributes table earlier is said 'relationship with <collection_name>'. however it doesn't tell the final user the exact relation-type. Now, it has been modified to '<relationType> with <collection_name>'

## Test Plan

You can test it by creating two collection within your database, where both collections have an attribute which is a relationship. You will be able to see relation type under type column of attribute table, in each collection.

![image](https://github.com/user-attachments/assets/3f4066c7-b0cb-4ab9-94a3-c0cff4df4771)

## Related PRs and Issues

NA

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes