### PR TITLE
Fix: interceptor interfering on wrong steps

### DIFF
--- a/src/lib/layout/wizard.svelte
+++ b/src/lib/layout/wizard.svelte
@@ -62,6 +62,8 @@
         const step = e.detail;
         if (step < $wizard.step) {
             $wizard.step = step;
+            // clear the interceptor
+            wizard.setInterceptor(null);
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes an issue where the interceptor from a future wizard step remains active after navigating to a previous step, causing errors on next button click.

---
Example:
1: Function name/runtime
2: Add permissions
3: Add variables (with an interceptor that throws some error)

Issue: Clicking back to Step 2 and submitting triggers Step 3's interceptor, resulting in an error.

## Test Plan

Manual.

Before -

https://github.com/user-attachments/assets/49fa94d5-140e-488a-ad7d-95bf9d2871e7

After -

https://github.com/user-attachments/assets/760c2fdd-cfa9-45bf-be22-ca80dda997c4


## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.