### PR TITLE
Fix repo connected even on `Connect later`

### DIFF
--- a/src/routes/(console)/project-[project]/sites/create-site/templates/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[project]/sites/create-site/templates/template-[template]/+page.svelte
@@ -158,6 +158,10 @@
         selectedInstallationId = $installation?.$id;
         repositoryName = name.split(' ').join('-').toLowerCase();
     }
+
+    $: if (connectBehaviour === 'later') {
+        selectedRepository = null;
+    }
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## What does this PR do?

Address a bug where if the user clicked on `Connect later`, the first selected repo was still used.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.