### PR TITLE
Fix flow for campaign credits apply

### DIFF
--- a/src/lib/components/billing/estimatedTotalBox.svelte
+++ b/src/lib/components/billing/estimatedTotalBox.svelte
@@ -43,7 +43,7 @@
         </Layout.Stack>
         <Layout.Stack direction="row" justifyContent="space-between">
             <Typography.Text variant={isDowngrade ? 'm-500' : 'm-400'}
-                >Additional seats ({collaborators?.length})</Typography.Text>
+                >Additional seats ({collaborators?.length ?? 0})</Typography.Text>
             <Typography.Text variant={isDowngrade ? 'm-500' : 'm-400'}
                 >{formatCurrency(extraSeatsCost)}</Typography.Text>
         </Layout.Stack>

--- a/src/routes/(console)/apply-credit/+page.svelte
+++ b/src/routes/(console)/apply-credit/+page.svelte
@@ -198,12 +198,11 @@
     ) as Organization;
 
     function getBillingPlan(): Tier | undefined {
-        const plansInfo = page.data.plansInfo;
         const campaignPlan =
-            campaign?.plan && plansInfo.get(campaign.plan) ? plansInfo.get(campaign.plan) : null;
+            campaign?.plan && $plansInfo.get(campaign.plan) ? $plansInfo.get(campaign.plan) : null;
         const orgPlan =
-            selectedOrg?.billingPlan && plansInfo.get(selectedOrg.billingPlan)
-                ? plansInfo.get(selectedOrg.billingPlan)
+            selectedOrg?.billingPlan && $plansInfo.get(selectedOrg.billingPlan)
+                ? $plansInfo.get(selectedOrg.billingPlan)
                 : null;
 
         if (!campaignPlan || !orgPlan) {


### PR DESCRIPTION
## What does this PR do?
Added improved check for updating the billing plan. It now checks the plan order to prevent unwanted downgrades.

When applying the campaign results in the same plan the organisation is already on (or lower), the user will see this. And nothing will change in the plan of the organisation.
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/0873206c-1546-41ee-bcf6-87c7b95c5e60" />
(screenshot shows a SCALE org with a PRO plan campaign)

When applying the campaign results in an upgrade, the user will be shown the campaign text in the estimated total box:
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/083e84c2-501b-4d4a-a3a3-04a92e5f2a3d" />
(screenshot shows a PRO org with a SCALE plan campaign)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅