### PR TITLE
Fix: upgrade, downgrade checks on non-public and same plans

### DIFF
--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -274,12 +274,12 @@
         }
     }
 
-    $: isUpgrade = $plansInfo.get(billingPlan).order > $currentPlan.order;
-    $: isDowngrade = $plansInfo.get(billingPlan).order < $currentPlan.order;
+    $: isSamePlan = billingPlan === $currentPlan.$id;
+    $: isUpgrade = isSamePlan ? false : $plansInfo.get(billingPlan)?.order > $currentPlan.order;
+    $: isDowngrade = isSamePlan ? false : $plansInfo.get(billingPlan)?.order < $currentPlan.order;
     $: if (billingPlan !== BillingPlan.FREE) {
         loadPaymentMethods();
     }
-    $: isButtonDisabled = ($currentPlan?.$id as Tier) === billingPlan;
 </script>
 
 <svelte:head>
@@ -387,7 +387,7 @@
         <Button
             fullWidthMobile
             on:click={() => formComponent.triggerSubmit()}
-            disabled={$isSubmitting || isButtonDisabled || !selfService}>
+            disabled={$isSubmitting || isSamePlan || !selfService}>
             Change plan
         </Button>
     </WizardSecondaryFooter>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Non-public plans are not returned from the backend, which causes the plan check to fail during order evaluation and crashes the console.

This PR skips the check when the current and target plans are the same, avoiding errors in such scenarios.

[Context in Discord](https://discord.com/channels/564160730845151244/740463504602955806/1353266418031919156).

## Test Plan

Manual.

## Related PRs and Issues

* [See issue on Discord](https://discord.com/channels/564160730845151244/740463504602955806/1353266418031919156).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.