### PR TITLE
Fix cancel shown on failed builds

### DIFF
--- a/src/routes/(console)/project-[project]/sites/(components)/logs.svelte
+++ b/src/routes/(console)/project-[project]/sites/(components)/logs.svelte
@@ -138,7 +138,7 @@
                         <Code lang="text" code={buildLogs.replace(/\\n/g, '\n')} />
                     </div> -->
     <Layout.Stack alignItems="flex-end">
-        {#if status !== 'ready'}
+        {#if ['processing', 'building'].includes(status)}
             <Button size="xs" text on:click={cancelDeployment}>Cancel deployment</Button>
         {/if}
     </Layout.Stack>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where if the deployment has failed, the logs area would still show `Cancel deployment` button which doesn't make sense.

## Test Plan

Manual.

![fixed-logs-area](https://github.com/user-attachments/assets/6216c156-ebbc-4dba-9a00-b1e602c8a7b1)

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.