### PR TITLE
Fix: Cannot update the Session length

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateSessionLength.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateSessionLength.svelte
@@ -17,7 +17,7 @@
 
     async function updateSessionLength() {
         try {
-            await sdk.forConsole.projects.updateAuthDuration($project.$id, $baseValue);
+            await sdk.forConsole.projects.updateAuthDuration(project.$id, $baseValue);
             await invalidate(Dependencies.PROJECT);
 
             addNotification({


### PR DESCRIPTION
## What does this PR do?

There was this issue reported in the **appwrite/appwrite** repo [Issue #10108 Link](https://github.com/appwrite/appwrite/issues/10108) which was suppose to be in this, I checked the repo and found a bug so I removed it.

- Problem File, Code and Line:
  - `file: updateSessionLength.svelte | 20th line`
  - `await sdk.forConsole.projects.updateAuthDuration($project.$id, $baseValue);`

- Solution File, Code and Line:
  - `file: updateSessionLength.svelte | 20th line`
  - `await sdk.forConsole.projects.updateAuthDuration(project.$id, $baseValue);`

- Changes:  From `$project.$id` -> `project.$id`


## Test Plan

- Open Appwrite (`https://cloud.appwrite.io/console/`)
- Open a **project** > Navigate to **Auth** > Click **Security**
- Change **Time Period** & **Length** (like: **Time Period - Hour** and **Length - 24**)
- Press **Update** button
- You will see this **Error**: `Cannot read properties of undefined (reading '$id')`

## Related PRs and Issues

This issue is related to this fix but they added the issue in `appwrite/appwrite` Repo instead of `appwrite/console`. [Here is the link to Issue #10108](https://github.com/appwrite/appwrite/issues/10108)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/console/blob/master/CONTRIBUTING.md)?

- [X] I have read the Contributing Guidelines on issues linked above.
- [X] Done Quality checks and Code Standard.

