### PR TITLE
fix: undefined errors around billing pages

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,7 @@ export enum Dependencies {
     INVOICES = 'dependency:invoices',
     ADDRESS = 'dependency:address',
     UPGRADE_PLAN = 'dependency:upgrade_plan',
-    CREATE_ORGANIZATION = 'dependency:create_organization',
+    ORGANIZATIONS = 'dependency:organizations',
     PAYMENT_METHODS = 'dependency:paymentMethods',
     ORGANIZATION = 'dependency:organization',
     MEMBERS = 'dependency:members',

--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -287,6 +287,7 @@ export function checkForEnterpriseTrial(org: Organization) {
 }
 
 export function calculateEnterpriseTrial(org: Organization) {
+    if (!org || !org.billingNextInvoiceDate) return 0;
     const endDate = new Date(org.billingNextInvoiceDate);
     const startDate = new Date(org.billingCurrentInvoiceDate);
     const today = new Date();

--- a/src/routes/(console)/account/payments/addressModal.svelte
+++ b/src/routes/(console)/account/payments/addressModal.svelte
@@ -56,7 +56,7 @@
             if (organization) {
                 org = await sdk.forConsole.billing.setBillingAddress(organization, response.$id);
                 trackEvent(Submit.OrganizationBillingAddressUpdate);
-                await invalidate(Dependencies.ORGANIZATION);
+                await invalidate(Dependencies.ORGANIZATIONS);
             }
             await invalidate(Dependencies.ADDRESS);
 

--- a/src/routes/(console)/create-organization/+page.ts
+++ b/src/routes/(console)/create-organization/+page.ts
@@ -6,7 +6,7 @@ import type { Organization } from '$lib/stores/organization';
 
 export const load: PageLoad = async ({ url, parent, depends }) => {
     const { organizations } = await parent();
-    depends(Dependencies.CREATE_ORGANIZATION);
+    depends(Dependencies.ORGANIZATIONS);
 
     const [coupon, paymentMethods] = await Promise.all([
         getCoupon(url),

--- a/src/routes/(console)/onboarding/create-organization/+page.svelte
+++ b/src/routes/(console)/onboarding/create-organization/+page.svelte
@@ -50,7 +50,7 @@
 
                 // fixes an edge case where
                 // the org is not available for some reason!
-                await invalidate(Dependencies.CREATE_ORGANIZATION);
+                await invalidate(Dependencies.ORGANIZATIONS);
             }
             isLoading = false;
         }

--- a/src/routes/(console)/organization-[organization]/billing/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/+page.svelte
@@ -134,7 +134,7 @@
         currentAggregation={data?.billingAggregation}
         currentInvoice={data?.billingInvoice} />
     <PaymentHistory />
-    <PaymentMethods methods={data?.paymentMethods} />
+    <PaymentMethods organization={data?.organization} methods={data?.paymentMethods} />
     <BillingAddress {data} />
     <TaxId />
     <BudgetCap organization={data?.organization} currentPlan={data?.currentPlan} />

--- a/src/routes/(console)/organization-[organization]/billing/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/+page.svelte
@@ -130,7 +130,7 @@
     <Typography.Title>Billing</Typography.Title>
     <PlanSummary
         availableCredit={data?.availableCredit}
-        currentPlan={data?.aggregationBillingPlan}
+        currentPlan={data?.currentPlan}
         currentAggregation={data?.billingAggregation}
         currentInvoice={data?.billingInvoice} />
     <PaymentHistory />

--- a/src/routes/(console)/organization-[organization]/billing/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/+page.svelte
@@ -135,7 +135,11 @@
         currentInvoice={data?.billingInvoice} />
     <PaymentHistory />
     <PaymentMethods organization={data?.organization} methods={data?.paymentMethods} />
-    <BillingAddress {data} />
+    <BillingAddress
+        organization={data?.organization}
+        billingAddress={data?.billingAddress}
+        locale={data?.locale}
+        countryList={data?.countryList} />
     <TaxId />
     <BudgetCap organization={data?.organization} currentPlan={data?.currentPlan} />
     <AvailableCredit areCreditsSupported={data.areCreditsSupported} />

--- a/src/routes/(console)/organization-[organization]/billing/+page.ts
+++ b/src/routes/(console)/organization-[organization]/billing/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 import { isCloud } from '$lib/system';
 
 export const load: PageLoad = async ({ parent, depends }) => {
-    const { organization, scopes, currentPlan, countryList, locale, plansInfo } = await parent();
+    const { organization, scopes, currentPlan, countryList, locale } = await parent();
 
     if (!scopes.includes('billing.read')) {
         return redirect(301, `/console/organization-${organization.$id}`);
@@ -64,10 +64,6 @@ export const load: PageLoad = async ({ parent, depends }) => {
         areCreditsSupported ? sdk.forConsole.billing.getAvailableCredit(organization.$id) : null
     ]);
 
-    const aggregationBillingPlan = plansInfo.get(
-        billingAggregation?.plan ?? organization.billingPlan
-    );
-
     // make number
     const credits = availableCredit ? availableCredit.available : null;
 
@@ -75,7 +71,6 @@ export const load: PageLoad = async ({ parent, depends }) => {
         paymentMethods,
         addressList,
         billingAddress,
-        aggregationBillingPlan,
         availableCredit: credits,
         billingAggregation,
         billingInvoice,

--- a/src/routes/(console)/organization-[organization]/billing/billingAddress.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/billingAddress.svelte
@@ -7,7 +7,7 @@
     import type { Address } from '$lib/sdk/billing';
     import { addressList } from '$lib/stores/billing';
     import { addNotification } from '$lib/stores/notifications';
-    import { organization } from '$lib/stores/organization';
+    import { type Organization } from '$lib/stores/organization';
     import { sdk } from '$lib/stores/sdk';
     import RemoveAddress from './removeAddress.svelte';
     import { user } from '$lib/stores/user';
@@ -23,14 +23,11 @@
         IconTrash
     } from '@appwrite.io/pink-icons-svelte';
     import type { Models } from '@appwrite.io/console';
-    import type { PageData } from './$types';
 
-    export let data: PageData;
-
-    const locale: Models.Locale = data.locale;
-    const countryList: Models.CountryList = data.countryList;
-
-    let billingAddress: Address = data?.billingAddress;
+    export let organization: Organization;
+    export let locale: Models.Locale;
+    export let countryList: Models.CountryList;
+    export let billingAddress: Address;
 
     let showCreate = false;
     let showEdit = false;
@@ -39,16 +36,16 @@
 
     async function addAddress(addressId: string) {
         try {
-            await sdk.forConsole.billing.setBillingAddress($organization.$id, addressId);
+            await sdk.forConsole.billing.setBillingAddress(organization.$id, addressId);
 
             addNotification({
                 type: 'success',
-                message: `A new billing address has been added to ${$organization.name}`
+                message: `A new billing address has been added to ${organization.name}`
             });
             trackEvent(Submit.OrganizationBillingAddressUpdate);
 
             invalidate(Dependencies.ADDRESS);
-            invalidate(Dependencies.ORGANIZATION);
+            invalidate(Dependencies.ORGANIZATIONS);
         } catch (error) {
             addNotification({
                 type: 'error',
@@ -63,7 +60,7 @@
     <svelte:fragment slot="title">Billing address</svelte:fragment>
     View or update your billing address. This address will be included in your invoices from Appwrite.
     <svelte:fragment slot="aside">
-        {#if $organization?.billingAddressId && billingAddress}
+        {#if organization?.billingAddressId && billingAddress}
             <Card.Base variant="secondary" padding="s">
                 <Layout.Stack direction="row" justifyContent="space-between">
                     <div>
@@ -140,7 +137,7 @@
 </CardGrid>
 
 {#if showCreate}
-    <AddressModal bind:show={showCreate} organization={$organization?.$id} {countryList} {locale} />
+    <AddressModal bind:show={showCreate} organization={organization?.$id} {countryList} {locale} />
 {/if}
 {#if showEdit}
     <EditAddressModal

--- a/src/routes/(console)/organization-[organization]/billing/budgetCap.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/budgetCap.svelte
@@ -6,31 +6,28 @@
     import { Button, Form, InputNumber, InputSwitch } from '$lib/elements/forms';
     import { showUsageRatesModal, upgradeURL } from '$lib/stores/billing';
     import { addNotification } from '$lib/stores/notifications';
-    import { organization, currentPlan } from '$lib/stores/organization';
+    import { type Organization } from '$lib/stores/organization';
     import { sdk } from '$lib/stores/sdk';
     import { Alert, Link } from '@appwrite.io/pink-svelte';
-    import { onMount } from 'svelte';
     import BudgetAlert from './budgetAlert.svelte';
+    import type { Plan } from '$lib/sdk/billing';
 
-    let capActive = false;
-    let budget: number;
-
-    onMount(() => {
-        budget = $organization?.billingBudget;
-        capActive = $organization?.billingBudget !== null;
-    });
+    export let currentPlan: Plan;
+    export let organization: Organization;
+    let capActive = organization?.billingBudget !== null;
+    let budget = organization.billingBudget;
 
     async function updateBudget() {
         try {
             await sdk.forConsole.billing.updateBudget(
-                $organization.$id,
+                organization.$id,
                 budget,
-                $organization.budgetAlerts
+                organization.budgetAlerts
             );
             await invalidate(Dependencies.ORGANIZATION);
             addNotification({
                 type: 'success',
-                message: `Budget cap enabled for ${$organization.name}`
+                message: `Budget cap enabled for ${organization.name}`
             });
             trackEvent(Submit.BudgetCapUpdate, {
                 budget: capActive ? budget : undefined
@@ -55,7 +52,7 @@
         Restrict your resource usage by setting a budget cap. Cap usage is reset at the beginning of
         each billing cycle.
         <svelte:fragment slot="aside">
-            {#if !$currentPlan.budgeting}
+            {#if !currentPlan.budgeting}
                 <Alert.Inline status="info" title="Budget caps are a Pro plan feature">
                     Upgrade to a Pro plan to set a budget cap for your organization. For more
                     information on what you can do with a Pro plan,
@@ -64,7 +61,7 @@
                         target="_blank"
                         rel="noopener noreferrer">view our pricing guide.</Link.Anchor>
                 </Alert.Inline>
-            {:else if !$currentPlan.budgetCapEnabled}
+            {:else if !currentPlan.budgetCapEnabled}
                 <Alert.Inline status="info" title="Budget cap disabled">
                     Budget caps are not supported on your current plan. For more information, please
                     reach out to your customer success manager.
@@ -92,7 +89,7 @@
         </svelte:fragment>
 
         <svelte:fragment slot="actions">
-            {#if $organization?.billingPlan === BillingPlan.FREE}
+            {#if organization?.billingPlan === BillingPlan.FREE}
                 <Button
                     secondary
                     href={$upgradeURL}
@@ -105,10 +102,10 @@
                     >Upgrade to Pro
                 </Button>
             {:else}
-                <Button disabled={$organization?.billingBudget === budget} submit>Update</Button>
+                <Button disabled={organization?.billingBudget === budget} submit>Update</Button>
             {/if}
         </svelte:fragment>
     </CardGrid>
 </Form>
 
-<BudgetAlert alertsEnabled={capActive && budget > 0} />
+<BudgetAlert {organization} {currentPlan} alertsEnabled={capActive && budget > 0} />

--- a/src/routes/(console)/organization-[organization]/billing/paymentMethods.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentMethods.svelte
@@ -5,7 +5,7 @@
     import { CardGrid, CreditCardBrandImage, CreditCardInfo } from '$lib/components';
     import { BillingPlan, Dependencies } from '$lib/constants';
     import { addNotification } from '$lib/stores/notifications';
-    import { organization } from '$lib/stores/organization';
+    import { type Organization } from '$lib/stores/organization';
     import { Button } from '$lib/elements/forms';
     import { hasStripePublicKey, isCloud } from '$lib/system';
     import type { PaymentList, PaymentMethodData } from '$lib/sdk/billing';
@@ -34,6 +34,7 @@
         IconTrash
     } from '@appwrite.io/pink-icons-svelte';
 
+    export let organization: Organization;
     export let methods: PaymentList;
 
     let showPayment = false;
@@ -47,12 +48,12 @@
     async function addPaymentMethod(paymentMethodId: string) {
         try {
             await sdk.forConsole.billing.setOrganizationPaymentMethod(
-                $organization.$id,
+                organization.$id,
                 paymentMethodId
             );
             addNotification({
                 type: 'success',
-                message: `A new payment method has been added to ${$organization.name}`
+                message: `A new payment method has been added to ${organization.name}`
             });
             trackEvent(Submit.OrganizationPaymentUpdate);
             invalidate(Dependencies.ORGANIZATION);
@@ -68,12 +69,12 @@
     async function addBackupPaymentMethod(paymentMethodId: string) {
         try {
             await sdk.forConsole.billing.setOrganizationPaymentMethodBackup(
-                $organization.$id,
+                organization.$id,
                 paymentMethodId
             );
             addNotification({
                 type: 'success',
-                message: `A new payment method has been added to ${$organization.name}`
+                message: `A new payment method has been added to ${organization.name}`
             });
             invalidate(Dependencies.ORGANIZATION);
         } catch (error) {
@@ -85,15 +86,15 @@
         }
     }
 
-    $: if ($organization?.backupPaymentMethodId) {
+    $: if (organization?.backupPaymentMethodId) {
         sdk.forConsole.billing
-            .getOrganizationPaymentMethod($organization.$id, $organization.backupPaymentMethodId)
+            .getOrganizationPaymentMethod(organization.$id, organization.backupPaymentMethodId)
             .then((res) => (backupPaymentMethod = res));
     }
 
-    $: if ($organization?.paymentMethodId) {
+    $: if (organization?.paymentMethodId) {
         sdk.forConsole.billing
-            .getOrganizationPaymentMethod($organization.$id, $organization.paymentMethodId)
+            .getOrganizationPaymentMethod(organization.$id, organization.paymentMethodId)
             .then((res) => (defaultPaymentMethod = res));
     }
 
@@ -112,7 +113,7 @@
     <svelte:fragment slot="title">Payment methods</svelte:fragment>
     View or update your organization payment methods here.
     <svelte:fragment slot="aside">
-        {#if $organization?.paymentMethodId}
+        {#if organization?.paymentMethodId}
             <Table.Root
                 let:root
                 columns={[
@@ -168,7 +169,7 @@
                         </Popover>
                     </Table.Cell>
                 </Table.Row.Base>
-                {#if $organization?.backupPaymentMethodId}
+                {#if organization?.backupPaymentMethodId}
                     <Table.Row.Base {root}>
                         <CreditCardInfo {root} isBackup paymentMethod={backupPaymentMethod} />
                         <Table.Cell column="actions" {root}>
@@ -209,9 +210,9 @@
                     </Table.Row.Base>
                 {/if}
             </Table.Root>
-            {#if !$organization?.backupPaymentMethodId}
+            {#if !organization?.backupPaymentMethodId}
                 {@const filteredPaymentMethods = methods.paymentMethods.filter(
-                    (o) => !!o.last4 && o.$id !== $organization?.paymentMethodId
+                    (o) => !!o.last4 && o.$id !== organization?.paymentMethodId
                 )}
                 <div>
                     <Popover let:toggle placement="bottom-start" padding="none">
@@ -264,7 +265,7 @@
             {/if}
         {:else}
             {@const filteredPaymentMethods = methods.paymentMethods.filter(
-                (o) => !!o.last4 && o.$id !== $organization?.backupPaymentMethodId
+                (o) => !!o.last4 && o.$id !== organization?.backupPaymentMethodId
             )}
             <Card.Base>
                 <Layout.Stack justifyContent="center" alignItems="center" gap="m">
@@ -319,15 +320,15 @@
         bind:show={showEdit} />
 {/if}
 {#if isCloud && hasStripePublicKey}
-    <ReplaceCard {methods} bind:show={showReplace} isBackup={isSelectedBackup} />
+    <ReplaceCard {organization} {methods} bind:show={showReplace} isBackup={isSelectedBackup} />
 {/if}
 {#if showDelete && isCloud && hasStripePublicKey}
     {@const hasOtherMethod = isSelectedBackup
-        ? !!$organization?.paymentMethodId
-        : !!$organization?.backupPaymentMethodId}
+        ? !!organization?.paymentMethodId
+        : !!organization?.backupPaymentMethodId}
     <DeleteOrgPayment
         bind:showDelete
         {hasOtherMethod}
         isBackup={isSelectedBackup}
-        disabled={$organization?.billingPlan !== BillingPlan.FREE && !hasOtherMethod} />
+        disabled={organization?.billingPlan !== BillingPlan.FREE && !hasOtherMethod} />
 {/if}

--- a/src/routes/(console)/organization-[organization]/billing/removeAddress.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/removeAddress.svelte
@@ -20,7 +20,7 @@
                 message: `The billing address has been removed from ${$organization.name}`
             });
             trackEvent(Submit.OrganizationBillingAddressDelete);
-            invalidate(Dependencies.ORGANIZATION);
+            invalidate(Dependencies.ORGANIZATIONS);
             show = false;
         } catch (e) {
             error = e.message;

--- a/src/routes/(console)/organization-[organization]/billing/replaceCard.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/replaceCard.svelte
@@ -3,7 +3,7 @@
     import { FakeModal } from '$lib/components';
     import { Button } from '$lib/elements/forms';
     import { sdk } from '$lib/stores/sdk';
-    import { organization } from '$lib/stores/organization';
+    import type { Organization } from '$lib/stores/organization';
     import { Dependencies } from '$lib/constants';
     import { submitStripeCard } from '$lib/stores/stripe';
     import { onMount } from 'svelte';
@@ -12,6 +12,7 @@
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
     import { PaymentBoxes } from '$lib/components/billing';
 
+    export let organization: Organization;
     export let show = false;
     export let isBackup = false;
     export let methods: PaymentList;
@@ -21,12 +22,12 @@
     let selectedPaymentMethodId: string;
 
     onMount(async () => {
-        if (!$organization.paymentMethodId && !$organization.backupPaymentMethodId) {
+        if (!organization.paymentMethodId && !organization.backupPaymentMethodId) {
             selectedPaymentMethodId = methods?.total ? methods.paymentMethods[0].$id : null;
         } else {
             selectedPaymentMethodId = isBackup
-                ? $organization.backupPaymentMethodId
-                : $organization.paymentMethodId;
+                ? organization.backupPaymentMethodId
+                : organization.paymentMethodId;
             // If the selected payment method does not belong to the current user, select the first one.
             if (
                 methods?.total &&
@@ -40,7 +41,7 @@
     async function handleSubmit() {
         try {
             if (selectedPaymentMethodId === '$new') {
-                const method = await submitStripeCard(name, $organization.$id);
+                const method = await submitStripeCard(name, organization.$id);
                 selectedPaymentMethodId = method.$id;
             }
             isBackup
@@ -68,7 +69,7 @@
     async function addPaymentMethod(paymentMethodId: string) {
         try {
             await sdk.forConsole.billing.setOrganizationPaymentMethod(
-                $organization.$id,
+                organization.$id,
                 paymentMethodId
             );
         } catch (e) {
@@ -79,7 +80,7 @@
     async function addBackupPaymentMethod(paymentMethodId: string) {
         try {
             await sdk.forConsole.billing.setOrganizationPaymentMethodBackup(
-                $organization.$id,
+                organization.$id,
                 paymentMethodId
             );
         } catch (e) {
@@ -97,18 +98,18 @@
         methods={filteredMethods}
         bind:name
         bind:group={selectedPaymentMethodId}
-        defaultMethod={$organization?.paymentMethodId}
-        backupMethod={$organization?.backupPaymentMethodId}
+        defaultMethod={organization?.paymentMethodId}
+        backupMethod={organization?.backupPaymentMethodId}
         disabledCondition={isBackup
-            ? $organization.paymentMethodId
-            : $organization.backupPaymentMethodId} />
+            ? organization.paymentMethodId
+            : organization.backupPaymentMethodId} />
     <svelte:fragment slot="footer">
         <Button text on:click={() => (show = false)}>Cancel</Button>
         <Button
             secondary
             submit
             disabled={selectedPaymentMethodId ===
-                (isBackup ? $organization.backupPaymentMethodId : $organization.paymentMethodId)}>
+                (isBackup ? organization.backupPaymentMethodId : organization.paymentMethodId)}>
             Save
         </Button>
     </svelte:fragment>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -16,7 +16,7 @@ export const ssr = false;
 
 export const load: LayoutLoad = async ({ depends, url, route }) => {
     depends(Dependencies.ACCOUNT);
-    depends(Dependencies.CREATE_ORGANIZATION);
+    depends(Dependencies.ORGANIZATIONS);
 
     const [account, error] = (await sdk.forConsole.account
         .get()


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

currentPlan (which came from the page's aggregationBillingPlan) can be undefined leading to an error like:

<img width="593" alt="image" src="https://github.com/user-attachments/assets/6def0ae4-a28a-4e02-88b7-922956815f80" />
<img width="804" alt="image" src="https://github.com/user-attachments/assets/b06fd881-38f4-49e0-9700-e0b835fbfbd9" />

leading to a blank page:

<img width="990" alt="image" src="https://github.com/user-attachments/assets/7e95f285-2e3e-4581-99f9-97160e7849ae" />

This PR changes the page to use the currentPlan from the parent that should already be available.

Also:

* fix undefined (reading 'billingNextInvoiceDate') for enterprise trial banner
* fix undefined (reading 'budgeting') in budget cap
* fix undefined (reading 'paymentMethodId') in replace card
* ensure billing address on the org and account page updates

## Test Plan

Manual test: 
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/20c03fcf-618b-42dd-b843-1b1520bac0a9" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes