### PR TITLE
fix: add option to usage bucket chart to be cumulative

### DIFF
--- a/src/lib/layout/usage.svelte
+++ b/src/lib/layout/usage.svelte
@@ -86,6 +86,7 @@
     export let countMetadata: MetricMetadata;
     export let path: string = null;
     export let hideSelectPeriod: boolean = false;
+    export let isCumulative: boolean = false;
 </script>
 
 <Container>
@@ -118,7 +119,9 @@
                     series={[
                         {
                             name: countMetadata.legend,
-                            data: accumulateFromEndingTotal(count, total)
+                            data: isCumulative
+                                ? count.map((m) => [m.date, m.value])
+                                : accumulateFromEndingTotal(count, total)
                         }
                     ]} />
             </div>

--- a/src/routes/(console)/project-[project]/storage/bucket-[bucket]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[project]/storage/bucket-[bucket]/usage/[[period]]/+page.svelte
@@ -30,4 +30,5 @@
         legend: 'Image transformations',
         title: 'Total transformations'
     }}
+    isCumulative
     hideSelectPeriod />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Image transformation values are cumulative so we need to adjust usage bucket chart to be cumulative as well/

## Test Plan

Before:
<img width="1029" alt="Screenshot 2025-03-06 at 10 25 33 AM" src="https://github.com/user-attachments/assets/d876fba0-df01-42f0-895f-9088f0db118e" />

After:
<img width="1073" alt="Screenshot 2025-03-06 at 10 25 47 AM" src="https://github.com/user-attachments/assets/06092efa-a6c2-4049-ac95-0c222da80d9e" />


## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.