### PR TITLE
Fix alerts when wizard is open

### DIFF
--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -2,7 +2,7 @@
     import { beforeNavigate } from '$app/navigation';
     import { Navbar, Sidebar } from '$lib/components';
     import type { NavbarProject } from '$lib/components/navbar.svelte';
-    import { wizard } from '$lib/stores/wizard';
+    import { isNewWizardStatusOpen, wizard } from '$lib/stores/wizard';
     import { activeHeaderAlert } from '$routes/(console)/store';
     import { setContext } from 'svelte';
     import { writable } from 'svelte/store';
@@ -131,7 +131,7 @@
 
 <svelte:window on:resize={handleResize} />
 <svelte:body use:style={$bodyStyle} />
-{#if $activeHeaderAlert?.show}
+{#if $activeHeaderAlert?.show && !$isNewWizardStatusOpen}
     <svelte:component this={$activeHeaderAlert.component} />
 {/if}
 <main

--- a/src/lib/layout/wizard.svelte
+++ b/src/lib/layout/wizard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+    import { goto } from '$app/navigation';
+    import { onDestroy, onMount } from 'svelte';
     import { Layout } from '@appwrite.io/pink-svelte';
     import { trackEvent } from '$lib/actions/analytics';
     import WizardExitModal from './wizardExitModal.svelte';
-    import { goto } from '$app/navigation';
-    import { wizard } from '$lib/stores/wizard';
+    import { isNewWizardStatusOpen, wizard } from '$lib/stores/wizard';
 
     type $$Props =
         | {
@@ -56,6 +57,10 @@
             }
         }
     }
+
+    onMount(() => ($isNewWizardStatusOpen = true));
+
+    onDestroy(() => ($isNewWizardStatusOpen = false));
 </script>
 
 <svelte:window on:keydown={handleKeydown} />

--- a/src/lib/stores/wizard.ts
+++ b/src/lib/stores/wizard.ts
@@ -101,6 +101,8 @@ function createWizardStore() {
 
 export const wizard = createWizardStore();
 
+export const isNewWizardStatusOpen = writable(false);
+
 export function updateStepStatus(map: WizardStepsType, key: number, status: boolean) {
     const updatedComponent = {
         ...map.get(key),

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/finish/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/finish/+page.svelte
@@ -20,8 +20,8 @@
 
     export let data;
 
-    let showConnectRepositry = false;
     let showOpenOnMobile = false;
+    let showConnectRepository = false;
     let showInviteCollaborator = false;
 
     const siteURL = data.proxyRuleList.rules[0].domain;
@@ -31,7 +31,7 @@
             page.url.searchParams.has('connectRepo') &&
             page.url.searchParams.get('connectRepo') === 'true'
         ) {
-            showConnectRepositry = true;
+            showConnectRepository = true;
         }
     });
 
@@ -106,7 +106,7 @@
                             <Card.Button
                                 radius="s"
                                 padding="s"
-                                on:click={() => (showConnectRepositry = true)}>
+                                on:click={() => (showConnectRepository = true)}>
                                 <Layout.Stack gap="s" style="height: 100%">
                                     <Layout.Stack
                                         direction="row"
@@ -206,11 +206,11 @@
     </svelte:fragment>
 </Wizard>
 
-{#if showConnectRepositry}
+{#if showConnectRepository}
     <ConnectRepoModal
-        bind:show={showConnectRepositry}
         {connect}
         product="sites"
+        bind:show={showConnectRepository}
         callbackState={{ connectRepo: 'true' }} />
 {/if}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Alert should not show over wizards and the legacy `$wizard.open` is no longer effective after the Pink2 Wizard integration.

Before -

<img width="1570" alt="Screenshot 2025-05-30 at 7 06 08 PM" src="https://github.com/user-attachments/assets/8bf948ba-a944-4494-82ce-a7f3bf401fa1" />

After -

<img width="1570" alt="Screenshot 2025-05-30 at 7 06 26 PM" src="https://github.com/user-attachments/assets/af16488e-eb65-4ffd-bd0d-133939e5593e" />

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.