### PR TITLE
Preload the region flags

### DIFF
--- a/src/lib/elements/flag.svelte
+++ b/src/lib/elements/flag.svelte
@@ -12,13 +12,10 @@
 
     export function getFlag(country: string, width: number, height: number, quality: number) {
         if (!isValueOfStringEnum(Flag, country)) return '';
-        let flag = sdk.forConsole.avatars
+        return sdk.forConsole.avatars
             .getFlag(country, width * 2, height * 2, quality)
-            ?.toString();
-        flag?.includes('&project=')
-            ? (flag = flag.replace('&project=', '&mode=admin'))
-            : flag + '&mode=admin';
-        return flag;
+            ?.toString()
+            ?.replace('&project=console', '&mode=admin');
     }
 </script>
 

--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -28,16 +28,17 @@
     import { ID, Region } from '@appwrite.io/console';
     import { openImportWizard } from '../project-[project]/settings/migrations/(import)';
     import { readOnly } from '$lib/stores/billing';
-    import type { RegionList } from '$lib/sdk/billing';
     import { onMount } from 'svelte';
     import { organization } from '$lib/stores/organization';
     import { canWriteProjects } from '$lib/stores/roles';
     import { checkPricingRefAndRedirect } from '$lib/helpers/pricingRedirect';
+    import { regions as regionsStore } from '$routes/(console)/organization-[organization]/store';
 
     export let data;
 
-    let addOrganization = false;
+    $: regionFlagUrls = [];
     let showCreate = false;
+    let addOrganization = false;
 
     const getPlatformInfo = (platform: string) => {
         let name: string, icon: string;
@@ -80,11 +81,22 @@
         );
     }
 
+    function preloadFlagUrls() {
+        // url is same as in Flag#getFlag component.
+        // make sure to use the same for correct preloading!
+        regionFlagUrls = $regionsStore.regions.map((region) => {
+            return `${sdk.forConsole.client.config.endpoint}/avatars/flags/${region.flag}?width=80&height=60&quality=100&mode=admin`;
+        });
+    }
+
     function handleCreateProject() {
+        preloadFlagUrls();
+
         if (!$canWriteProjects) return;
         if (isCloud) wizard.start(Create);
         else showCreate = true;
     }
+
     $: $registerCommands([
         {
             label: 'Create project',
@@ -120,19 +132,24 @@
         }
     };
 
-    let regions: RegionList;
     onMount(async () => {
         if (isCloud) {
-            regions = await sdk.forConsole.billing.listRegions();
+            const regions = await sdk.forConsole.billing.listRegions();
+            regionsStore.set(regions);
             checkPricingRefAndRedirect($page.url.searchParams);
         }
     });
 
     function findRegion(project: Models.Project) {
-        const region = regions.regions.find((region) => region.$id === project.region);
-        return region;
+        return $regionsStore?.regions?.find((region) => region.$id === project.region);
     }
 </script>
+
+<svelte:head>
+    {#each regionFlagUrls as image}
+        <link rel="preload" as="image" href={image} />
+    {/each}
+</svelte:head>
 
 {#if $organization?.$id}
     <Container>
@@ -198,7 +215,7 @@
                                 </Pill>
                             {/if}
                             <svelte:fragment slot="icons">
-                                {#if isCloud && regions}
+                                {#if isCloud && $regionsStore?.regions}
                                     {@const region = findRegion(project)}
                                     <span class="u-color-text-gray u-medium u-line-height-2">
                                         {region?.name}

--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -36,7 +36,6 @@
 
     export let data;
 
-    $: regionFlagUrls = [];
     let showCreate = false;
     let addOrganization = false;
 
@@ -81,17 +80,7 @@
         );
     }
 
-    function preloadFlagUrls() {
-        // url is same as in Flag#getFlag component.
-        // make sure to use the same for correct preloading!
-        regionFlagUrls = $regionsStore.regions.map((region) => {
-            return `${sdk.forConsole.client.config.endpoint}/avatars/flags/${region.flag}?width=80&height=60&quality=100&mode=admin`;
-        });
-    }
-
     function handleCreateProject() {
-        preloadFlagUrls();
-
         if (!$canWriteProjects) return;
         if (isCloud) wizard.start(Create);
         else showCreate = true;
@@ -144,12 +133,6 @@
         return $regionsStore?.regions?.find((region) => region.$id === project.region);
     }
 </script>
-
-<svelte:head>
-    {#each regionFlagUrls as image}
-        <link rel="preload" as="image" href={image} />
-    {/each}
-</svelte:head>
 
 {#if $organization?.$id}
     <Container>

--- a/src/routes/(console)/organization-[organization]/store.ts
+++ b/src/routes/(console)/organization-[organization]/store.ts
@@ -1,5 +1,8 @@
 import { page } from '$app/stores';
 import type { Models } from '@appwrite.io/console';
-import { derived } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+import type { RegionList } from '$lib/sdk/billing';
+
+export const regions = writable<RegionList | undefined>(undefined);
 
 export const projects = derived(page, ($page) => $page.data?.projects as Models.ProjectList);

--- a/src/routes/(console)/organization-[organization]/store.ts
+++ b/src/routes/(console)/organization-[organization]/store.ts
@@ -2,7 +2,13 @@ import { page } from '$app/stores';
 import type { Models } from '@appwrite.io/console';
 import { derived, writable } from 'svelte/store';
 import type { RegionList } from '$lib/sdk/billing';
+import { sdk } from '$lib/stores/sdk';
 
 export const regions = writable<RegionList | undefined>(undefined);
+export const regionFlagUrls = derived(regions, ($regions) => {
+    return $regions?.regions?.map((region) => {
+        return `${sdk.forConsole.client.config.endpoint}/avatars/flags/${region.flag}?width=80&height=60&quality=100&mode=admin`;
+    });
+});
 
 export const projects = derived(page, ($page) => $page.data?.projects as Models.ProjectList);

--- a/src/routes/(console)/organization-[organization]/store.ts
+++ b/src/routes/(console)/organization-[organization]/store.ts
@@ -6,6 +6,8 @@ import { sdk } from '$lib/stores/sdk';
 
 export const regions = writable<RegionList | undefined>(undefined);
 export const regionFlagUrls = derived(regions, ($regions) => {
+    if (!$regions?.regions?.length) return [];
+
     return $regions?.regions?.map((region) => {
         return `${sdk.forConsole.client.config.endpoint}/avatars/flags/${region.flag}?width=80&height=60&quality=100&mode=admin`;
     });

--- a/src/routes/(console)/organization-[organization]/wizard/step1.svelte
+++ b/src/routes/(console)/organization-[organization]/wizard/step1.svelte
@@ -4,11 +4,14 @@
     import { InputText, FormList } from '$lib/elements/forms';
     import { WizardStep } from '$lib/layout';
     import { sdk } from '$lib/stores/sdk';
-    import { createProject, regions } from './store';
+    import { createProject } from './store';
+    import { regions } from '$routes/(console)/organization-[organization]/store';
 
     let showCustomId = false;
 
-    sdk.forConsole.billing.listRegions().then(regions.set);
+    if (!$regions?.regions) {
+        sdk.forConsole.billing.listRegions().then(regions.set);
+    }
 </script>
 
 <WizardStep>

--- a/src/routes/(console)/organization-[organization]/wizard/step1.svelte
+++ b/src/routes/(console)/organization-[organization]/wizard/step1.svelte
@@ -5,7 +5,7 @@
     import { WizardStep } from '$lib/layout';
     import { sdk } from '$lib/stores/sdk';
     import { createProject } from './store';
-    import { regions } from '$routes/(console)/organization-[organization]/store';
+    import { regionFlagUrls, regions } from '$routes/(console)/organization-[organization]/store';
 
     let showCustomId = false;
 
@@ -13,6 +13,12 @@
         sdk.forConsole.billing.listRegions().then(regions.set);
     }
 </script>
+
+<svelte:head>
+    {#each $regionFlagUrls as image}
+        <link rel="preload" as="image" href={image} />
+    {/each}
+</svelte:head>
 
 <WizardStep>
     <svelte:fragment slot="title">Details</svelte:fragment>

--- a/src/routes/(console)/organization-[organization]/wizard/step2.svelte
+++ b/src/routes/(console)/organization-[organization]/wizard/step2.svelte
@@ -4,11 +4,12 @@
     import { WizardStep } from '$lib/layout';
     import { sdk } from '$lib/stores/sdk';
     import { onMount } from 'svelte';
-    import { createProject, regions } from './store';
+    import { createProject } from './store';
     import type { Region } from '$lib/sdk/billing';
     import { addNotification } from '$lib/stores/notifications';
     import type { Models } from '@appwrite.io/console';
     import { page } from '$app/stores';
+    import { regions } from '$routes/(console)/organization-[organization]/store';
 
     let prefs: Models.Preferences;
 

--- a/src/routes/(console)/organization-[organization]/wizard/store.ts
+++ b/src/routes/(console)/organization-[organization]/wizard/store.ts
@@ -1,4 +1,3 @@
-import type { RegionList } from '$lib/sdk/billing';
 import { writable } from 'svelte/store';
 
 export const createProject = writable<{
@@ -10,5 +9,3 @@ export const createProject = writable<{
     name: null,
     region: 'fra'
 });
-
-export const regions = writable<RegionList | undefined>(undefined);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

We currently load the regions twice. One in `organization-[organization]`, another when creating a new project causing a slow load of flags. This PR preloads the flag urls when necessary.

## Test Plan

Manual.

https://github.com/user-attachments/assets/d3bbab0f-5266-4710-89c5-5d6739e82f5c


## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.