### PR TITLE
fix: update messaging provider popover when changing providers

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/messaging/providers/settingsFormInput.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/providers/settingsFormInput.svelte
@@ -43,18 +43,6 @@
         | FCMProviderParams
         | APNSProviderParams
     >;
-    const popover = input.popover ? PopoverContent : null;
-    const popoverProps = getPopoverProps(input);
-
-    function getPopoverProps(input: ProviderInput) {
-        if (!input.popover) {
-            return {};
-        }
-        return {
-            lines: input.popover,
-            image: input.popoverImage
-        };
-    }
 
     function handleInvalid(e: CustomEvent) {
         const reason = e.detail?.reason ?? '';
@@ -71,6 +59,14 @@
             });
         }
     }
+
+    $: popover = input.popover ? PopoverContent : null;
+    $: popoverProps = !input.popover
+        ? {}
+        : {
+              lines: input.popover,
+              image: input.popoverImage
+          };
 </script>
 
 {#if input.type === 'text'}


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Make the popover content reactive so that the tooltip popover updates when the provider changes. Otherwise, the popover content remains static and does not reflect the current provider's settings.

## Test Plan

Before:

https://github.com/user-attachments/assets/01079599-21d7-4d13-b714-0c727a306d24

After:

https://github.com/user-attachments/assets/0788a3b7-ce99-4745-bfe2-17bd7b0ad82e

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes