### PR TITLE
fix: resolve file deletion navigation issue and improve delete modal

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
@@ -169,7 +169,15 @@
                         </Table.Cell>
                         <Table.Cell column="actions" {root}>
                             <Popover let:toggle placement="bottom-start" padding="none">
-                                <Button text icon ariaLabel="more options" on:click={toggle}>
+                                <Button
+                                    text
+                                    icon
+                                    ariaLabel="more options"
+                                    on:click={(e) => {
+                                        e.stopPropagation();
+                                        e.preventDefault();
+                                        toggle();
+                                    }}>
                                     <Icon icon={IconDotsHorizontal} size="s" />
                                 </Button>
                                 <ActionMenu.Root slot="tooltip">
@@ -178,7 +186,9 @@
                                     </ActionMenu.Item.Anchor>
                                     <ActionMenu.Item.Button
                                         leadingIcon={IconTrash}
-                                        on:click={() => {
+                                        on:click={(e) => {
+                                            e.stopPropagation();
+                                            e.preventDefault();
                                             selectedFile = file;
                                             showDelete = true;
                                         }}>

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/deleteFile.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/deleteFile.svelte
@@ -6,8 +6,6 @@
     import { createEventDispatcher } from 'svelte';
     import { page } from '$app/state';
     import type { Models } from '@appwrite.io/console';
-    import { calculateSize } from '$lib/helpers/sizeConvertion';
-    import { Typography, Layout } from '@appwrite.io/pink-svelte';
 
     export let file: Models.File;
     export let showDelete = false;
@@ -34,30 +32,5 @@
 </script>
 
 <Confirm {onSubmit} title="Delete file" bind:open={showDelete} bind:error>
-    <Layout.Stack gap="l">
-        <Typography.Text variant="m-400">
-            Are you sure you want to delete the following file?
-        </Typography.Text>
-
-        <div
-            class="u-flex u-flex-wrap u-gap-8 u-main-space-between u-cross-center u-padding-16 u-border u-radius">
-            <Layout.Stack gap="xs">
-                <Typography.Text variant="m-600" data-private>{file.name}</Typography.Text>
-                <Layout.Stack direction="row" gap="s" alignItems="center">
-                    <Typography.Text variant="m-400" class="u-color-text-secondary">
-                        {file.mimeType}
-                    </Typography.Text>
-                    <span class="u-color-text-secondary">•</span>
-                    <Typography.Text variant="m-400" class="u-color-text-secondary">
-                        {calculateSize(file.sizeOriginal)}
-                    </Typography.Text>
-                </Layout.Stack>
-            </Layout.Stack>
-        </div>
-
-        <Typography.Text variant="m-400" class="u-color-text-secondary">
-            This action cannot be undone. The file will be permanently deleted from your storage
-            bucket.
-        </Typography.Text>
-    </Layout.Stack>
+    <p>Are you sure you want to delete <b>{file.name}</b>?</p>
 </Confirm>

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/deleteFile.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/deleteFile.svelte
@@ -6,6 +6,8 @@
     import { createEventDispatcher } from 'svelte';
     import { page } from '$app/state';
     import type { Models } from '@appwrite.io/console';
+    import { calculateSize } from '$lib/helpers/sizeConvertion';
+    import { Typography, Layout } from '@appwrite.io/pink-svelte';
 
     export let file: Models.File;
     export let showDelete = false;
@@ -32,5 +34,30 @@
 </script>
 
 <Confirm {onSubmit} title="Delete file" bind:open={showDelete} bind:error>
-    Are you sure you want to delete <b>{file.name}</b>?
+    <Layout.Stack gap="l">
+        <Typography.Text variant="m-400">
+            Are you sure you want to delete the following file?
+        </Typography.Text>
+
+        <div
+            class="u-flex u-flex-wrap u-gap-8 u-main-space-between u-cross-center u-padding-16 u-border u-radius">
+            <Layout.Stack gap="xs">
+                <Typography.Text variant="m-600" data-private>{file.name}</Typography.Text>
+                <Layout.Stack direction="row" gap="s" alignItems="center">
+                    <Typography.Text variant="m-400" class="u-color-text-secondary">
+                        {file.mimeType}
+                    </Typography.Text>
+                    <span class="u-color-text-secondary">•</span>
+                    <Typography.Text variant="m-400" class="u-color-text-secondary">
+                        {calculateSize(file.sizeOriginal)}
+                    </Typography.Text>
+                </Layout.Stack>
+            </Layout.Stack>
+        </div>
+
+        <Typography.Text variant="m-400" class="u-color-text-secondary">
+            This action cannot be undone. The file will be permanently deleted from your storage
+            bucket.
+        </Typography.Text>
+    </Layout.Stack>
 </Confirm>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes a critical bug in the storage bucket file deletion functionality where clicking the "Delete" option in the file action menu would navigate to the file preview page instead of opening the delete confirmation modal, preventing users from deleting files.
## Key Changes:
1) Fixed event handling to prevent unintended navigation when clicking delete button
2) Added event.stopPropagation() and event.preventDefault() to action menu handlers
3) Improved the delete confirmation modal with better file information display
4) Enhanced UI with file metadata (type, size) and clearer warning messages about permanent deletion

## Test Plan

1) Log into the Appwrite Console and open any project
2) Navigate to Storage → Buckets → choose any bucket
3) Upload a test file
4) In the file list, click the "•••" menu next to your file
5) Click "Delete"

## Related PRs and Issues

Fixes: PRO-1916 - Unable to delete file from bucket
also fixes https://github.com/appwrite/console/issues/2052

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes