### PR TITLE
Fix: Tag dimensions on button and anchor

### DIFF
--- a/src/lib/elements/pill.svelte
+++ b/src/lib/elements/pill.svelte
@@ -73,3 +73,11 @@
         <slot />
     </div>
 {/if}
+
+<style>
+    /* button and anchor tags seem to have special dimens, this should be auto fixed in pink2. */
+    :global(.tag):where(button, a) {
+        --p-tag-height: 2.125rem;
+        --p-tag-content-height: 2.024rem;
+    }
+</style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Reduce the tag size when using anchor or a button.

## Test Plan

Before -

![tags before](https://github.com/user-attachments/assets/e70ca934-d102-4f2e-9e00-8f5c7015193d)

After -

![tags after](https://github.com/user-attachments/assets/1e1beef3-c813-4a89-8dbe-afa46fc967c3)

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.