### PR TITLE
fix: Modal enter key not submitting issue

### DIFF
--- a/src/lib/layout/createProject.svelte
+++ b/src/lib/layout/createProject.svelte
@@ -22,44 +22,42 @@
     {/each}
 </svelte:head>
 
-<form on:submit|preventDefault>
+<Layout.Stack direction="column" gap="xxl">
+    {#if showTitle}
+        <Typography.Title size="l">Create your project</Typography.Title>
+    {/if}
     <Layout.Stack direction="column" gap="xxl">
-        {#if showTitle}
-            <Typography.Title size="l">Create your project</Typography.Title>
-        {/if}
         <Layout.Stack direction="column" gap="xxl">
-            <Layout.Stack direction="column" gap="xxl">
-                <Layout.Stack direction="column" gap="s">
-                    <Input.Text
-                        label="Name"
-                        placeholder="Project name"
-                        required
-                        autofocus
-                        bind:value={projectName} />
-                    {#if !showCustomId}
-                        <div>
-                            <Tag
-                                size="s"
-                                on:click={() => {
-                                    showCustomId = true;
-                                }}><Icon slot="start" icon={IconPencil} size="s" /> Project ID</Tag>
-                        </div>
-                    {/if}
-                    <CustomId bind:show={showCustomId} name="Project" isProject bind:id />
-                </Layout.Stack>
-                {#if isCloud && regions.length > 0}
-                    <Layout.Stack gap="xs">
-                        <Input.Select
-                            required
-                            bind:value={region}
-                            placeholder="Select a region"
-                            options={filterRegions(regions)}
-                            label="Region" />
-                        <Typography.Text>Region cannot be changed after creation</Typography.Text>
-                    </Layout.Stack>
+            <Layout.Stack direction="column" gap="s">
+                <Input.Text
+                    label="Name"
+                    placeholder="Project name"
+                    required
+                    autofocus
+                    bind:value={projectName} />
+                {#if !showCustomId}
+                    <div>
+                        <Tag
+                            size="s"
+                            on:click={() => {
+                                showCustomId = true;
+                            }}><Icon icon={IconPencil} slot="start" size="s" /> Project ID</Tag>
+                    </div>
                 {/if}
+                <CustomId bind:show={showCustomId} name="Project" isProject bind:id />
             </Layout.Stack>
+            {#if isCloud && regions.length > 0}
+                <Layout.Stack gap="xs">
+                    <Input.Select
+                        required
+                        bind:value={region}
+                        placeholder="Select a region"
+                        options={filterRegions(regions)}
+                        label="Region" />
+                    <Typography.Text>Region cannot be changed after creation</Typography.Text>
+                </Layout.Stack>
+            {/if}
         </Layout.Stack>
-        <slot name="submit"></slot>
     </Layout.Stack>
-</form>
+    <slot name="submit"></slot>
+</Layout.Stack>


### PR DESCRIPTION
## What does this PR do?

Fixes an accessibility issue in the Create Project modal. Removes a nested form wrapper that was blocking form submission when pressing Enter. The modal now correctly submits the form using the Enter key.

## Test Plan

- Open the Create Project modal
- Fill in the input fields
- Press Enter
- Verified that the form submits as expected without requiring a manual click

## Related PRs and Issues

Resolves: [SER-84]

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes
