### PR TITLE
Filter the new users count to not include future days

### DIFF
--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
@@ -143,9 +143,11 @@
         <Heading tag="h6" size="7">Users</Heading>
 
         <p class="text">The total number of users across all projects in your organization.</p>
-
         <svelte:fragment slot="aside">
             {#if data.organizationUsage.users}
+                {@const users = data.organizationUsage.users.filter(
+                    (user) => new Date(user.date) < new Date()
+                )}
                 {@const current = data.organizationUsage.usersTotal}
                 {@const max = getServiceLimit('users', tier, plan)}
                 <ProgressBarBig
@@ -169,7 +171,7 @@
                             {
                                 name: 'Users',
                                 data: accumulateFromEndingTotal(
-                                    data.organizationUsage.users,
+                                    users,
                                     data.organizationUsage.usersTotal
                                 )
                             }

--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
@@ -145,9 +145,6 @@
         <p class="text">The total number of users across all projects in your organization.</p>
         <svelte:fragment slot="aside">
             {#if data.organizationUsage.users}
-                {@const users = data.organizationUsage.users.filter(
-                    (user) => new Date(user.date) < new Date()
-                )}
                 {@const current = data.organizationUsage.usersTotal}
                 {@const max = getServiceLimit('users', tier, plan)}
                 <ProgressBarBig
@@ -171,7 +168,7 @@
                             {
                                 name: 'Users',
                                 data: accumulateFromEndingTotal(
-                                    users,
+                                    data.usersUsageToDate,
                                     data.organizationUsage.usersTotal
                                 )
                             }

--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.ts
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.ts
@@ -72,12 +72,15 @@ export const load: PageLoad = async ({ params, parent }) => {
         }
     }
 
+    const usersUsageToDate = usage.users.filter((user) => new Date(user.date) < new Date());
+
     return {
         organizationUsage: usage,
         projectNames,
         invoices,
         currentInvoice,
         organizationMembers,
-        plan
+        plan,
+        usersUsageToDate
     };
 };


### PR DESCRIPTION
## What does this PR do?

Before:
<img width="630" alt="image" src="https://github.com/user-attachments/assets/bb668f83-2d94-43d8-be04-48e97bf73216" />


After:
<img width="635" alt="image" src="https://github.com/user-attachments/assets/4a4c7218-d769-450f-988a-0da5c6b997f3" />

Usage data comes from the API as newly added users per day. The graph is being built by subtracting these newly added users from the total amount. The API returns future dates (with 0 new users added on those day, because they are in the future). So the graph showed days in the future. This is now fixed!


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅