### PR TITLE
Fix: Updated incorrect path mentioned for updating configuration settings in Android starter guide

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createAndroid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createAndroid.svelte
@@ -172,7 +172,7 @@ const val APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.region, page.
                         <Typography.Text variant="m-500"
                             >2. Open the file <InlineCode
                                 size="s"
-                                code="data/repository/AppwriteRepository.kt" /> and update the configuration
+                                code="constants/AppwriteConfig.kt" /> and update the configuration
                             settings.</Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->


### PR DESCRIPTION

## What does this PR do?

This PR corrects an inconsistency in the Android SDK setup instructions shown in the Appwrite Console.

### Problem

The current instructions direct users to update configuration settings inside the following file: `data/repository/AppwriteRepository.kt`. 
However, the configuration settings have since been refactored and are now located in: `constants/AppwriteConfig.kt` file. And are referenced inside AppwriteRepository.kt via `.setProject(AppwriteConfig.APPWRITE_PROJECT_ID)`

### Fix

Updated the setup guide to point users to the correct file (AppwriteConfig.kt).

### Screenshot: Actual location of all the configuration settings in `constants/AppwriteConfig.kt`
![image](https://github.com/user-attachments/assets/bb0569de-1683-4b45-b92e-cf8eb03c4221)


## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues]

Yes

> I didn’t raise an issue separately since this is a minor fix, but I’m happy to open one if needed.