### PR TITLE
Fix: cross-region deployment preview screenshots

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
@@ -3,6 +3,7 @@
     import { humanFileSize } from '$lib/helpers/sizeConvertion';
     import { formatTimeDetailed } from '$lib/helpers/timeConversion';
     import type { Models } from '@appwrite.io/console';
+    import { page } from '$app/state';
     import {
         Badge,
         Divider,
@@ -45,7 +46,10 @@
     }
 
     function getFilePreview(fileId: string) {
-        return sdk.forConsole.storage.getFileView('screenshots', fileId);
+        // Project SDK with `console` project ID = Console SDK with region prefix
+        return sdk
+            .forProject(page.params.region, 'console')
+            .storage.getFileView('screenshots', fileId);
     }
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
@@ -46,10 +46,7 @@
     }
 
     function getFilePreview(fileId: string) {
-        // Project SDK with `console` project ID = Console SDK with region prefix
-        return sdk
-            .forProject(page.params.region, 'console')
-            .storage.getFileView('screenshots', fileId);
+        return sdk.forConsoleIn(page.params.region).storage.getFileView('screenshots', fileId);
     }
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
@@ -33,7 +33,10 @@
     }
 
     function getFilePreview(fileId: string) {
-        return sdk.forConsole.storage.getFileView('screenshots', fileId);
+        // Project SDK with `console` project ID = Console SDK with region prefix
+        return sdk
+            .forProject(page.params.region, 'console')
+            .storage.getFileView('screenshots', fileId);
     }
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
@@ -33,10 +33,7 @@
     }
 
     function getFilePreview(fileId: string) {
-        // Project SDK with `console` project ID = Console SDK with region prefix
-        return sdk
-            .forProject(page.params.region, 'console')
-            .storage.getFileView('screenshots', fileId);
+        return sdk.forConsoleIn(page.params.region).storage.getFileView('screenshots', fileId);
     }
 </script>
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes previews showing missing image (because screenshot storage is region-specific)

## Test Plan

- [x] manual QA:

Before:

![CleanShot 2025-06-26 at 11 27 11@2x](https://github.com/user-attachments/assets/5e51b5ed-42f3-4a12-8447-6d86cf819b94)

![CleanShot 2025-06-26 at 11 27 17@2x](https://github.com/user-attachments/assets/57c1ab5c-f1c5-42b6-a2ee-167f9b397a74)

After:

![CleanShot 2025-06-26 at 12 09 29@2x](https://github.com/user-attachments/assets/51145fb5-d7fa-4871-aede-dc84a7289945)


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes