### PR TITLE
Fix: Breadcrumbs not updated

### DIFF
--- a/src/lib/components/breadcrumbs.svelte
+++ b/src/lib/components/breadcrumbs.svelte
@@ -190,83 +190,107 @@
         $currentPlan?.name.toLocaleLowerCase() !== selectedOrg?.tierName.toLocaleLowerCase()
             ? $currentPlan.name
             : selectedOrg?.tierName; // fallback
+
+    $: derivedKey = `${selectedOrg?.$id}-${selectedProject?.$id}`;
 </script>
 
 <svelte:window on:resize={onResize} />
-<div use:melt={$menubar}>
-    {#if !$isSmallViewport}
-        <span class="breadcrumb-separator">/</span>
-        <button
-            type="button"
-            class="trigger"
-            use:melt={$triggerOrganizations}
-            aria-label="Open organizations tab">
-            <span class="orgName">{selectedOrg?.name ?? 'Organization'}</span>
-            <span class="not-mobile"
-                >{#if correctPlanName}<Badge
-                        variant="secondary"
-                        content={correctPlanName} />{/if}</span>
-            <Icon icon={IconChevronDown} size="s" color="--fgcolor-neutral-secondary" />
-        </button>
-    {:else}
-        <button
-            type="button"
-            class="trigger"
-            on:click={() => {
-                organisationBottomSheetOpen = true;
-            }}
-            aria-label="Open organizations tab">
-            <span class="orgName" class:noProjects={!selectedProject}
-                >{selectedOrg?.name ?? 'Organization'}</span>
-            <span class="not-mobile"
-                ><Badge variant="secondary" content={correctPlanName ?? ''} /></span>
-            <Icon icon={IconChevronDown} size="s" color="--fgcolor-neutral-secondary" />
-        </button>
-    {/if}
 
-    <div class="menu" use:melt={$menuOrganizations}>
-        <Card.Base padding="xxxs" shadow={true}>
-            {#if selectedOrg}
-                <div use:melt={$itemOrganizations}>
-                    <ActionMenu.Root>
-                        <ActionMenu.Item.Anchor href={`${base}/organization-${selectedOrg?.$id}`}
-                            >Organization overview</ActionMenu.Item.Anchor
-                        ></ActionMenu.Root>
-                </div>
-                {#if organizations.length > 1}
-                    <div class="separator" use:melt={$separatorOrganizations}></div>
+{#key derivedKey}
+    <div use:melt={$menubar}>
+        {#if !$isSmallViewport}
+            <span class="breadcrumb-separator">/</span>
+            <button
+                type="button"
+                class="trigger"
+                use:melt={$triggerOrganizations}
+                aria-label="Open organizations tab">
+                <span class="orgName">{selectedOrg?.name ?? 'Organization'}</span>
+                <span class="not-mobile"
+                    >{#if correctPlanName}<Badge
+                            variant="secondary"
+                            content={correctPlanName} />{/if}</span>
+                <Icon icon={IconChevronDown} size="s" color="--fgcolor-neutral-secondary" />
+            </button>
+        {:else}
+            <button
+                type="button"
+                class="trigger"
+                on:click={() => {
+                    organisationBottomSheetOpen = true;
+                }}
+                aria-label="Open organizations tab">
+                <span class="orgName" class:noProjects={!selectedProject}
+                    >{selectedOrg?.name ?? 'Organization'}</span>
+                <span class="not-mobile"
+                    ><Badge variant="secondary" content={correctPlanName ?? ''} /></span>
+                <Icon icon={IconChevronDown} size="s" color="--fgcolor-neutral-secondary" />
+            </button>
+        {/if}
 
-                    <div use:melt={$subTriggerOrganizations}>
+        <div class="menu" use:melt={$menuOrganizations}>
+            <Card.Base padding="xxxs" shadow={true}>
+                {#if selectedOrg}
+                    <div use:melt={$itemOrganizations}>
                         <ActionMenu.Root>
-                            <ActionMenu.Item.Button trailingIcon={IconChevronRight}
-                                >Switch organization</ActionMenu.Item.Button>
-                        </ActionMenu.Root>
+                            <ActionMenu.Item.Anchor
+                                href={`${base}/organization-${selectedOrg?.$id}`}
+                                >Organization overview</ActionMenu.Item.Anchor
+                            ></ActionMenu.Root>
                     </div>
-                    <div class="menu subMenu" use:melt={$subMenuOrganizations}>
-                        <Card.Base padding="xxxs" shadow={true}>
-                            <div use:melt={$radioGroupOrganizations}>
-                                {#each organizations as organization}
+                    {#if organizations.length > 1}
+                        <div class="separator" use:melt={$separatorOrganizations}></div>
+
+                        <div use:melt={$subTriggerOrganizations}>
+                            <ActionMenu.Root>
+                                <ActionMenu.Item.Button trailingIcon={IconChevronRight}
+                                    >Switch organization</ActionMenu.Item.Button>
+                            </ActionMenu.Root>
+                        </div>
+                        <div class="menu subMenu" use:melt={$subMenuOrganizations}>
+                            <Card.Base padding="xxxs" shadow={true}>
+                                <div use:melt={$radioGroupOrganizations}>
+                                    {#each organizations as organization}
+                                        <div use:melt={$itemOrganizations}>
+                                            <ActionMenu.Root>
+                                                <ActionMenu.Item.Anchor
+                                                    href={`${base}/organization-${organization?.$id}`}
+                                                    >{organization.name}</ActionMenu.Item.Anchor>
+                                            </ActionMenu.Root>
+                                        </div>
+                                    {/each}
+                                    <div class="separator" use:melt={$separatorOrganizations}></div>
                                     <div use:melt={$itemOrganizations}>
                                         <ActionMenu.Root>
-                                            <ActionMenu.Item.Anchor
-                                                href={`${base}/organization-${organization?.$id}`}
-                                                >{organization.name}</ActionMenu.Item.Anchor>
-                                        </ActionMenu.Root>
+                                            <ActionMenu.Item.Button
+                                                leadingIcon={IconPlusSm}
+                                                on:click={createOrg}
+                                                >Create organization</ActionMenu.Item.Button
+                                            ></ActionMenu.Root>
                                     </div>
-                                {/each}
-                                <div class="separator" use:melt={$separatorOrganizations}></div>
-                                <div use:melt={$itemOrganizations}>
-                                    <ActionMenu.Root>
-                                        <ActionMenu.Item.Button
-                                            leadingIcon={IconPlusSm}
-                                            on:click={createOrg}
-                                            >Create organization</ActionMenu.Item.Button
-                                        ></ActionMenu.Root>
                                 </div>
-                            </div>
-                        </Card.Base>
-                    </div>
+                            </Card.Base>
+                        </div>
+                    {:else}
+                        <div class="separator" use:melt={$separatorOrganizations}></div>
+                        <div use:melt={$itemOrganizations}>
+                            <ActionMenu.Root>
+                                <ActionMenu.Item.Button
+                                    leadingIcon={IconPlusSm}
+                                    on:click={createOrg}>Create organization</ActionMenu.Item.Button
+                                ></ActionMenu.Root>
+                        </div>
+                    {/if}
                 {:else}
+                    {#each organizations as organization}
+                        <div use:melt={$itemOrganizations}>
+                            <ActionMenu.Root>
+                                <ActionMenu.Item.Anchor
+                                    href={`${base}/organization-${organization?.$id}`}
+                                    >{organization.name}</ActionMenu.Item.Anchor
+                                ></ActionMenu.Root>
+                        </div>
+                    {/each}
                     <div class="separator" use:melt={$separatorOrganizations}></div>
                     <div use:melt={$itemOrganizations}>
                         <ActionMenu.Root>
@@ -275,89 +299,74 @@
                             ></ActionMenu.Root>
                     </div>
                 {/if}
-            {:else}
-                {#each organizations as organization}
-                    <div use:melt={$itemOrganizations}>
-                        <ActionMenu.Root>
-                            <ActionMenu.Item.Anchor
-                                href={`${base}/organization-${organization?.$id}`}
-                                >{organization.name}</ActionMenu.Item.Anchor
-                            ></ActionMenu.Root>
-                    </div>
-                {/each}
-                <div class="separator" use:melt={$separatorOrganizations}></div>
-                <div use:melt={$itemOrganizations}>
-                    <ActionMenu.Root>
-                        <ActionMenu.Item.Button leadingIcon={IconPlusSm} on:click={createOrg}
-                            >Create organization</ActionMenu.Item.Button
-                        ></ActionMenu.Root>
-                </div>
-            {/if}
-        </Card.Base>
-    </div>
-
-    {#if selectedOrg && selectedProject}
-        <span class="breadcrumb-separator">/</span>
-        {#if !$isSmallViewport}
-            <button
-                type="button"
-                class="trigger"
-                use:melt={$triggerProjects}
-                aria-label="Open projects tab">
-                <span class="projectName">{selectedProject.name}</span>
-                <Icon icon={IconChevronDown} size="s" />
-            </button>
-        {:else}
-            <button
-                type="button"
-                class="trigger"
-                on:click={() => (projectsBottomSheetOpen = true)}
-                aria-label="Open projects tab">
-                <span class="projectName">{selectedProject.name}</span>
-                <Icon icon={IconChevronDown} size="s" />
-            </button>
-        {/if}
-
-        <div class="menu" use:melt={$menuProjects}>
-            <Card.Base padding="xxxs" shadow={true}>
-                {#if selectedOrg.projects.length > 1}
-                    {#each selectedOrg.projects as project, index}
-                        {#if index < 4}
-                            <div use:melt={$itemProjects}>
-                                <ActionMenu.Root>
-                                    <ActionMenu.Item.Anchor
-                                        href={`${base}/project-${project.region}-${project.$id}`}>
-                                        {project.name}
-                                    </ActionMenu.Item.Anchor>
-                                </ActionMenu.Root>
-                            </div>
-                        {:else if index === 4}
-                            <div use:melt={$itemProjects}>
-                                <ActionMenu.Root>
-                                    <ActionMenu.Item.Anchor
-                                        href={`${base}/organization-${selectedOrg.$id}`}>
-                                        All projects
-                                    </ActionMenu.Item.Anchor>
-                                </ActionMenu.Root>
-                            </div>
-                        {/if}
-                    {/each}
-                    <div class="separator" use:melt={$separatorProjects}></div>
-                {/if}
-                <div use:melt={$itemProjects}>
-                    <ActionMenu.Root>
-                        <ActionMenu.Item.Anchor
-                            leadingIcon={IconPlusSm}
-                            href={`${base}/organization-${selectedOrg?.$id}?create-project`}>
-                            Create project
-                        </ActionMenu.Item.Anchor></ActionMenu.Root>
-                </div>
             </Card.Base>
         </div>
-    {/if}
-</div>
-<BottomSheet.Menu bind:isOpen={organisationBottomSheetOpen} menu={organizationsBottomSheet} />
-<BottomSheet.Menu bind:isOpen={projectsBottomSheetOpen} menu={projectsBottomSheet} />
+
+        {#if selectedOrg && selectedProject}
+            <span class="breadcrumb-separator">/</span>
+            {#if !$isSmallViewport}
+                <button
+                    type="button"
+                    class="trigger"
+                    use:melt={$triggerProjects}
+                    aria-label="Open projects tab">
+                    <span class="projectName">{selectedProject.name}</span>
+                    <Icon icon={IconChevronDown} size="s" />
+                </button>
+            {:else}
+                <button
+                    type="button"
+                    class="trigger"
+                    on:click={() => (projectsBottomSheetOpen = true)}
+                    aria-label="Open projects tab">
+                    <span class="projectName">{selectedProject.name}</span>
+                    <Icon icon={IconChevronDown} size="s" />
+                </button>
+            {/if}
+
+            <div class="menu" use:melt={$menuProjects}>
+                <Card.Base padding="xxxs" shadow={true}>
+                    {#if selectedOrg.projects.length > 1}
+                        {#each selectedOrg.projects as project, index}
+                            {#if index < 4}
+                                <div use:melt={$itemProjects}>
+                                    <ActionMenu.Root>
+                                        <ActionMenu.Item.Anchor
+                                            href={`${base}/project-${project.region}-${project.$id}`}>
+                                            {project.name}
+                                        </ActionMenu.Item.Anchor>
+                                    </ActionMenu.Root>
+                                </div>
+                            {:else if index === 4}
+                                <div use:melt={$itemProjects}>
+                                    <ActionMenu.Root>
+                                        <ActionMenu.Item.Anchor
+                                            href={`${base}/organization-${selectedOrg.$id}`}>
+                                            All projects
+                                        </ActionMenu.Item.Anchor>
+                                    </ActionMenu.Root>
+                                </div>
+                            {/if}
+                        {/each}
+                        <div class="separator" use:melt={$separatorProjects}></div>
+                    {/if}
+                    <div use:melt={$itemProjects}>
+                        <ActionMenu.Root>
+                            <ActionMenu.Item.Anchor
+                                leadingIcon={IconPlusSm}
+                                href={`${base}/organization-${selectedOrg?.$id}?create-project`}>
+                                Create project
+                            </ActionMenu.Item.Anchor></ActionMenu.Root>
+                    </div>
+                </Card.Base>
+            </div>
+        {/if}
+    </div>
+
+    <BottomSheet.Menu bind:isOpen={organisationBottomSheetOpen} menu={organizationsBottomSheet} />
+
+    <BottomSheet.Menu bind:isOpen={projectsBottomSheetOpen} menu={projectsBottomSheet} />
+{/key}
 
 <style lang="scss">
     .menu {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where switching projects via the navbar, then navigating to the organization overview and back to a project would cause the projects menubar to disappear. This PR ensures the menubar renders correctly in this flow.

**Probable cause:** When navigating to the organization and then to a project, the `selectedProject` store could temporarily be `null`, which prevented the component from re-rendering. Wrapping the component in a `#key` block resolved the issue.

## Test Plan

Manual. See -

<video src="https://github.com/user-attachments/assets/662955a9-4fff-4f3a-89f0-93c7a1be160f" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.