### PR TITLE
Fix Flutter web platform creation

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createFlutter.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createFlutter.svelte
@@ -115,9 +115,11 @@ static const String APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.reg
                 projectId,
                 platform,
                 $createPlatform.name,
-                $createPlatform.key || undefined,
+                platform === PlatformType.Flutterweb ? undefined : $createPlatform.key || undefined,
                 undefined,
-                undefined
+                platform === PlatformType.Flutterweb
+                    ? $createPlatform.hostname || undefined
+                    : undefined
             );
 
             isPlatformCreated = true;
@@ -189,19 +191,35 @@ static const String APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.reg
                                 bind:value={$createPlatform.name} />
 
                             <!-- Tooltips on InputText don't work as of now -->
-                            <InputText
-                                id="hostname"
-                                label={hostname[platform]}
-                                placeholder={placeholder[platform].hostname}
-                                required
-                                bind:value={$createPlatform.key}>
-                                <Tooltip slot="info" maxWidth="15rem">
-                                    <Icon icon={IconInfo} size="s" />
-                                    <Typography.Caption variant="400" slot="tooltip">
-                                        {placeholder[platform].tooltip}
-                                    </Typography.Caption>
-                                </Tooltip>
-                            </InputText>
+                            {#if platform === PlatformType.Flutterweb}
+                                <InputText
+                                    id="hostname"
+                                    label={hostname[platform]}
+                                    placeholder={placeholder[platform].hostname}
+                                    required
+                                    bind:value={$createPlatform.hostname}>
+                                    <Tooltip slot="info" maxWidth="15rem">
+                                        <Icon icon={IconInfo} size="s" />
+                                        <Typography.Caption variant="400" slot="tooltip">
+                                            {placeholder[platform].tooltip}
+                                        </Typography.Caption>
+                                    </Tooltip>
+                                </InputText>
+                            {:else}
+                                <InputText
+                                    id="key"
+                                    label={hostname[platform]}
+                                    placeholder={placeholder[platform].hostname}
+                                    required
+                                    bind:value={$createPlatform.key}>
+                                    <Tooltip slot="info" maxWidth="15rem">
+                                        <Icon icon={IconInfo} size="s" />
+                                        <Typography.Caption variant="400" slot="tooltip">
+                                            {placeholder[platform].tooltip}
+                                        </Typography.Caption>
+                                    </Tooltip>
+                                </InputText>
+                            {/if}
                         </Layout.Stack>
 
                         <Button
@@ -212,7 +230,7 @@ static const String APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.reg
                             submissionLoader={isCreatingPlatform}
                             disabled={!platform ||
                                 !$createPlatform.name ||
-                                !$createPlatform.key ||
+                                (!$createPlatform.key && !$createPlatform.hostname) ||
                                 isCreatingPlatform}>
                             Create platform
                         </Button>


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Use `hostname` instead of `key` for Flutter web platform creation.

## Test Plan

Tested manually and confirmed the hostname was sent

![Screenshot 2025-06-10 at 17 39 48](https://github.com/user-attachments/assets/112f370f-1dd3-4616-b3d0-b466828aa764)

Also confirmed non-web still works:

![Screenshot 2025-06-10 at 17 45 12](https://github.com/user-attachments/assets/81bbc977-77a7-4791-b02c-e7e913b97847)


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes