### PR TITLE
fix: don't set endpoint during build

### DIFF
--- a/src/lib/stores/sdk.ts
+++ b/src/lib/stores/sdk.ts
@@ -24,6 +24,7 @@ import {
 import { Billing } from '../sdk/billing';
 import { Backups } from '../sdk/backups';
 import { Sources } from '$lib/sdk/sources';
+import { building } from '$app/environment';
 
 export function getApiEndpoint(): string {
     if (VARS.APPWRITE_ENDPOINT) return VARS.APPWRITE_ENDPOINT;
@@ -33,10 +34,12 @@ export function getApiEndpoint(): string {
 const endpoint = getApiEndpoint();
 
 const clientConsole = new Client();
-clientConsole.setEndpoint(endpoint).setProject('console');
-
 const clientProject = new Client();
-clientProject.setEndpoint(endpoint).setMode('admin');
+
+if (!building) {
+    clientConsole.setEndpoint(endpoint).setProject('console');
+    clientProject.setEndpoint(endpoint).setMode('admin');
+}
 
 const sdkForProject = {
     client: clientProject,

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -2,16 +2,14 @@ import '@testing-library/jest-dom/vitest';
 import { beforeAll, vi } from 'vitest';
 
 beforeAll(() => {
-    vi.mock('$app/environment', () => ({
-        browser: true
-    }));
     vi.mock('$app/navigation', () => ({
         goto: vi.fn(),
         beforeNavigate: vi.fn()
     }));
     vi.mock('$app/environment', () => ({
         dev: true,
-        browser: true
+        browser: true,
+        building: true
     }));
     vi.mock('$env/static/public', () => import.meta.env);
     vi.mock('$env/dynamic/public', () => ({


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

During build, the endpoint is invalid so calling setEndpoint() would result in an error:

Invalid endpoint URL: undefined/v1

This PR ensures setEndpoint() isn't called during build.

## Test Plan

Manually ran `pnpm run build` before:

<img width="1677" alt="image" src="https://github.com/user-attachments/assets/233aa166-9cd2-4346-80d5-575e0eef1910" />

Manually ran `pnpm run build` after:

<img width="661" alt="image" src="https://github.com/user-attachments/assets/03acf072-e8ef-41b0-bd18-c15cdb51bdb3" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes