### PR TITLE
Fix: Show the summation of the graph, not the totals

### DIFF
--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
@@ -31,8 +31,20 @@
     $: projects = (data.organizationUsage as OrganizationUsage).projects;
 
     $: legendData = [
-        { name: 'Reads', value: data.organizationUsage.databasesReadsTotal },
-        { name: 'Writes', value: data.organizationUsage.databasesWritesTotal }
+        {
+            name: 'Reads',
+            value: data.organizationUsage.databasesReads.reduce(
+                (sum, singleDay) => sum + singleDay.value,
+                0
+            )
+        },
+        {
+            name: 'Writes',
+            value: data.organizationUsage.databasesWrites.reduce(
+                (sum, singleDay) => sum + singleDay.value,
+                0
+            )
+        }
     ];
 </script>
 


### PR DESCRIPTION
## What does this PR do?
The legend below the graph now shows the summation of what is in the graph, instead of the all time data

Before:
<img width="638" alt="image" src="https://github.com/user-attachments/assets/884b5df4-1e43-4ed5-81d8-0e7b223c0bf4" />


After:
<img width="653" alt="image" src="https://github.com/user-attachments/assets/ffb5468a-48aa-4fb2-8b65-4ecac73ad228" />


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes