### PR TITLE
fix: update height of sidebar when alert is open

### DIFF
--- a/src/lib/layout/headerAlert.svelte
+++ b/src/lib/layout/headerAlert.svelte
@@ -18,6 +18,7 @@
         }
         if (sidebar) {
             sidebar.style.top = `${alertHeight + ($isTabletViewport ? 0 : header.getBoundingClientRect().height)}px`;
+            sidebar.style.height = `calc(100vh - (${alertHeight + ($isTabletViewport ? 0 : header.getBoundingClientRect().height)}px))`;
         }
         if (contentSection) {
             contentSection.style.paddingBlockStart = `${alertHeight}px`;


### PR DESCRIPTION
## What does this PR do?
<img width="1291" alt="image" src="https://github.com/user-attachments/assets/081ee374-3a5b-4646-a568-9fee2052eb6a" />
Ensure settings option is visible when there's also an alert at the top of the page

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
✅