### PR TITLE
fix: error during attribute creation.

### DIFF
--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -57,7 +57,7 @@ function createPreferences() {
         getCustomCollectionColumns: (
             projectId: string,
             collectionId: string
-        ): Preferences['columns'] => preferences[projectId]?.collections?.[collectionId] ?? null,
+        ): Preferences['columns'] => preferences[projectId]?.collections?.[collectionId] ?? [],
         setLimit: (projectId: string, route: Page['route'], limit: Preferences['limit']) =>
             update((n) => {
                 if (!n[projectId]?.[route.id]) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If the saved preferences do not include Preferences['columns'], the attribute creation modal can throw an error. This PR fixes that.

## Test Plan

Manual.

## Related PRs and Issues

* #1614 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.