### PR TITLE
fix: apns provider key file upload input

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/messaging/providers/settingsFormInput.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/providers/settingsFormInput.svelte
@@ -24,8 +24,7 @@
         APNSProviderParams
     } from './store';
     import TooltipPopover from './tooltipPopover.svelte';
-    import { Icon, Tooltip, Upload, Layout, Typography } from '@appwrite.io/pink-svelte';
-    import { IconInfo } from '@appwrite.io/pink-icons-svelte';
+    import { Upload, Layout, Typography } from '@appwrite.io/pink-svelte';
     import { InvalidFileType, removeFile } from '$lib/helpers/files';
     import { addNotification } from '$lib/stores/notifications';
 
@@ -122,25 +121,15 @@
 {:else if input.type === 'file'}
     <Upload.Dropzone
         on:invalid={handleInvalid}
-        extensions={['json']}
+        extensions={input.allowedFileExtensions}
         bind:files={files[input.name]}
         maxSize={10000000}
         required={!input.optional}>
-        <Layout.Stack alignItems="center" gap="s">
-            <Layout.Stack alignItems="center" gap="s">
-                <Layout.Stack alignItems="center" justifyContent="center" direction="row" gap="s">
-                    <Typography.Text variant="l-500">
-                        Drag and drop service account JSON here or click to upload
-                    </Typography.Text>
-                    <Tooltip>
-                        <Layout.Stack alignItems="center" justifyContent="center" inline>
-                            <Icon icon={IconInfo} size="s" />
-                        </Layout.Stack>
-                        <svelte:fragment slot="tooltip">Only .json files allowed</svelte:fragment>
-                    </Tooltip>
-                </Layout.Stack>
-                <Typography.Caption variant="400">Max file size 10MB</Typography.Caption>
-            </Layout.Stack>
+        <Layout.Stack alignItems="center" justifyContent="center" direction="row" gap="xxs">
+            <Typography.Text variant="l-500">
+                Drag and drop your {input.label} here or click to upload
+            </Typography.Text>
+            <TooltipPopover {popover} {popoverProps} tooltip={input.tooltip} />
         </Layout.Stack>
     </Upload.Dropzone>
     {#if files[input.name]?.length}

--- a/src/routes/(console)/project-[region]-[project]/messaging/providers/store.ts
+++ b/src/routes/(console)/project-[region]-[project]/messaging/providers/store.ts
@@ -85,7 +85,7 @@ export const providers: ProvidersMap = {
                 ],
                 configure: [
                     {
-                        label: 'Service account JSON (.json file)',
+                        label: 'service account JSON (.json file)',
                         name: 'serviceAccountJSON',
                         type: 'file',
                         allowedFileExtensions: ['json'],
@@ -164,7 +164,7 @@ export const providers: ProvidersMap = {
                         }
                     },
                     {
-                        label: 'Auth key (.p8 file)',
+                        label: 'auth key (.p8 file)',
                         name: 'authKey',
                         type: 'file',
                         allowedFileExtensions: ['p8'],


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Don't hardcode the upload dropzone to be for service account JSON files only.

Fixes https://github.com/appwrite/console/issues/2045

## Test Plan

Tested locally:

FCM:

<img width="887" alt="image" src="https://github.com/user-attachments/assets/b775417e-d916-4e5f-a77f-dcd6f5016c95" />

APNS:

<img width="929" alt="image" src="https://github.com/user-attachments/assets/94fbaf9a-a53f-44c8-9012-c6fcda64569a" />


## Related PRs and Issues

* https://github.com/appwrite/console/issues/2045

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes