### PR TITLE
more explicit disabled cache for /console route in nginx config

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -26,6 +26,10 @@ server {
     location /console {
         index index.html index.html;
         try_files $uri /console/index.html;
+        
+        expires 0;
+        add_header Cache-Control "no-cache, must-revalidate";
+        add_header Pragma no-cache;
     }
 
     location / {


### PR DESCRIPTION
## What does this PR do?

- be more explicit about the no-cache routes

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 