### PR TITLE
fix: add tooltip on disabled button

### DIFF
--- a/src/routes/(console)/organization-[organization]/header.svelte
+++ b/src/routes/(console)/organization-[organization]/header.svelte
@@ -7,7 +7,13 @@
     import { toLocaleDate } from '$lib/helpers/date';
     import { isTabSelected } from '$lib/helpers/load';
     import { Cover } from '$lib/layout';
-    import { daysLeftInTrial, getServiceLimit, plansInfo, readOnly } from '$lib/stores/billing';
+    import {
+        daysLeftInTrial,
+        getServiceLimit,
+        plansInfo,
+        readOnly,
+        tierToPlan
+    } from '$lib/stores/billing';
     import { members, newMemberModal, type Organization } from '$lib/stores/organization';
     import {
         canSeeBilling,
@@ -114,14 +120,25 @@
                     {/if}
 
                     {#if $isOwner}
-                        <Button
-                            secondary
-                            size="s"
-                            on:click={() => newMemberModal.set(true)}
-                            disabled={areMembersLimited}>
-                            <Icon icon={IconPlus} size="s" slot="start" />
-                            Invite
-                        </Button>
+                        <Tooltip disabled={!areMembersLimited} placement="bottom-end">
+                            <div>
+                                <Button
+                                    secondary
+                                    size="s"
+                                    on:click={() => newMemberModal.set(true)}
+                                    disabled={areMembersLimited}>
+                                    <Icon icon={IconPlus} size="s" slot="start" />
+                                    Invite
+                                </Button>
+                            </div>
+                            <div slot="tooltip">
+                                {organization?.billingPlan === BillingPlan.FREE
+                                    ? 'Upgrade to add more members'
+                                    : `You've reached the members limit for the ${
+                                          tierToPlan(organization?.billingPlan)?.name
+                                      } plan`}
+                            </div>
+                        </Tooltip>
                     {/if}
                 </Layout.Stack>
             </div>


### PR DESCRIPTION
### Fix: Restore Tooltip for Disabled "Invite" Button on Free Orgs

**Problem:**  
Disabled "Invite" button on free orgs lacked tooltip, leaving users unclear on how to enable it.

**Solution:**  
Added missing tooltip in:
![image](https://github.com/user-attachments/assets/89936b2f-c310-4be9-8aab-fc129b0da3be)

- `/organization-[org]/members`  
- Header invite button (top-right)

**Tooltip Behavior:**  
- Shown **only on FREE plans** with 1+ members  
- Message: `"Upgrade to add more members"`  
- Position: `bottom-end` (below, right-aligned)

**Testing:**  
- On FREE orgs with 1+ members, hover over disabled "Invite" button  
- Tooltip should appear below and say **"Upgrade to add more members"**

