### PR TITLE
Add `$createdAt` to deployments table

### DIFF
--- a/src/routes/(console)/project-[project]/functions/function-[function]/+page.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/+page.svelte
@@ -64,6 +64,14 @@
             ]
         },
         {
+            id: '$createdAt',
+            title: 'Created',
+            type: 'datetime',
+            show: true,
+            width: 150,
+            format: 'datetime'
+        },
+        {
             id: '$updatedAt',
             title: 'Updated',
             type: 'datetime',
@@ -71,7 +79,6 @@
             width: 150,
             format: 'datetime'
         },
-
         {
             id: 'buildTime',
             title: 'Build time',

--- a/src/routes/(console)/project-[project]/functions/function-[function]/deploymentBy.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/deploymentBy.svelte
@@ -2,10 +2,13 @@
     import { timeFromNow } from '$lib/helpers/date';
     import type { Models } from '@appwrite.io/console';
 
+    export let type: 'create' | 'update';
     export let deployment: Models.Deployment;
+
+    let variable = type === 'create' ? '$createdAt' : '$updatedAt';
 </script>
 
-{timeFromNow(deployment.$updatedAt)}
+{timeFromNow(deployment[variable])}
 {#if deployment.providerCommitAuthor}
     by <a
         class="u-underline u-cursor-pointer"

--- a/src/routes/(console)/project-[project]/functions/function-[function]/deploymentCard.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/deploymentCard.svelte
@@ -5,7 +5,7 @@
     import { Pill } from '$lib/elements';
     import { humanFileSize } from '$lib/helpers/sizeConvertion';
     import { calculateTime } from '$lib/helpers/timeConversion';
-    import DeploymentCreatedBy from './deploymentCreatedBy.svelte';
+    import DeploymentBy from './deploymentBy.svelte';
     import DeploymentSource from './deploymentSource.svelte';
 
     import DeploymentDomains from './deploymentDomains.svelte';
@@ -80,7 +80,7 @@
             <li class="u-flex-vertical u-gap-4">
                 <p class="u-color-text-offline">Updated</p>
                 <p class="u-line-height-2">
-                    <DeploymentCreatedBy {deployment} />
+                    <DeploymentBy {deployment} type="update" />
                 </p>
             </li>
         </ul>

--- a/src/routes/(console)/project-[project]/functions/function-[function]/executions/execute-function/+page.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/executions/execute-function/+page.svelte
@@ -37,7 +37,7 @@
     import DeploymentSource from '../../deploymentSource.svelte';
     import DeploymentDomains from '../../deploymentDomains.svelte';
     import { proxyRuleList } from '../../store';
-    import DeploymentCreatedBy from '../../deploymentCreatedBy.svelte';
+    import DeploymentBy from '../../deploymentBy.svelte';
     import {
         isSameDay,
         toLocaleDateISO,
@@ -400,7 +400,7 @@
                 <div class="u-flex-vertical u-gap-8">
                     <p class="u-color-text-offline">Updated</p>
                     <span>
-                        <DeploymentCreatedBy {deployment} />
+                        <DeploymentBy {deployment} type="update" />
                     </span>
                 </div>
             </Card>

--- a/src/routes/(console)/project-[project]/functions/function-[function]/table.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/table.svelte
@@ -93,6 +93,10 @@
                             <TableCell width={column.width} title={column.title}>
                                 <DeploymentSource {deployment} />
                             </TableCell>
+                        {:else if column.id === '$createdAt'}
+                            <TableCellText width={column.width} title={column.title}>
+                                <DeploymentCreatedBy {deployment} />
+                            </TableCellText>
                         {:else if column.id === '$updatedAt'}
                             <TableCellText width={column.width} title={column.title}>
                                 <DeploymentCreatedBy {deployment} />

--- a/src/routes/(console)/project-[project]/functions/function-[function]/table.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/table.svelte
@@ -15,7 +15,7 @@
     import { Pill } from '$lib/elements';
     import { calculateTime } from '$lib/helpers/timeConversion';
     import DeploymentSource from './deploymentSource.svelte';
-    import DeploymentCreatedBy from './deploymentCreatedBy.svelte';
+    import DeploymentBy from './deploymentBy.svelte';
     import { timer } from '$lib/actions/timer';
     import { calculateSize } from '$lib/helpers/sizeConvertion';
     import { func } from './store';
@@ -95,11 +95,11 @@
                             </TableCell>
                         {:else if column.id === '$createdAt'}
                             <TableCellText width={column.width} title={column.title}>
-                                <DeploymentCreatedBy {deployment} />
+                                <DeploymentBy {deployment} type="create" />
                             </TableCellText>
                         {:else if column.id === '$updatedAt'}
                             <TableCellText width={column.width} title={column.title}>
-                                <DeploymentCreatedBy {deployment} />
+                                <DeploymentBy {deployment} type="update" />
                             </TableCellText>
                         {:else if column.id === 'buildTime'}
                             <TableCellText width={column.width} title={column.title}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds a `Created` column in deployment table to avoid confusion on when a Function was created.

## Test Plan

Manual.

<img width="1190" alt="Screenshot 2025-03-03 at 2 08 44 PM" src="https://github.com/user-attachments/assets/a0a3980c-ea72-422e-ac41-5afaa8d71a58" />
## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.