### PR TITLE
fix: enter closes warning

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/create.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/create.svelte
@@ -24,7 +24,6 @@
     let name = '';
     let id: string = null;
     let showCustomId = false;
-    let showPlanUpgradeAlert = true;
 
     const trackEvents = (policies) => {
         policies.forEach((policy) => {
@@ -103,10 +102,6 @@
             trackError(error, Submit.DatabaseCreate);
         }
     };
-
-    $: if (!showCreate) {
-        showPlanUpgradeAlert = true;
-    }
 </script>
 
 <Modal title="Create database" onSubmit={create} bind:show={showCreate}>
@@ -132,18 +127,12 @@
 
     {#if isCloud}
         {#if $organization?.billingPlan === BillingPlan.FREE}
-            {#if showPlanUpgradeAlert}
-                <Alert.Inline
-                    dismissible
-                    title="This database won't be backed up"
-                    status="warning"
-                    on:dismiss={() => (showPlanUpgradeAlert = false)}>
-                    Upgrade your plan to ensure your data stays safe and backed up.
-                    <svelte:fragment slot="actions">
-                        <Button compact href={$upgradeURL}>Upgrade plan</Button>
-                    </svelte:fragment>
-                </Alert.Inline>
-            {/if}
+            <Alert.Inline title="This database won't be backed up" status="warning">
+                Upgrade your plan to ensure your data stays safe and backed up.
+                <svelte:fragment slot="actions">
+                    <Button compact href={$upgradeURL}>Upgrade plan</Button>
+                </svelte:fragment>
+            </Alert.Inline>
         {:else}
             <CreatePolicy
                 bind:totalPolicies


### PR DESCRIPTION
# Fix: Database creation modal ENTER key behavior (SER-40)

## Problem
When creating a database, pressing ENTER in the name field was dismissing the backup warning alert instead of submitting the form. Users had to press ENTER twice - once to dismiss the warning, then again to create the database.

## Root Cause
The dismissible `Alert.Inline` component's close button was capturing ENTER key events before they could reach the form submission handler. This happened due to accessibility keyboard support in the alert component.

![image](https://github.com/user-attachments/assets/3e945761-b8c7-4c7f-bc40-2a3737cc550b)
