### PR TITLE
fix: oauth endpoints to follow multi region naming

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/appleOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/appleOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputSwitch, InputText, InputTextarea } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -67,7 +67,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/auth0OAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/auth0OAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -77,7 +77,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/authentikOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/authentikOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -77,7 +77,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/gitlabOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/gitlabOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -75,7 +75,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/googleOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/googleOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -68,9 +68,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${
-                    sdk.forConsole.client.config.endpoint
-                }/account/sessions/oauth2/callback/${provider.name.toLocaleLowerCase()}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -2,11 +2,11 @@
     import { page } from '$app/stores';
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
-    import { sdk } from '$lib/stores/sdk';
+    import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
-    import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
 
     const projectId = $page.params.project;
 
@@ -67,7 +67,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/microsoftOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/microsoftOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -76,7 +76,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/oidcOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/oidcOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -114,7 +114,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/oktaOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/oktaOAuth.svelte
@@ -3,10 +3,10 @@
     import { Alert, CopyInput, Modal } from '$lib/components';
     import { Button, FormList, InputPassword, InputSwitch, InputText } from '$lib/elements/forms';
     import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
-    import { sdk } from '$lib/stores/sdk';
+    import { getApiEndpoint } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
-    import type { Models } from '@appwrite.io/console';
 
     const projectId = $page.params.project;
 
@@ -86,7 +86,7 @@
         <div>
             <p>URI</p>
             <CopyInput
-                value={`${sdk.forConsole.client.config.endpoint}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
+                value={`${getApiEndpoint($page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
         </div>
     </FormList>
     <svelte:fragment slot="footer">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the callback URI in oauth modals to follow the new multi region naming.

## Test Plan

<img width="1013" alt="Screenshot 2025-04-22 at 7 47 43 PM" src="https://github.com/user-attachments/assets/0e66d4a6-74e4-4049-ac10-001cc5e55913" />

<img width="995" alt="Screenshot 2025-04-22 at 7 50 00 PM" src="https://github.com/user-attachments/assets/46f23cc1-0775-4df2-979f-1d08a7cf2a3b" />

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.