### PR TITLE
Allow focus on labels to trigger enter hit

### DIFF
--- a/src/lib/components/regionCard.svelte
+++ b/src/lib/components/regionCard.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+    import { onMount } from 'svelte';
+
     export let name: string;
     export let group: string;
     export let value: string | number | boolean;
     export let disabled = false;
     export let padding = 1;
+    export let autofocus = false;
     export let fullHeight = true;
     export let borderRadius: 'xsmall' | 'small' | 'medium' | 'large' = 'small';
 
@@ -13,9 +16,18 @@
         medium = '--border-radius-medium',
         large = '--border-radius-large'
     }
+
+    let labelReference: HTMLLabelElement | null = null;
+
+    onMount(() => {
+        if (autofocus) {
+            labelReference?.focus();
+        }
+    });
 </script>
 
 <label
+    bind:this={labelReference}
     class="box u-cursor-pointer u-flex u-flex-vertical u-gap-16"
     class:is-allow-focus={!disabled}
     class:is-disabled={disabled}

--- a/src/routes/(console)/organization-[organization]/wizard/step2.svelte
+++ b/src/routes/(console)/organization-[organization]/wizard/step2.svelte
@@ -77,13 +77,15 @@
                         return 1;
                     }
                     return -1;
-                }) as region}
+                }) as region, index}
                 <li>
                     <RegionCard
                         name="region"
                         bind:group={$createProject.region}
                         value={region.$id}
-                        disabled={region.disabled}>
+                        disabled={region.disabled}
+                        autofocus={index === 0}>
+                        <!-- focus first item so enter key works! -->
                         <div
                             class="u-flex u-flex-vertical u-gap-8 u-justify-main-center u-cross-center u-margin-inline-auto">
                             {#if region.disabled}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes an issue where if there's one region only, and you hit enter, it doesn't move ahead. Add a focus on the first item so that enter is correctly triggered.

## Test Plan

Manual -

https://github.com/user-attachments/assets/3d4bc4a7-c305-432f-9503-f035663109c8

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.