### PR TITLE
Validate cron before updating function

### DIFF
--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateSchedule.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateSchedule.svelte
@@ -11,6 +11,7 @@
     import { func } from '../store';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { parseExpression } from 'cron-parser';
 
     const functionId = $page.params.function;
     let functionSchedule: string = null;
@@ -24,6 +25,10 @@
             if (!isValueOfStringEnum(Runtime, $func.runtime)) {
                 throw new Error(`Invalid runtime: ${$func.runtime}`);
             }
+
+            // an error is shown if invalid.
+            parseExpression(functionSchedule);
+
             await sdk.forProject.functions.update(
                 functionId,
                 $func.name,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes a bug that allows using an invalid cron job that later crashes the console.

Example: 
```
59 23 31 2 *

┌──────── minute (0 - 59)
│ ┌────── hour (0 - 23)
│ │ ┌──── day of the month (1 - 31)
│ │ │ ┌── month (1 - 12)
│ │ │ │ ┌── day of the week (0 - 6) (Sunday = 0)
│ │ │ │ │
59 23 31 2 *  → Run at 23:59 (11:59 PM) on the 31st of February, every year.
```


## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.