### PR TITLE
fix: multi region support for cached env files

### DIFF
--- a/src/lib/stores/sdk.ts
+++ b/src/lib/stores/sdk.ts
@@ -42,7 +42,7 @@ export function getApiEndpoint(region?: string): string {
     const hostname = url.hostname;
 
     // If instance supports multi-region, add the region subdomain.
-    const subdomain = isMultiRegionSupported() ? getSubdomain(region) : '';
+    const subdomain = isMultiRegionSupported(url) ? getSubdomain(region) : '';
 
     return `${protocol}//${subdomain}${hostname}/v1`;
 }

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -36,8 +36,7 @@ export function isMultiRegionSupported(): boolean {
     if (env.PUBLIC_APPWRITE_MULTI_REGION === 'true') return true;
 
     try {
-        const endpoint = getApiEndpoint();
-        return new URL(endpoint).hostname.endsWith('cloud.appwrite.io');
+        return new URL(getApiEndpoint()).hostname.endsWith('cloud.appwrite.io');
     } catch {
         return false;
     }

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -1,5 +1,6 @@
 import { env } from '$env/dynamic/public';
 import { dev } from '$app/environment';
+import { getApiEndpoint } from '$lib/stores/sdk';
 
 export const enum Mode {
     CLOUD = 'cloud',
@@ -35,7 +36,8 @@ export function isMultiRegionSupported(): boolean {
     if (env.PUBLIC_APPWRITE_MULTI_REGION === 'true') return true;
 
     try {
-        return new URL(VARS.APPWRITE_ENDPOINT).hostname.endsWith('cloud.appwrite.io');
+        const endpoint = getApiEndpoint();
+        return new URL(endpoint).hostname.endsWith('cloud.appwrite.io');
     } catch {
         return false;
     }

--- a/src/lib/system.ts
+++ b/src/lib/system.ts
@@ -1,6 +1,5 @@
 import { env } from '$env/dynamic/public';
 import { dev } from '$app/environment';
-import { getApiEndpoint } from '$lib/stores/sdk';
 
 export const enum Mode {
     CLOUD = 'cloud',
@@ -32,11 +31,11 @@ export const GRACE_PERIOD_OVERRIDE = false;
 /**
  * Returns true if multi-region is supported.
  */
-export function isMultiRegionSupported(): boolean {
+export function isMultiRegionSupported(url: URL): boolean {
     if (env.PUBLIC_APPWRITE_MULTI_REGION === 'true') return true;
 
     try {
-        return new URL(getApiEndpoint()).hostname.endsWith('cloud.appwrite.io');
+        return url.hostname.endsWith('cloud.appwrite.io');
     } catch {
         return false;
     }


### PR DESCRIPTION
- uses getApiEndpoint to get the endpoint to consider relative urls