### PR TITLE
Fix: content overflown on previews

### DIFF
--- a/src/routes/(console)/project-[project]/messaging/pushPhone.svelte
+++ b/src/routes/(console)/project-[project]/messaging/pushPhone.svelte
@@ -18,7 +18,7 @@
         </div>
         <div>
             <p class="body-text-1 u-small u-bold">{title || 'Message Title'}</p>
-            <p class="body-text-2 u-x-small">
+            <p class="notification-bubble body-text-2 u-x-small">
                 {body || 'Enter your message in the input field on the left to see it here'}
             </p>
         </div>
@@ -47,6 +47,14 @@
                 }
             }
         }
+    }
+
+    .notification-bubble {
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 4;
+        word-break: break-word;
+        -webkit-box-orient: vertical;
     }
 
     :global(.theme-dark) .phone {

--- a/src/routes/(console)/project-[project]/messaging/pushPhone.svelte
+++ b/src/routes/(console)/project-[project]/messaging/pushPhone.svelte
@@ -52,8 +52,9 @@
     .notification-bubble {
         overflow: hidden;
         display: -webkit-box;
-        -webkit-line-clamp: 4;
+        line-clamp: 4;
         word-break: break-word;
+        -webkit-line-clamp: 4;
         -webkit-box-orient: vertical;
     }
 

--- a/src/routes/(console)/project-[project]/messaging/smsPhone.svelte
+++ b/src/routes/(console)/project-[project]/messaging/smsPhone.svelte
@@ -92,6 +92,11 @@
                     padding-block: 7px;
                     margin-inline-start: 6px;
                     margin-inline-end: 33px;
+                    overflow: hidden;
+                    display: -webkit-box;
+                    word-break: break-word;
+                    -webkit-line-clamp: 4;
+                    -webkit-box-orient: vertical;
                 }
             }
         }

--- a/src/routes/(console)/project-[project]/messaging/smsPhone.svelte
+++ b/src/routes/(console)/project-[project]/messaging/smsPhone.svelte
@@ -95,6 +95,7 @@
                     overflow: hidden;
                     display: -webkit-box;
                     word-break: break-word;
+                    line-clamp: 4;
                     -webkit-line-clamp: 4;
                     -webkit-box-orient: vertical;
                 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes the issue with preview content on Push & SMS being overflown on a single line.

## Test Plan

Manual.

Before -

![image](https://github.com/user-attachments/assets/ba4272ec-7762-46c6-a164-ece5c9f23570)

After -

<img width="401" alt="Screenshot 2025-03-17 at 10 19 00 AM" src="https://github.com/user-attachments/assets/04bc640d-8fd4-40a4-88db-03f8eb7aefa6" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.