### PR TITLE
Fix domain check and max size

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -83,7 +83,7 @@
             // Add domain
             await sdk
                 .forProject(page.params.region, page.params.project)
-                .proxy.createSiteRule(domain, site.$id);
+                .proxy.createSiteRule(`${domain}.${$consoleVariables._APP_DOMAIN_SITES}`, site.$id);
 
             //Add variables
             const promises = variables.map((variable) =>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -42,7 +42,7 @@
     let outputDirectory = adapter?.outputDirectory;
     let variables: Partial<Models.Variable>[] = [];
     let files: FileList;
-    
+
     $: maxSize =
         isCloud && $currentPlan
             ? $currentPlan.deploymentSize * 1000000
@@ -52,7 +52,13 @@
 
     async function create() {
         try {
-            domain = await buildVerboseDomain($consoleVariables._APP_DOMAIN_SITES, name, $organization.name, $project.name, id);
+            domain = await buildVerboseDomain(
+                $consoleVariables._APP_DOMAIN_SITES,
+                name,
+                $organization.name,
+                $project.name,
+                id
+            );
 
             const fr = Object.values(Framework).find((f) => f === framework.key);
             const buildRuntime = Object.values(BuildRuntime).find(


### PR DESCRIPTION
## What does this PR do?

1. Max size was always 10MB:

![CleanShot 2025-05-24 at 23 17 52@2x](https://github.com/user-attachments/assets/1b3c3161-9e58-4493-85f0-fb2ecf254f1c)

2. Domain was always considered valid, but always failed to create rule:

![CleanShot 2025-05-24 at 23 22 37@2x](https://github.com/user-attachments/assets/c9993573-e4b7-4e7b-863e-601bd495ea6e)

![CleanShot 2025-05-24 at 23 26 28@2x](https://github.com/user-attachments/assets/39290c8b-841a-4f08-8c7a-b29ae1aeb7dc)

3. Manual deployment of ~50mb fails to deploy

![CleanShot 2025-05-24 at 23 30 22@2x](https://github.com/user-attachments/assets/7577ed03-7c90-4083-93b9-9017701fed98)

![CleanShot 2025-05-24 at 23 30 25@2x](https://github.com/user-attachments/assets/d591e57b-ad0c-4f08-bf86-e119a4b79490)

## Test Plan

1. Max size now respects env var:
![CleanShot 2025-05-24 at 23 25 28@2x](https://github.com/user-attachments/assets/15e21b31-b619-4d20-b9e3-1b8f3044f5c0)

2. Rule now creates successfully

![CleanShot 2025-05-24 at 23 29 49@2x](https://github.com/user-attachments/assets/29ed1193-a787-4ace-9247-4b2c5214dee9)

3. Manual deployment works no matter size

![CleanShot 2025-05-24 at 23 57 56@2x](https://github.com/user-attachments/assets/5eb5455f-3546-42a8-a28d-03d1f89bd3ec)

![CleanShot 2025-05-24 at 23 58 15@2x](https://github.com/user-attachments/assets/c7c38b9d-0fc3-4186-999f-7d13dfa82dc3)

![CleanShot 2025-05-25 at 00 02 25@2x](https://github.com/user-attachments/assets/22960ac3-bb35-4835-b537-910da0aaf126)


## Related PRs and Issues

https://discord.com/channels/564160730845151244/1375865210279166113

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes