### PR TITLE
fix: refresh payment methods after user adds a payment method

### DIFF
--- a/src/routes/(console)/apply-credit/+page.svelte
+++ b/src/routes/(console)/apply-credit/+page.svelte
@@ -255,6 +255,14 @@
             })();
         }
     }
+
+    // after adding a payment method, fetch the payment methods again so the input can be updated
+    $: if (
+        paymentMethodId &&
+        !methods?.paymentMethods?.find((method) => method.$id === paymentMethodId)
+    ) {
+        loadPaymentMethods();
+    }
 </script>
 
 <svelte:head>


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If methods doesn't include the paymentMethodId, the Payment method input will show "No saved payment methods".

Since paymentMethodId gets set after a user adds their payment method, we can listen for when it's set and fetch the methods if the newly added payment method isn't in the original list of payment methods.

## Test Plan

Tested adding a payment method on the /console/apply-credit page

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes