### PR TITLE
Add support for 'appwrite' action type in Synapse and chat components

### DIFF
--- a/src/lib/components/studio/chat/message.svelte
+++ b/src/lib/components/studio/chat/message.svelte
@@ -42,6 +42,7 @@
 
         try {
             const action = item.data;
+            console.log(item)
             switch (action.type) {
                 case 'file':
                     await synapse.dispatch('fs', {
@@ -65,6 +66,18 @@
                         {
                             noReturn: action.content.endsWith('run dev'),
                             timeout: 30_000
+                        }
+                    );
+                    break;
+                case 'appwrite':
+                    await synapse.dispatch(
+                        'appwrite',
+                        {
+                            operation: action.operation,
+                            params: {
+                                service: action.service,
+                                payload: JSON.parse(action.content) ?? {}
+                            }
                         }
                     );
                     break;
@@ -163,6 +176,17 @@
                                     </Typography.Code>
                                 {:else if action.type === 'shell'}
                                     <Typography.Code size="s">{action.content}</Typography.Code>
+                                    <Typography.Code size="s">
+                                        {#if actionInQueue.status === 'waiting'}
+                                            Waiting
+                                        {:else if actionInQueue.status === 'processing'}
+                                            <ShimmerText>Running</ShimmerText>
+                                        {:else if actionInQueue.status === 'done'}
+                                            Finished
+                                        {/if}
+                                    </Typography.Code>
+                                {:else if action.type === 'appwrite'}
+                                    <Typography.Code size="s">{action.type} - {action.service} - {action.operation}</Typography.Code>
                                     <Typography.Code size="s">
                                         {#if actionInQueue.status === 'waiting'}
                                             Waiting

--- a/src/lib/components/studio/chat/parser.ts
+++ b/src/lib/components/studio/chat/parser.ts
@@ -1,6 +1,6 @@
 import { writable, type Readable } from 'svelte/store';
 
-export type ActionType = 'file' | 'shell';
+export type ActionType = 'file' | 'shell' | 'appwrite';
 
 interface Base {
     id: symbol;
@@ -13,6 +13,8 @@ interface Base {
 export interface Action extends Base {
     type: ActionType;
     src?: string;
+    service?: string;
+    operation?: string;
 }
 
 export interface TextChunk extends Base {}
@@ -23,7 +25,7 @@ export interface ActionsContainer extends Base {
 }
 
 export function isActionType(type: string): type is ActionType {
-    return ['file', 'shell'].includes(type);
+    return ['file', 'shell', 'appwrite'].includes(type);
 }
 
 type ParserEvents = 'complete' | 'chunk';
@@ -242,7 +244,9 @@ export class StreamParser {
                                 type,
                                 src: attributes.src,
                                 content: '',
-                                complete: false
+                                complete: false,
+                                service: attributes.service,
+                                operation: attributes.method
                             };
 
                             this.isFirstActionContent = true;

--- a/src/lib/components/studio/synapse.svelte.ts
+++ b/src/lib/components/studio/synapse.svelte.ts
@@ -2,7 +2,7 @@ import { page } from '$app/state';
 import { SvelteURL } from 'svelte/reactivity';
 
 type WebSocketEvent = 'connect' | 'disconnect' | 'reconnect';
-type SynapseMessageType = 'terminal' | 'fs' | 'synapse';
+type SynapseMessageType = 'terminal' | 'fs' | 'synapse' | 'appwrite';
 type SynapseMessageOperations = {
     operation: 'updateWorkDir';
     params: { workDir: string };
@@ -31,6 +31,16 @@ type SynapseMessageOperationFileSystem =
 type SynapseMessageOperationTerminal =
     | { operation: 'updateSize'; params: { cols: number; rows: number } }
     | { operation: 'createCommand'; params: { command: string } };
+
+type SynapseMessageAppwriteOperations = {
+    operation: string;
+    params: {
+        service: string;
+        payload: {
+            [key: string]: string;
+        };
+    };
+};
 
 type Events = WebSocketEvent | SynapseMessageType;
 type BaseMessage = {
@@ -126,6 +136,7 @@ export class Synapse {
             synapse: SynapseMessageOperations;
             fs: SynapseMessageOperationFileSystem;
             terminal: SynapseMessageOperationTerminal;
+            appwrite: SynapseMessageAppwriteOperations;
         }[T],
         options?: {
             timeout?: number;
@@ -133,13 +144,12 @@ export class Synapse {
         }
     ): Promise<BaseMessage> {
         const requestId = String(Date.now().toString() + ++this.requestCounter);
-
         const message = {
             type,
             operation: payload.operation,
             params: payload.params,
             requestId
-        };
+        };  
         const response = new Promise<BaseMessage>((resolve, reject) => {
             const noReturn = options?.noReturn === true;
             const timeout = setTimeout(() => {
@@ -192,7 +202,7 @@ export class Synapse {
     }
 }
 
-export const endpoint = 'wss://terminal.appwrite.torsten.work';
+export const endpoint = 'ws://localhost:3000';
 export function createSynapse(endpoint: string, artifact?: string) {
     const url = new SvelteURL(endpoint);
 

--- a/src/routes/(console)/project-[project]/studio/artifact-[artifact]/+page.svelte
+++ b/src/routes/(console)/project-[project]/studio/artifact-[artifact]/+page.svelte
@@ -10,7 +10,7 @@
     import { SvelteURL } from 'svelte/reactivity';
     import type { EventHandler } from 'svelte/elements';
 
-    let previewUrl = new SvelteURL('https://preview.torsten.work');
+    let previewUrl = new SvelteURL('http://localhost:1234');
 
     let iframeRef: HTMLIFrameElement | null = $state(null);
     $effect(() => {


### PR DESCRIPTION
- Extended SynapseMessageType to include 'appwrite'.
- Introduced SynapseMessageAppwriteOperations for handling appwrite operations.
- Updated chat message handling to process 'appwrite' actions.
- Modified StreamParser to include service and operation attributes for appwrite actions.
- Changed preview URL to localhost for development purposes.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)