### PR TITLE
fix:improved padding between uri and filed

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/appleOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/appleOAuth.svelte
@@ -67,11 +67,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/auth0OAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/auth0OAuth.svelte
@@ -71,11 +71,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/authentikOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/authentikOAuth.svelte
@@ -75,11 +75,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/gitlabOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/gitlabOAuth.svelte
@@ -70,11 +70,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/googleOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/googleOAuth.svelte
@@ -65,11 +65,9 @@
         To complete the setup, create an OAuth2 client ID with "Web application" as the application
         type, then add this redirect URI to your {provider.name} configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
 
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -65,11 +65,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/microsoftOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/microsoftOAuth.svelte
@@ -72,11 +72,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/oidcOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/oidcOAuth.svelte
@@ -109,11 +109,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/oktaOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/oktaOAuth.svelte
@@ -82,11 +82,9 @@
     <Alert.Inline status="info">
         To complete set up, add this OAuth2 redirect URI to your {provider.name} app configuration.
     </Alert.Inline>
-    <div>
-        <p>URI</p>
-        <CopyInput
-            value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
-    </div>
+    <CopyInput
+        label="URI"
+        value={`${getApiEndpoint(page.params.region)}/account/sessions/oauth2/callback/${provider.key}/${projectId}`} />
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button


### PR DESCRIPTION
## What does this PR do?

Fixes inconsistent spacing for the URI field in OAuth provider configuration modals. The URI section now has proper spacing that matches other form elements in the modal.

### Changes made:

- Updated **Auth0** OAuth provider modal to use `CopyInput`'s built-in `label` prop instead of a wrapper `<div>` with a separate `<p>` element.
- Applied the same fix to the **Apple** OAuth provider modal.
- Removed unnecessary wrapper `<div>` elements that were preventing proper spacing using the modal’s `u-gap-24` system.

**Before:** The URI field had inconsistent spacing compared to other inputs (Client ID, Client Secret, etc.)  
**After:** All form elements now have uniform spacing using the Modal component’s layout system.
![image](https://github.com/user-attachments/assets/39765a08-0c6f-4c82-9636-b2aa07ae6ded)
![image](https://github.com/user-attachments/assets/4669be36-5f0f-49c5-8e12-f14711fc664f)

---

## Test Plan

1. Navigate to **Project Settings → Authentication → Auth Providers**.
2. Click **"Update"** on the **Auth0** OAuth provider.
3. Verify that the URI field has consistent spacing with other form inputs (Client ID, Client Secret, Auth0 Domain).
4. Repeat for the **Apple** OAuth provider.
5. Confirm spacing matches other form inputs (Services ID, Key ID, Team ID, P8 File).
6. Check on both **desktop** and **mobile** viewports to ensure responsive behavior.

---

## Related PRs and Issues

Fixes: **SER-7** – Missing padding below OAuth callback (addresses spacing inconsistency in OAuth provider modals)

---

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and understand the contributing guidelines.
