### PR TITLE
Fix a crash from Perplexity template setup

### DIFF
--- a/src/lib/wizards/functions/steps/templatePermissions.svelte
+++ b/src/lib/wizards/functions/steps/templatePermissions.svelte
@@ -10,7 +10,10 @@
     onMount(() => {
         $templateConfig.execute = $template.permissions.includes('any');
         templateScopes = scopes
-            .filter((scope) => $template.scopes.includes(scope.scope))
+            // hot fix for perplexity chat templates,
+            // backend doesn't have scopes for this template.
+            // TODO: @itznotabug fix on backend too.
+            .filter((scope) => ($template.scopes ?? []).includes(scope.scope))
             .map((scope) => ({
                 ...scope,
                 active: true

--- a/src/lib/wizards/functions/steps/templatePermissions.svelte
+++ b/src/lib/wizards/functions/steps/templatePermissions.svelte
@@ -10,7 +10,7 @@
     onMount(() => {
         $templateConfig.execute = $template.permissions.includes('any');
         templateScopes = scopes
-            // hot fix for perplexity chat templates,
+            // hot fix for perplexity chat template,
             // backend doesn't have scopes for this template.
             // TODO: @itznotabug fix on backend too.
             .filter((scope) => ($template.scopes ?? []).includes(scope.scope))


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The said template doesn't have `scopes` crashing the setup wizard, this is a temporary fix until backend is patched.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.