### PR TITLE
Fix incorrect product name for env var updates

### DIFF
--- a/src/routes/(console)/project-[project]/createVariable.svelte
+++ b/src/routes/(console)/project-[project]/createVariable.svelte
@@ -44,9 +44,9 @@
     title={`${selectedVar ? 'Update' : 'Create'} ${isGlobal ? 'global' : 'environment'} variable`}>
     <svelte:fragment slot="description">
         <span>
-            Set the environment variables or secret keys that will be passed to {isGlobal
-                ? `all ${product}s within your project`
-                : `your ${product}s`}.
+            Set the environment variables or secret keys that will be passed to {!isGlobal
+                ? `your ${product}s`
+                : `all functions and sites within your project`}.
         </span>
     </svelte:fragment>
     <Layout.Stack>

--- a/src/routes/(console)/project-[project]/createVariable.svelte
+++ b/src/routes/(console)/project-[project]/createVariable.svelte
@@ -45,7 +45,7 @@
     <svelte:fragment slot="description">
         <span>
             Set the environment variables or secret keys that will be passed to {!isGlobal
-                ? `your ${product}s`
+                ? `your ${product}`
                 : `all functions and sites within your project`}.
         </span>
     </svelte:fragment>

--- a/src/routes/(console)/project-[project]/updateVariables.svelte
+++ b/src/routes/(console)/project-[project]/updateVariables.svelte
@@ -191,12 +191,12 @@
     </Heading>
     {#if isGlobal}
         <p>
-            Set the environment variables or secret keys that will be passed to all functions within
-            your project.
+            Set the environment variables or secret keys that will be passed to all functions and
+            sites within your project.
         </p>
     {:else}
         <p>
-            Set the environment variables or secret keys that will be passed to your function.
+            Set the environment variables or secret keys that will be passed to your {product}.
             Global variables can be found in <Link
                 href={`${base}/project-${$project.$id}/settings#variables`}>
                 project settings</Link
@@ -375,6 +375,7 @@
 
 {#if showVariablesUpload}
     <UploadVariables
+        {product}
         {isGlobal}
         {sdkCreateVariable}
         {sdkUpdateVariable}

--- a/src/routes/(console)/project-[project]/uploadVariablesModal.svelte
+++ b/src/routes/(console)/project-[project]/uploadVariablesModal.svelte
@@ -63,15 +63,14 @@
             error = e.message;
         }
     }
+
+    const title = `Import new ${isGlobal ? 'global' : 'environment'} variables`;
 </script>
 
-<Modal headerDivider={false} bind:show onSubmit={handleSubmit} bind:error>
-    <svelte:fragment slot="title">
-        Import new {isGlobal ? 'global' : 'environment'} variables
-    </svelte:fragment>
+<Modal {title} bind:show bind:error headerDivider={false} onSubmit={handleSubmit}>
     <div class="u-flex u-flex-vertical u-gap-24 u-margin-block-start-8">
         <p>
-            Import new {isGlobal ? 'global' : 'environment'} variables from
+            {title} from
             <span class="inline-code">.env</span>
             file that will be passed to {!isGlobal
                 ? `your ${product}`

--- a/src/routes/(console)/project-[project]/uploadVariablesModal.svelte
+++ b/src/routes/(console)/project-[project]/uploadVariablesModal.svelte
@@ -18,6 +18,7 @@
 
     let files: FileList;
     let error: string;
+    export let product: 'function' | 'site' = 'function';
 
     async function handleSubmit() {
         try {
@@ -72,9 +73,9 @@
         <p>
             Import new {isGlobal ? 'global' : 'environment'} variables from
             <span class="inline-code">.env</span>
-            file that will be passed to {isGlobal
-                ? 'all functions within your project'
-                : 'your function'}.
+            file that will be passed to {!isGlobal
+                ? `your ${product}`
+                : 'all functions and sites within your project'}.
         </p>
 
         {#if variableList.total > 0}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where the global variables handling components were hardcoded to show `function` as a product when not in Global mode. This is fixed now and the modals, components properly show -
1. `site`
2. `function`
3. `functions and sites` [when in global mode]

## Test Plan

Manual.

![site](https://github.com/user-attachments/assets/e3ccd3cf-effb-4ebc-8b11-747722e372d1)

![sites-modal](https://github.com/user-attachments/assets/4dbd0d21-be41-4686-8a89-8016458948fd)

---

![project](https://github.com/user-attachments/assets/586110e6-d46d-4bfb-889c-914ab7a926aa)

![projects-modal](https://github.com/user-attachments/assets/54f7907a-82bb-4c7d-858c-94380be1bb06)

---

![function](https://github.com/user-attachments/assets/592cd8f4-c961-4d38-8c0c-3ad878eeb6b2)

![functions-modal](https://github.com/user-attachments/assets/64745832-7924-44bd-ba91-0eec2ef00d89)

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.