### PR TITLE
fix: permission dialog not closing automaticaally

### DIFF
--- a/src/lib/components/permissions/actions.svelte
+++ b/src/lib/components/permissions/actions.svelte
@@ -12,7 +12,6 @@
     export let showTeam: boolean;
     export let showLabel: boolean;
     export let showCustom: boolean;
-    export let hideOnClick: boolean = false;
     export let groups: Writable<Map<string, Permission>>;
 
     const dispatch = createEventDispatcher();
@@ -49,22 +48,22 @@
             <ActionMenu.Item.Button
                 on:click={(e) => {
                     showUser = true;
-                    if (hideOnClick) hide(e);
+                    hide(e);
                 }}>Select users</ActionMenu.Item.Button>
             <ActionMenu.Item.Button
                 on:click={(e) => {
                     showTeam = true;
-                    if (hideOnClick) hide(e);
+                    hide(e);
                 }}>Select teams</ActionMenu.Item.Button>
             <ActionMenu.Item.Button
                 on:click={(e) => {
                     showLabel = true;
-                    if (hideOnClick) hide(e);
+                    hide(e);
                 }}>Label</ActionMenu.Item.Button>
             <ActionMenu.Item.Button
                 on:click={(e) => {
                     showCustom = true;
-                    if (hideOnClick) hide(e);
+                    hide(e);
                 }}>Custom permission</ActionMenu.Item.Button>
         </ActionMenu.Root>
     </svelte:fragment>

--- a/src/lib/components/permissions/actions.svelte
+++ b/src/lib/components/permissions/actions.svelte
@@ -25,7 +25,7 @@
             <ActionMenu.Item.Button
                 disabled={$groups.has('any')}
                 on:click={(e) => {
-                    if (hideOnClick) hide(e);
+                    hide(e);
                     dispatch('create', ['any']);
                 }}>
                 Any
@@ -33,7 +33,7 @@
             <ActionMenu.Item.Button
                 disabled={$groups.has('guests')}
                 on:click={(e) => {
-                    if (hideOnClick) hide(e);
+                    hide(e);
                     dispatch('create', ['guests']);
                 }}>
                 All guests
@@ -41,7 +41,7 @@
             <ActionMenu.Item.Button
                 disabled={$groups.has('users')}
                 on:click={(e) => {
-                    if (hideOnClick) hide(e);
+                    hide(e);
                     dispatch('create', ['users']);
                 }}>
                 All users

--- a/src/lib/components/permissions/permissions.svelte
+++ b/src/lib/components/permissions/permissions.svelte
@@ -22,7 +22,6 @@
     import { Card } from '$lib/components';
 
     export let withCreate = false;
-    export let hideOnClick = false;
     export let permissions: string[] = [];
 
     let showUser = false;
@@ -197,7 +196,6 @@
             bind:showTeam
             bind:showUser
             {groups}
-            {hideOnClick}
             on:create={create}
             let:toggle>
             <Button secondary on:click={toggle}>
@@ -215,7 +213,6 @@
                 bind:showTeam
                 bind:showUser
                 {groups}
-                {hideOnClick}
                 on:create={create}
                 let:toggle>
                 <Button secondary icon on:click={toggle}>

--- a/src/lib/components/permissions/team.svelte
+++ b/src/lib/components/permissions/team.svelte
@@ -34,6 +34,7 @@
         offset = 0;
         search = '';
         selected.clear();
+        show = false;
     }
 
     function create() {

--- a/src/lib/components/permissions/user.svelte
+++ b/src/lib/components/permissions/user.svelte
@@ -37,6 +37,7 @@
         offset = 0;
         search = '';
         selected.clear();
+        show = false;
     }
 
     function create() {


### PR DESCRIPTION
## What does this PR do?

This PR fixes a UX issue where permission dialog modals and dropdown menus did not close automatically after users made selections.  
The bug affected both:

- Modal-based permission selections (`Select users`, `Select teams`)
- Direct dropdown selections (`Any`, `All guests`, `All users`)

This created an inconsistent and frustrating user experience.

---

## Changes Made

- Fixed user and team selection modals not closing after adding roles  
- Fixed dropdown menu not closing when selecting direct permission options  
- Ensured consistent closing behavior across all permission types

---

## Test Plan

To verify the fix:

### Modal Closing

1. Navigate to any permissions settings (e.g., `Database Collection → Settings`, `Storage Bucket → Settings`)
2. Click `Add role` → `Select users`
3. Select users and click `Add` — the modal should close automatically
4. Repeat for `Select teams` — the modal should close automatically

### Dropdown Closing

1. Click `Add role` → `Any` — the dropdown should close immediately
2. Click `Add role` → `All guests` — the dropdown should close immediately
3. Click `Add role` → `All users` — the dropdown should close immediately

### Verify Existing Behavior

- Ensure `Label` and `Custom permission` options still work correctly
- Confirm all permission types can be added and removed properly

---

## Related PRs and Issues

Fixes: Permission dialogs not closing on selecting one field (internal issue)

---

## Have you read the Contributing Guidelines?

Yes, I have read and understood the contributing guidelines.
