### PR TITLE
Remove custom ID field when creating an organization

### DIFF
--- a/src/routes/(console)/createOrganization.svelte
+++ b/src/routes/(console)/createOrganization.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-    import { Modal, CustomId } from '$lib/components';
-    import { Pill } from '$lib/elements';
+    import { Modal } from '$lib/components';
     import { InputText, Button, FormList } from '$lib/elements/forms';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
@@ -16,15 +15,13 @@
     export let show = false;
 
     let name: string;
-    let id: string;
-    let showCustomId = false;
     let error: string;
 
     const dispatch = createEventDispatcher();
 
     async function create() {
         try {
-            const org = await sdk.forConsole.teams.create(id ?? ID.unique(), name);
+            const org = await sdk.forConsole.teams.create(ID.unique(), name);
             await invalidate(Dependencies.ACCOUNT);
             dispatch('created');
             await goto(`${base}/organization-${org.$id}`);
@@ -32,11 +29,8 @@
                 type: 'success',
                 message: `${name} has been created`
             });
-            trackEvent(Submit.OrganizationCreate, {
-                customId: !!id
-            });
+            trackEvent(Submit.OrganizationCreate);
             name = null;
-            id = null;
             show = false;
         } catch (e) {
             error = e.message;
@@ -66,17 +60,6 @@
             bind:value={name}
             autofocus={true}
             required />
-        {#if !showCustomId}
-            <div>
-                <Pill button on:click={() => (showCustomId = !showCustomId)}>
-                    <span class="icon-pencil" aria-hidden="true" /><span class="text">
-                        Organization ID
-                    </span>
-                </Pill>
-            </div>
-        {:else}
-            <CustomId autofocus bind:show={showCustomId} name="Organization" bind:id />
-        {/if}
     </FormList>
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (show = false)}>Cancel</Button>

--- a/src/routes/(console)/onboarding/+page.svelte
+++ b/src/routes/(console)/onboarding/+page.svelte
@@ -3,9 +3,7 @@
     import { page } from '$app/stores';
     import { Submit, trackEvent, trackError } from '$lib/actions/analytics';
     import { Card, Heading } from '$lib/components';
-    import CustomId from '$lib/components/customId.svelte';
     import { BillingPlan, Dependencies } from '$lib/constants';
-    import { Pill } from '$lib/elements';
     import { Button, Form, InputSelect, InputText } from '$lib/elements/forms';
     import FormList from '$lib/elements/forms/formList.svelte';
     import { Container } from '$lib/layout';
@@ -20,8 +18,6 @@
     import { checkPricingRefAndRedirect } from '$lib/helpers/pricingRedirect';
 
     let name: string;
-    let id: string;
-    let showCustomId = false;
     let plan: Tier;
 
     const options = isCloud
@@ -53,14 +49,13 @@
             if (plan === BillingPlan.FREE) {
                 try {
                     const org = await sdk.forConsole.billing.createOrganization(
-                        id ?? ID.unique(),
+                        ID.unique(),
                         orgName,
                         plan,
                         null,
                         null
                     );
                     trackEvent(Submit.OrganizationCreate, {
-                        customId: !!id,
                         plan: tierToPlan(plan)?.name
                     });
                     await invalidate(Dependencies.ACCOUNT);
@@ -81,7 +76,7 @@
             }
         } else {
             try {
-                const org = await sdk.forConsole.teams.create(id ?? ID.unique(), orgName);
+                const org = await sdk.forConsole.teams.create(ID.unique(), orgName);
 
                 await invalidate(Dependencies.ACCOUNT);
                 await goto(`${base}/organization-${org.$id}`);
@@ -112,22 +107,6 @@
                     placeholder="Organization name"
                     hideRequired
                     bind:value={name} />
-                {#if !showCustomId}
-                    <div>
-                        <Pill button on:click={() => (showCustomId = !showCustomId)}>
-                            <span class="icon-pencil" aria-hidden="true" /><span class="text">
-                                Organization ID
-                            </span>
-                        </Pill>
-                    </div>
-                {:else}
-                    <CustomId
-                        autofocus
-                        bind:show={showCustomId}
-                        name="Organization"
-                        isProject
-                        bind:id />
-                {/if}
                 {#if isCloud}
                     <div class="u-margin-block-start-8">
                         <h3><b>Plan</b></h3>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Removes the custom ID field when creating an organization during onboarding keeping it consistent everywhere.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.