### PR TITLE
fix(support): fix upgrade URL for free organization

### DIFF
--- a/src/lib/components/support.svelte
+++ b/src/lib/components/support.svelte
@@ -27,7 +27,7 @@
         (team) => !$plansInfo.get((team as Organization).billingPlan)?.premiumSupport
     );
 
-    $: upgradeURL = `${base}/organization-${freeOrganization.$id}/change-plan`;
+    $: upgradeURL = `${base}/organization-${freeOrganization?.$id}/change-plan`;
 
     $: supportTimings = `${utcHourToLocaleHour('16:00')} - ${utcHourToLocaleHour('00:00')} ${localeShortTimezoneName()}`;
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Even though upgradeURL isn't used when there are no free orgs, this line is still evaluated and will throw an error because freeOrganization is undefined. This commit adds a null check to prevent this error.

## Test Plan

Manually tested using an org with a Pro org and opened the support popup and wizard.

## Related PRs and Issues

PR for 1.7:

* https://github.com/appwrite/console/pull/1878

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes