### PR TITLE
fix: hide estimated costs in project breakdown

### DIFF
--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/ProjectBreakdown.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/ProjectBreakdown.svelte
@@ -115,7 +115,7 @@
                 { id: 'reads', hide: !databaseOperationMetric },
                 { id: 'writes', hide: !databaseOperationMetric },
                 { id: 'metric', hide: !!databaseOperationMetric },
-                { id: 'costs' }
+                { id: 'costs', hide: true }
             ]}
             let:root>
             <svelte:fragment slot="header" let:root>


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Since the backend doesn't return the estimated cost, the Console shows 0 for every estimated cost.

As an interim, this PR hides the column rather than showing incorrect data.

## Test Plan

Tested manually:

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/4621be02-e53c-4acc-a24d-cd4b8c0e2fef" />

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes