### PR TITLE
Save the specification when updating a function

### DIFF
--- a/src/lib/wizards/functions/connectExisting.svelte
+++ b/src/lib/wizards/functions/connectExisting.svelte
@@ -36,7 +36,8 @@
                 $repository.id,
                 $choices.branch,
                 $choices.silentMode || undefined,
-                $choices.rootDir
+                $choices.rootDir,
+                $func.specification || undefined
             );
             trackEvent(Submit.FunctionConnectRepo, {
                 customId: !!$func.$id

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateConfiguration.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateConfiguration.svelte
@@ -135,7 +135,8 @@
                 $func.providerRepositoryId || undefined,
                 selectedBranch,
                 silentMode,
-                selectedDir
+                selectedDir,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateEvents.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateEvents.svelte
@@ -51,7 +51,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateLogging.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateLogging.svelte
@@ -44,7 +44,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateName.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateName.svelte
@@ -41,7 +41,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updatePermissions.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updatePermissions.svelte
@@ -45,7 +45,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateSchedule.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateSchedule.svelte
@@ -46,7 +46,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateScopes.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateScopes.svelte
@@ -43,7 +43,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateTimeout.svelte
+++ b/src/routes/(console)/project-[project]/functions/function-[function]/settings/updateTimeout.svelte
@@ -41,7 +41,8 @@
                 $func.providerRepositoryId || undefined,
                 $func.providerBranch || undefined,
                 $func.providerSilentMode || undefined,
-                $func.providerRootDirectory || undefined
+                $func.providerRootDirectory || undefined,
+                $func.specification || undefined
             );
             await invalidate(Dependencies.FUNCTION);
             addNotification({


### PR DESCRIPTION
## What does this PR do?
The update function call is a PUT, so the specification has to be added to all update functions, otherwise it gets reset.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅