### PR TITLE
fix:Resource limits submit button state management

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
@@ -18,6 +18,8 @@
     export let func: Models.Function;
     export let specs: Models.SpecificationList;
     let specification = func.specification;
+    let originalSpecification = func.specification;
+    $: originalSpecification = func.specification;
 
     async function updateLogging() {
         try {
@@ -47,6 +49,9 @@
                     specification || undefined
                 );
             await invalidate(Dependencies.FUNCTION);
+
+            originalSpecification = specification;
+
             addNotification({
                 type: 'success',
                 message: 'Resource limits have been updated'
@@ -96,7 +101,7 @@
         </svelte:fragment>
 
         <svelte:fragment slot="actions">
-            <Button disabled={func.specification === specification} submit>Update</Button>
+            <Button disabled={originalSpecification === specification} submit>Update</Button>
         </svelte:fragment>
     </CardGrid>
 </Form>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -17,6 +17,9 @@
     export let site: Models.Site;
     export let specs: Models.SpecificationList;
     let specification = site.specification;
+    let originalSpecification = site.specification;
+
+    $: originalSpecification = site.specification;
 
     async function updateLogging() {
         try {
@@ -42,7 +45,9 @@
                     site?.providerRootDirectory || undefined,
                     specification || undefined
                 );
-            await invalidate(Dependencies.FUNCTION);
+            await invalidate(Dependencies.SITE);
+            originalSpecification = specification;
+
             addNotification({
                 type: 'success',
                 message: 'Resource limits have been updated'
@@ -92,7 +97,7 @@
         </svelte:fragment>
 
         <svelte:fragment slot="actions">
-            <Button disabled={site.specification === specification} submit>Update</Button>
+            <Button disabled={originalSpecification === specification} submit>Update</Button>
         </svelte:fragment>
     </CardGrid>
 </Form>


### PR DESCRIPTION
## Fix: Resource limits submit button state management

### Problem
Submit button stayed enabled after saving resource limits and prevented reverting to original values.

### Solution
- Track saved specification value separately from current selection
- Update baseline after successful save
- Fix button disabled state comparison
- Fix incorrect dependency invalidation in sites component

### Files Changed
- `updateResourceLimits.svelte` (sites & functions)

**Before:** Button compared against stale prop value  
**After:** Button compares against actual saved value