### PR TITLE
Fix: leaking realtime event

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploying/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploying/+page.svelte
@@ -17,8 +17,8 @@
 
     let deployment = $state(data.deployment);
 
-    onMount(async () => {
-        sdk.forConsole.client.subscribe(
+    onMount(() => {
+        return sdk.forConsole.client.subscribe(
             'console',
             async (response: RealtimeResponseEvent<Models.Deployment>) => {
                 if (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Realtime wasn't closed so it kept observing the build stat for the deployment even after navigating to other page.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.