### PR TITLE
Only show sidebar padding on project pages

### DIFF
--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -113,7 +113,7 @@
     $: state = $isSidebarOpen ? 'open' : 'closed';
 
     let isProjectPage;
-    $: isProjectPage = $page.url.pathname.includes('project-');
+    $: isProjectPage = $page.route.id.includes('project-');
 
     function handleResize() {
         $isSidebarOpen = false;

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -112,6 +112,9 @@
     let state: undefined | 'open' | 'closed' | 'icons' = 'closed';
     $: state = $isSidebarOpen ? 'open' : 'closed';
 
+    let isProjectPage;
+    $: isProjectPage = $page.url.pathname.includes('project-');
+
     function handleResize() {
         $isSidebarOpen = false;
         showAccountMenu = false;
@@ -156,7 +159,7 @@
     <div
         class="content"
         class:has-transition={showContentTransition}
-        class:icons-content={state === 'icons'}
+        class:icons-content={state === 'icons' && isProjectPage}
         class:no-sidebar={!showSideNavigation}>
         <section class="main-content" data-test={showSideNavigation}>
             {#if $page.data?.header}

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -113,7 +113,7 @@
     $: state = $isSidebarOpen ? 'open' : 'closed';
 
     let isProjectPage;
-    $: isProjectPage = $page.route?.id.includes('project-');
+    $: isProjectPage = $page.route?.id?.includes('project-');
 
     function handleResize() {
         $isSidebarOpen = false;

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -113,7 +113,7 @@
     $: state = $isSidebarOpen ? 'open' : 'closed';
 
     let isProjectPage;
-    $: isProjectPage = $page.route.id.includes('project-');
+    $: isProjectPage = $page.route?.id.includes('project-');
 
     function handleResize() {
         $isSidebarOpen = false;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Remove the unwanted padding when not on a project related page.

Before (watch the footer padding):
<img width="449" alt="image" src="https://github.com/user-attachments/assets/e370afb5-c97c-4234-82d8-06fbe5dde8f7" />

After:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/43902fab-d73a-40e9-af3f-ba5b4066b090" />


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
