### PR TITLE
Fix: Broken region flags

### DIFF
--- a/src/lib/elements/flag.svelte
+++ b/src/lib/elements/flag.svelte
@@ -12,7 +12,7 @@
 
     export function getFlag(country: string, width: number, height: number, quality: number) {
         if (!isValueOfStringEnum(Flag, country)) return '';
-        let flag = sdk.forProject.avatars
+        let flag = sdk.forConsole.avatars
             .getFlag(country, width * 2, height * 2, quality)
             ?.toString();
         flag?.includes('&project=')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes an issue with broken flags request in some cases.

The issue is that the `sdk.forProject` will use whatever the last project was opened to load the Avatars API. If the project was invalid or deleted and then you'd navigate to creating a new project, it would throw an exception that the Project ID is not valid or the Project doesn't exist, hence failing the image loads. 

As a solution, we use `sdk.forConsole` as it'll always load the flags.

## Test Plan

Manual.

## Related PRs and Issues

* https://github.com/appwrite/console/issues/1387

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.