### PR TITLE
fix-PRO-1949: Fix .env values in platform creation screen to follow e…

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
@@ -35,9 +35,10 @@
     const gitCloneCode =
         '\ngit clone https://github.com/appwrite/starter-for-react-native\ncd starter-for-react-native\n';
 
-    const updateConfigCode = `const EXPO_PUBLIC_APPWRITE_PROJECT_ID = "${projectId}";
-const EXPO_PUBLIC_APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}";
-        `;
+    const updateConfigCode = (
+        prefix: string
+    ) => `${prefix}EXPO_PUBLIC_APPWRITE_PROJECT_ID=${projectId}
+${prefix}EXPO_PUBLIC_APPWRITE_ENDPOINT=${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}`;
 
     export let platform: PlatformType = PlatformType.Reactnativeandroid;
 
@@ -232,7 +233,7 @@ const EXPO_PUBLIC_APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page
 
                     <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
                     <div class="pink2-code-margin-fix">
-                        <Code lang="javascript" lineNumbers code={updateConfigCode} />
+                        <Code lang="bash" lineNumbers code={updateConfigCode('')} />
                     </div>
 
                     <Typography.Text variant="m-500"

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
@@ -35,7 +35,7 @@
     const gitCloneCode =
         '\ngit clone https://github.com/appwrite/starter-for-react-native\ncd starter-for-react-native\n';
 
-    const updateConfigCode = () => `EXPO_PUBLIC_APPWRITE_PROJECT_ID=${projectId}
+    const updateConfigCode = `EXPO_PUBLIC_APPWRITE_PROJECT_ID=${projectId}
 EXPO_PUBLIC_APPWRITE_ENDPOINT=${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}`;
 
     export let platform: PlatformType = PlatformType.Reactnativeandroid;
@@ -231,7 +231,7 @@ EXPO_PUBLIC_APPWRITE_ENDPOINT=${sdk.forProject(page.params.region, page.params.p
 
                     <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
                     <div class="pink2-code-margin-fix">
-                        <Code lang="bash" lineNumbers code={updateConfigCode()} />
+                        <Code lang="dotenv" lineNumbers code={updateConfigCode} />
                     </div>
 
                     <Typography.Text variant="m-500"

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createReactNative.svelte
@@ -35,10 +35,8 @@
     const gitCloneCode =
         '\ngit clone https://github.com/appwrite/starter-for-react-native\ncd starter-for-react-native\n';
 
-    const updateConfigCode = (
-        prefix: string
-    ) => `${prefix}EXPO_PUBLIC_APPWRITE_PROJECT_ID=${projectId}
-${prefix}EXPO_PUBLIC_APPWRITE_ENDPOINT=${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}`;
+    const updateConfigCode = () => `EXPO_PUBLIC_APPWRITE_PROJECT_ID=${projectId}
+EXPO_PUBLIC_APPWRITE_ENDPOINT=${sdk.forProject(page.params.region, page.params.project).client.config.endpoint}`;
 
     export let platform: PlatformType = PlatformType.Reactnativeandroid;
 
@@ -233,7 +231,7 @@ ${prefix}EXPO_PUBLIC_APPWRITE_ENDPOINT=${sdk.forProject(page.params.region, page
 
                     <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
                     <div class="pink2-code-margin-fix">
-                        <Code lang="bash" lineNumbers code={updateConfigCode('')} />
+                        <Code lang="bash" lineNumbers code={updateConfigCode()} />
                     </div>
 
                     <Typography.Text variant="m-500"

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
@@ -302,7 +302,7 @@ ${prefix}APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.p
 
                     <!-- Temporary fix: Remove this div once Code splitting issue with stack spacing is resolved -->
                     <div class="pink2-code-margin-fix">
-                        <Code lang="bash" lineNumbers code={selectedFramework.updateConfigCode} />
+                        <Code lang="dotenv" lineNumbers code={selectedFramework.updateConfigCode} />
                     </div>
 
                     <Typography.Text variant="m-500"


### PR DESCRIPTION
…nv format

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!
-->

## What does this PR do?

This PR fixes the formatting of `.env` values shown in the **platform creation screen**.  
Previously, environment variables were not displayed in proper `.env` format (`KEY=value`).  
This fix ensures the format adheres to `.env` standards, improving copy-paste usability and consistency.

## Test Plan

- Manually navigated to the platform creation screen
- Verified that environment variable values are shown in correct `KEY=value` format
- Confirmed that changes do not break layout or logic

## Related PRs and Issues


Closes PRO-1949

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes ✅
