### PR TITLE
Add cache headers for console static assets

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -4,7 +4,6 @@ server {
 
     gzip_static on;
 
-    # Set root for all locations
     root /usr/share/nginx/html;
 
     # Security headers for all locations
@@ -22,11 +21,17 @@ server {
         add_header Cache-Control "public";
     }
 
+    # Cache, but revalidate, for images, css, fonts, and icons folders
+    location ~* ^/console/(images|css|fonts|icons)/ {
+        expires 1d;
+        add_header Cache-Control "public, must-revalidate";
+    }
+
     # All other /console requests (no cache)
     location /console {
         index index.html index.html;
         try_files $uri /console/index.html;
-        
+
         expires 0;
         add_header Cache-Control "no-store";
         add_header Pragma "no-cache";


### PR DESCRIPTION
Configure 1-day caching with revalidation for images, CSS, fonts, and icons in the /console path to improve performance while ensuring freshness.

<img width="614" alt="Bildschirmfoto 2025-05-27 um 15 50 05" src="https://github.com/user-attachments/assets/26eb7e89-7cf2-4f39-bde0-7a31efee8e60" />
