### PR TITLE
fix(databases): vertically center backups sign up button

### DIFF
--- a/src/routes/(console)/project-[project]/databases/database-[database]/backups/upgradeCard.svelte
+++ b/src/routes/(console)/project-[project]/databases/database-[database]/backups/upgradeCard.svelte
@@ -78,7 +78,7 @@
                     {/if}
                 </div>
             </div>
-            <div class="u-flex u-flex-vertical-mobile u-gap-mobile-6">
+            <div class="u-flex u-flex-vertical-mobile u-gap-mobile-6 u-cross-center">
                 <div class="u-flex-vertical u-gap-8">
                     <h3 class="body-text-2 u-bold">
                         {title}


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

On the backups page for self-hosted, there's a button that takes users to Cloud since backups are not available on self-hosted. The button looked odd because it was aligned to the top. Instead, vertically center the button.

## Test Plan

Manually tested.

Before:

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/5e162557-679c-485c-8633-e55a19c8e019" />


After:

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/2f1870f8-91f1-4b9f-a4c8-e53d25ad63c4" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes