### PR TITLE
Hide realtime stats until fixed

### DIFF
--- a/src/routes/(console)/project-[project]/overview/+layout.svelte
+++ b/src/routes/(console)/project-[project]/overview/+layout.svelte
@@ -19,7 +19,7 @@
     import Bandwidth from './bandwidth.svelte';
     import { createApiKey } from './keys/+page.svelte';
     import Onboard from './onboard.svelte';
-    import Realtime from './realtime.svelte';
+    // import Realtime from './realtime.svelte';
     import Requests from './requests.svelte';
     import { usage } from './store';
     import { formatNum } from '$lib/helpers/string';
@@ -28,9 +28,9 @@
     import { periodToDates } from '$lib/layout/usage.svelte';
     import { canWriteProjects } from '$lib/stores/roles';
 
+    let period: UsagePeriods = '30d';
     $: projectId = $page.params.project;
     $: path = `${base}/project-${projectId}/overview`;
-    let period: UsagePeriods = '30d';
 
     onMount(handle);
     afterNavigate(handle);
@@ -197,10 +197,10 @@
                                 </div>
                             </div>
                         </a>
-                        <div
-                            class="card is-2-columns-medium-screen is-2-columns-large-screen is-2-rows-large-screen is-location-row-2-end-large-screen">
-                            <Realtime />
-                        </div>
+<!--                        <div-->
+<!--                            class="card is-2-columns-medium-screen is-2-columns-large-screen is-2-rows-large-screen is-location-row-2-end-large-screen">-->
+<!--                            <Realtime />-->
+<!--                        </div>-->
                     </div>
                 </section>
             {/if}
@@ -237,3 +237,21 @@
         {/if}
     </Container>
 {/if}
+
+<style>
+    @media (min-width: 1199px) {
+        .grid-dashboard-1s-2m-6l {
+            grid-template-columns: repeat(12, 1fr);
+        }
+
+        .is-3-columns-large-screen {
+            /* 6/12 = half */
+            grid-column: span 6;
+        }
+
+        .is-2-columns-large-screen {
+            /* 3/12 = 1/4 → fits 4 items per row */
+            grid-column: span 3;
+        }
+    }
+</style>

--- a/src/routes/(console)/project-[project]/overview/+layout.svelte
+++ b/src/routes/(console)/project-[project]/overview/+layout.svelte
@@ -197,10 +197,10 @@
                                 </div>
                             </div>
                         </a>
-<!--                        <div-->
-<!--                            class="card is-2-columns-medium-screen is-2-columns-large-screen is-2-rows-large-screen is-location-row-2-end-large-screen">-->
-<!--                            <Realtime />-->
-<!--                        </div>-->
+                        <!--                        <div-->
+                        <!--                            class="card is-2-columns-medium-screen is-2-columns-large-screen is-2-rows-large-screen is-location-row-2-end-large-screen">-->
+                        <!--                            <Realtime />-->
+                        <!--                        </div>-->
                     </div>
                 </section>
             {/if}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Hides the realtime stats card due to it being flaky.

## Test Plan

Manual.

<img width="1523" alt="Screenshot 2025-04-02 at 10 26 10 AM" src="https://github.com/user-attachments/assets/6366931f-3daf-4541-94de-e2e080e7e6e2" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.