### PR TITLE
Update legends to show abbreviated numbers format

### DIFF
--- a/src/lib/charts/legend.svelte
+++ b/src/lib/charts/legend.svelte
@@ -8,16 +8,22 @@
 <script lang="ts">
     import { Colors } from '$lib/charts/config';
     import { Status } from '$lib/components';
-    import { formatNumberWithCommas } from '$lib/helpers/numbers';
+    import { abbreviateNumber, formatNumberWithCommas } from '$lib/helpers/numbers';
 
     export let legendData: LegendData[] = [];
+    export let numberFormat: 'comma' | 'abbreviate' = 'comma';
 
     let colors = Object.values(Colors);
 </script>
 
 <div class="u-flex u-cross-center u-gap-16">
     {#each legendData as { name, value }, index}
-        {@const formattedValue = typeof value === 'number' ? formatNumberWithCommas(value) : value}
+        {@const formattedValue =
+            typeof value === 'number'
+                ? numberFormat === 'abbreviate'
+                    ? abbreviateNumber(value)
+                    : formatNumberWithCommas(value)
+                : value}
         <Status status="none" statusIconStyle="background-color: {colors[index % colors.length]}">
             {name} ({formattedValue})
         </Status>

--- a/src/lib/helpers/numbers.ts
+++ b/src/lib/helpers/numbers.ts
@@ -1,7 +1,10 @@
 export function abbreviateNumber(num: number, decimals: number = 1): string {
     if (isNaN(num)) return String(num);
-    if (num >= 1000000) {
-        const result = num / 1000000;
+    if (num >= 1_000_000_000) {
+        const result = num / 1_000_000_000;
+        return result.toFixed(result % 1 !== 0 ? decimals : 0) + 'B';
+    } else if (num >= 1_000_000) {
+        const result = num / 1_000_000;
         return result.toFixed(result % 1 !== 0 ? decimals : 0) + 'M';
     } else if (num >= 1000) {
         const result = num / 1000;

--- a/src/lib/layout/usageMultiple.svelte
+++ b/src/lib/layout/usageMultiple.svelte
@@ -14,6 +14,7 @@
     export let legendData: LegendData[];
     export let showHeader: boolean = true;
     export let overlapContainerCover = false;
+    export let legendNumberFormat: 'comma' | 'abbreviate' = 'comma';
 </script>
 
 <Container overlapCover={overlapContainerCover}>
@@ -55,7 +56,7 @@
                     }))} />
 
                 {#if legendData}
-                    <Legend {legendData} />
+                    <Legend {legendData} numberFormat={legendNumberFormat} />
                 {/if}
             </div>
         {/if}

--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
@@ -238,7 +238,7 @@
                         ]} />
                 </div>
 
-                <Legend {legendData} />
+                <Legend {legendData} numberFormat="abbreviate" />
 
                 {#if projects?.length > 0}
                     <ProjectBreakdown

--- a/src/routes/(console)/project-[project]/databases/database-[database]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[project]/databases/database-[database]/usage/[[period]]/+page.svelte
@@ -33,6 +33,7 @@
         overlapContainerCover
         total={[readsTotal, writesTotal]}
         count={[reads, writes]}
+        legendNumberFormat="abbreviate"
         legendData={[
             { name: 'Reads', value: readsTotal },
             { name: 'Writes', value: writesTotal }

--- a/src/routes/(console)/project-[project]/databases/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[project]/databases/usage/[[period]]/+page.svelte
@@ -32,6 +32,7 @@
         overlapContainerCover
         total={[readsTotal, writesTotal]}
         count={[reads, writes]}
+        legendNumberFormat="abbreviate"
         legendData={[
             { name: 'Reads', value: readsTotal },
             { name: 'Writes', value: writesTotal }

--- a/src/routes/(console)/project-[project]/settings/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/project-[project]/settings/usage/[[invoice]]/+page.svelte
@@ -233,7 +233,7 @@
                         ]} />
                 </div>
 
-                <Legend {legendData} />
+                <Legend {legendData} numberFormat="abbreviate" />
             {:else}
                 <Card isDashed>
                     <div class="u-flex u-cross-center u-flex-vertical u-main-center u-flex">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

DB Reads and Writes can easily cross huge numbers, comma separated numbers can be confusing on legends in that are. This PR fixes/updates that to show abbreviated numbering format.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.