### PR TITLE
Hide project breakdown if the metric doesn't exist for projects

### DIFF
--- a/src/lib/sdk/billing.ts
+++ b/src/lib/sdk/billing.ts
@@ -198,6 +198,8 @@ export type OrganizationUsage = {
         storage: number;
         executions: number;
         bandwidth: number;
+        databasesReads: number;
+        databasesWrites: number;
         users: number;
         authPhoneTotal: number;
         authPhoneEstimate: number;

--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
@@ -28,7 +28,7 @@
         : (data?.currentInvoice?.plan ?? $organization?.billingPlan);
     const plan = data?.plan ?? undefined;
 
-    $: project = (data.organizationUsage as OrganizationUsage).projects;
+    $: projects = (data.organizationUsage as OrganizationUsage).projects;
 
     $: legendData = [
         { name: 'Reads', value: data.organizationUsage.databasesReadsTotal },
@@ -129,8 +129,8 @@
                             }
                         ]} />
                 </div>
-                {#if project?.length > 0}
-                    <ProjectBreakdown projects={project} metric="bandwidth" {data} />
+                {#if projects?.length > 0}
+                    <ProjectBreakdown {projects} metric="bandwidth" {data} />
                 {/if}
             {:else}
                 <Card isDashed>
@@ -181,8 +181,8 @@
                             }
                         ]} />
                 </div>
-                {#if project?.length > 0}
-                    <ProjectBreakdown projects={project} metric="users" {data} />
+                {#if projects?.length > 0}
+                    <ProjectBreakdown {projects} metric="users" {data} />
                 {/if}
             {:else}
                 <Card isDashed>
@@ -239,10 +239,10 @@
 
                 <Legend {legendData} />
 
-                {#if project?.length > 0}
+                {#if projects?.length > 0}
                     <ProjectBreakdown
                         {data}
-                        projects={project}
+                        {projects}
                         databaseOperationMetric={['databasesReads', 'databasesWrites']} />
                 {/if}
             {:else}
@@ -298,9 +298,10 @@
                             }
                         ]} />
                 </div>
-                {#if project?.length > 0}
-                    <ProjectBreakdown projects={project} metric="executions" {data} />
-                {/if}
+                {#if projects?.length > 0}<ProjectBreakdown
+                        {projects}
+                        metric="executions"
+                        {data} />{/if}
             {:else}
                 <Card isDashed>
                     <div class="u-flex u-cross-center u-flex-vertical u-main-center u-flex">
@@ -368,9 +369,10 @@
                     progressValue={bytesToSize(current, 'GB')}
                     progressMax={max}
                     progressBarData={progressBarStorageDate} />
-                {#if project?.length > 0}
-                    <ProjectBreakdown projects={project} metric="storage" {data} />
-                {/if}
+                {#if projects?.length > 0}<ProjectBreakdown
+                        {projects}
+                        metric="storage"
+                        {data} />{/if}
             {:else}
                 <Card isDashed>
                     <div class="u-flex u-cross-center u-flex-vertical u-main-center u-flex">
@@ -478,9 +480,9 @@
                     </p>
                 </div>
 
-                {#if project?.length > 0}
+                {#if projects?.length > 0}
                     <ProjectBreakdown
-                        projects={project}
+                        {projects}
                         metric="authPhoneTotal"
                         estimate="authPhoneEstimate"
                         {data} />

--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/ProjectBreakdown.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/ProjectBreakdown.svelte
@@ -111,90 +111,92 @@
     });
 </script>
 
-<Collapsible>
-    <CollapsibleItem>
-        <svelte:fragment slot="title">Project breakdown</svelte:fragment>
-        <TableScroll dense noStyles noMargin style="table-layout: auto">
-            <TableHeader>
-                <TableCellHead>Project</TableCellHead>
-                {#if databaseOperationMetric}
-                    <TableCellHead>Reads</TableCellHead>
-                    <TableCellHead>Writes</TableCellHead>
-                {:else}
-                    <TableCellHead>{getMetricTitle(metric)}</TableCellHead>
-                {/if}
-
-                {#if estimate}
-                    <TableCellHead>Estimated cost</TableCellHead>
-                {/if}
-                {#if $canSeeProjects}
-                    <TableCellHead />
-                {/if}
-            </TableHeader>
-            <TableBody>
-                {#each groupByProject(metric, estimate, databaseOperationMetric).sort((a, b) => {
-                    const aValue = a.usage ?? a.databasesReads ?? 0;
-                    const bValue = b.usage ?? b.databasesReads ?? 0;
-                    return bValue - aValue;
-                }) as project}
-                    {#if !$canSeeProjects}
-                        <TableRow>
-                            <TableCell title="Project">
-                                {data.projectNames[project.projectId]?.name ?? 'Unknown'}
-                            </TableCell>
-                            {#if databaseOperationMetric}
-                                <TableCell title="Reads">
-                                    {format(project.databasesReads ?? 0)}
-                                </TableCell>
-                                <TableCell title="Writes">
-                                    {format(project.databasesWrites ?? 0)}
-                                </TableCell>
-                            {:else}
-                                <TableCell>
-                                    {format(project.usage)}
-                                </TableCell>
-                            {/if}
-
-                            {#if project.estimate}
-                                <TableCell title="Estimated cost">
-                                    {formatCurrency(project.estimate)}
-                                </TableCell>
-                            {/if}
-                        </TableRow>
+{#if projects.some((project) => project[metric]) || projects.some( (project) => databaseOperationMetric?.some((metric) => project[metric]) )}
+    <Collapsible>
+        <CollapsibleItem>
+            <svelte:fragment slot="title">Project breakdown</svelte:fragment>
+            <TableScroll dense noStyles noMargin style="table-layout: auto">
+                <TableHeader>
+                    <TableCellHead>Project</TableCellHead>
+                    {#if databaseOperationMetric}
+                        <TableCellHead>Reads</TableCellHead>
+                        <TableCellHead>Writes</TableCellHead>
                     {:else}
-                        <TableRowLink href={getProjectUsageLink(project.projectId)}>
-                            <TableCell title="Project">
-                                {data.projectNames[project.projectId]?.name ?? 'Unknown'}
-                            </TableCell>
-                            {#if databaseOperationMetric}
-                                <TableCell title="Reads">
-                                    {format(project.databasesReads ?? 0)}
-                                </TableCell>
-                                <TableCell title="Writes">
-                                    {format(project.databasesWrites ?? 0)}
-                                </TableCell>
-                            {:else}
-                                <TableCell>
-                                    {format(project.usage)}
-                                </TableCell>
-                            {/if}
-
-                            {#if project.estimate}
-                                <TableCell title="Estimated cost">
-                                    {formatCurrency(project.estimate)}
-                                </TableCell>
-                            {/if}
-                            <TableCell right={true}>
-                                <span
-                                    class="icon-cheveron-right u-cross-child-center ignore-icon-rotate" />
-                            </TableCell>
-                        </TableRowLink>
+                        <TableCellHead>{getMetricTitle(metric)}</TableCellHead>
                     {/if}
-                {/each}
-            </TableBody>
-        </TableScroll>
-    </CollapsibleItem>
-</Collapsible>
+
+                    {#if estimate}
+                        <TableCellHead>Estimated cost</TableCellHead>
+                    {/if}
+                    {#if $canSeeProjects}
+                        <TableCellHead />
+                    {/if}
+                </TableHeader>
+                <TableBody>
+                    {#each groupByProject(metric, estimate, databaseOperationMetric).sort( (a, b) => {
+                            const aValue = a.usage ?? a.databasesReads ?? 0;
+                            const bValue = b.usage ?? b.databasesReads ?? 0;
+                            return bValue - aValue;
+                        } ) as project}
+                        {#if !$canSeeProjects}
+                            <TableRow>
+                                <TableCell title="Project">
+                                    {data.projectNames[project.projectId]?.name ?? 'Unknown'}
+                                </TableCell>
+                                {#if databaseOperationMetric}
+                                    <TableCell title="Reads">
+                                        {format(project.databasesReads ?? 0)}
+                                    </TableCell>
+                                    <TableCell title="Writes">
+                                        {format(project.databasesWrites ?? 0)}
+                                    </TableCell>
+                                {:else}
+                                    <TableCell>
+                                        {format(project.usage)}
+                                    </TableCell>
+                                {/if}
+
+                                {#if project.estimate}
+                                    <TableCell title="Estimated cost">
+                                        {formatCurrency(project.estimate)}
+                                    </TableCell>
+                                {/if}
+                            </TableRow>
+                        {:else}
+                            <TableRowLink href={getProjectUsageLink(project.projectId)}>
+                                <TableCell title="Project">
+                                    {data.projectNames[project.projectId]?.name ?? 'Unknown'}
+                                </TableCell>
+                                {#if databaseOperationMetric}
+                                    <TableCell title="Reads">
+                                        {format(project.databasesReads ?? 0)}
+                                    </TableCell>
+                                    <TableCell title="Writes">
+                                        {format(project.databasesWrites ?? 0)}
+                                    </TableCell>
+                                {:else}
+                                    <TableCell>
+                                        {format(project.usage)}
+                                    </TableCell>
+                                {/if}
+
+                                {#if project.estimate}
+                                    <TableCell title="Estimated cost">
+                                        {formatCurrency(project.estimate)}
+                                    </TableCell>
+                                {/if}
+                                <TableCell right={true}>
+                                    <span
+                                        class="icon-cheveron-right u-cross-child-center ignore-icon-rotate" />
+                                </TableCell>
+                            </TableRowLink>
+                        {/if}
+                    {/each}
+                </TableBody>
+            </TableScroll>
+        </CollapsibleItem>
+    </Collapsible>
+{/if}
 
 <style>
     .ignore-icon-rotate {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Hides the project breakdown accordion when the specified metric doesn't exist.

## Test Plan

Manual.

<img width="1174" alt="Screenshot 2025-01-29 at 8 00 52 PM" src="https://github.com/user-attachments/assets/ed9bf6dc-f61f-41bc-a585-2764b8776329" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.