### PR TITLE
fix(functions): remove specification from function runtime settings

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRuntime.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRuntime.svelte
@@ -9,7 +9,6 @@
     import { sdk } from '$lib/stores/sdk';
     import { func } from '../store';
     import InputSelect from '$lib/elements/forms/inputSelect.svelte';
-    import { specificationsList } from '$lib/stores/specifications';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime, type Models } from '@appwrite.io/console';
     import { Layout, Typography } from '@appwrite.io/pink-svelte';
@@ -17,17 +16,11 @@
 
     const functionId = page.params.function;
     export let runtimesList: Models.RuntimeList;
-    let { runtime, entrypoint, specification } = $func;
+    let { runtime, entrypoint } = $func;
 
     const options = runtimesList.runtimes.map((runtime) => ({
         label: `${runtime.name} - ${runtime.version}`,
         value: runtime.$id
-    }));
-    const specificationOptions = $specificationsList.specifications.map((size) => ({
-        label:
-            `${size.cpus} CPU, ${size.memory} MB RAM` +
-            (!size.enabled ? ` (Upgrade to use this)` : ''),
-        value: size.slug
     }));
 
     async function updateRuntime() {
@@ -99,12 +92,6 @@
                     required
                     placeholder="Enter entrypoint"
                     bind:value={entrypoint} />
-                <InputSelect
-                    label="CPU and memory"
-                    id="size"
-                    placeholder="Select runtime specification"
-                    bind:value={specification}
-                    options={specificationOptions} />
             </Layout.Stack>
         </svelte:fragment>
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

There is a separate Resource limits card down the page that allows user to change the runtime specification so there's no need to have it in the Runtime card.

## Test Plan

Manually tested:

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/4145770d-fe27-4075-8e05-e439b9dcd068" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes