### PR TITLE
Fix: platform wizard copies

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createAndroid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createAndroid.svelte
@@ -160,8 +160,8 @@ const val APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.region, page.
                 <Fieldset legend="Clone starter">
                     <Layout.Stack gap="l">
                         <Typography.Text variant="m-500">
-                            1. Clone the starter kit from GitHub using the terminal or Android
-                            Studio.
+                            1. If you're starting a new project, you can clone our starter kit from
+                            GitHub using the terminal, VSCode or Android Studio.
                         </Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createApple.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createApple.svelte
@@ -186,7 +186,8 @@ APPWRITE_PUBLIC_ENDPOINT: "${sdk.forProject(page.params.region, page.params.proj
                 <Fieldset legend="Clone starter">
                     <Layout.Stack gap="l">
                         <Typography.Text variant="m-500">
-                            1. Clone the starter kit from GitHub using the terminal or XCode.
+                            1. If you're starting a new project, you can clone our starter kit from
+                            GitHub using the terminal or XCode.
                         </Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createFlutter.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createFlutter.svelte
@@ -260,8 +260,8 @@ static const String APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.reg
                 <Fieldset legend="Clone starter">
                     <Layout.Stack gap="l">
                         <Typography.Text variant="m-500">
-                            1. Clone the starter kit from GitHub using the terminal, Android Studio
-                            or VSCode.
+                            1. If you're starting a new project, you can clone our starter kit from
+                            GitHub using the terminal, VSCode or Android Studio.
                         </Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
@@ -25,7 +25,6 @@
     import ConnectionLine from './components/ConnectionLine.svelte';
     import OnboardingPlatformCard from './components/OnboardingPlatformCard.svelte';
     import { PlatformType } from '@appwrite.io/console';
-    import { isCloud } from '$lib/system';
 
     let showExitModal = false;
     let isPlatformCreated = false;
@@ -36,9 +35,7 @@
     const gitCloneCode =
         '\ngit clone https://github.com/appwrite/starter-for-react-native\ncd starter-for-react-native\n';
 
-    const updateConfigCode = isCloud
-        ? `const APPWRITE_PROJECT_ID = "${projectId}";`
-        : `const APPWRITE_PROJECT_ID = "${projectId}";
+    const updateConfigCode = `const APPWRITE_PROJECT_ID = "${projectId}";
 const APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}";
         `;
 
@@ -212,7 +209,8 @@ const APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.region, page.para
                 <Fieldset legend="Clone starter">
                     <Layout.Stack gap="l">
                         <Typography.Text variant="m-500">
-                            1. Clone the starter kit from GitHub using the terminal or VSCode.
+                            1. If you're starting a new project, you can clone our starter kit from
+                            GitHub using the terminal or VSCode.
                         </Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
@@ -221,9 +219,11 @@ const APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.region, page.para
                         </div>
 
                         <Typography.Text variant="m-500"
-                            >2. Open the file <InlineCode
+                            >2. Add your Appwrite credentials to <InlineCode
                                 size="s"
-                                code="lib/constants/appwrite.js" /> and update the configuration settings.</Typography.Text>
+                                code=".env.example" /> then rename it to <InlineCode
+                                size="s"
+                                code=".env" /> if needed.</Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
                         <div class="pink2-code-margin-fix">

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
@@ -35,8 +35,8 @@
     const gitCloneCode =
         '\ngit clone https://github.com/appwrite/starter-for-react-native\ncd starter-for-react-native\n';
 
-    const updateConfigCode = `const APPWRITE_PROJECT_ID = "${projectId}";
-const APPWRITE_PUBLIC_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}";
+    const updateConfigCode = `const EXPO_PUBLIC_APPWRITE_PROJECT_ID = "${projectId}";
+const EXPO_PUBLIC_APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}";
         `;
 
     export let platform: PlatformType = PlatformType.Reactnativeandroid;

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
@@ -274,7 +274,8 @@ ${prefix}APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.p
                 <Fieldset legend="Clone starter">
                     <Layout.Stack gap="l">
                         <Typography.Text variant="m-500">
-                            1. Clone the starter kit from GitHub using the terminal or VSCode.
+                            1. If you're starting a new project, you can clone our starter kit from
+                            GitHub using the terminal or VSCode.
                         </Typography.Text>
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
@@ -293,9 +294,11 @@ ${prefix}APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.p
                                 to reflect the values below:</Typography.Text>
                         {:else}
                             <Typography.Text variant="m-500"
-                                >2. Rename <InlineCode size="s" code=".env.example" /> into <InlineCode
+                                >2. Add your Appwrite credentials to <InlineCode
                                     size="s"
-                                    code=".env" /> and update the values.</Typography.Text>
+                                    code=".env.example" /> then rename it to <InlineCode
+                                    size="s"
+                                    code=".env" /> if needed.</Typography.Text>
                         {/if}
 
                         <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Improves the copy in the platform wizard to clarify when to clone the repository, and updates the `.env` instructions in the Web and React Native flows to avoid confusion.

React Native -

![react-native](https://github.com/user-attachments/assets/f1c6460a-aad4-436e-99e1-f8c9f167c38e)

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.