### PR TITLE
Fix: Add loading spinner to self-hosted project creation modal

### DIFF
--- a/src/routes/(console)/organization-[organization]/createProject.svelte
+++ b/src/routes/(console)/organization-[organization]/createProject.svelte
@@ -21,10 +21,12 @@
     let showCustomId = false;
     let disabled: boolean = false;
     let name: string = 'New project';
+    let showSubmissionLoader = false;
 
     async function create() {
         try {
             disabled = true;
+            showSubmissionLoader = true;
             const project = await sdk.forConsole.projects.create(id ?? ID.unique(), name, teamId);
             show = false;
             dispatch('created', project);
@@ -40,7 +42,9 @@
         } catch (e) {
             error = e.message;
             trackError(e, Submit.ProjectCreate);
+        } finally {
             disabled = false;
+            showSubmissionLoader = false;
         }
     }
 </script>
@@ -62,6 +66,10 @@
 
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (show = false)}>Cancel</Button>
-        <Button submit {disabled}>Create</Button>
+        <Button
+            submit
+            {disabled}
+            forceShowLoader={showSubmissionLoader}
+            submissionLoader={showSubmissionLoader}>Create</Button>
     </svelte:fragment>
 </Modal>


### PR DESCRIPTION
## ✅ What does this PR do?

Fixes inconsistent loading spinner behavior between **Cloud** and **Self-hosted** project creation modals.

Previously:
- **Cloud** version displayed a loading spinner during project creation.
- **Self-hosted** version only disabled the button without any visual feedback.

---

## Changes

- Added `showSubmissionLoader` state variable to the Self-hosted modal
- Updated `create()` function to manage loading state with proper `try/finally` blocks
- Enhanced `Button` component with `forceShowLoader` and `submissionLoader` props

---

## Test Plan

### Self-hosted Modal Testing
- Set environment: `PUBLIC_CONSOLE_MODE=self-hosted`
- Run: `npm run dev`
- Navigate to: `/console/organization-[org-id]`
- Click "Create project" → fill project name → click "Create"

✅ **Verify:** Loading spinner appears on button during creation  
✅ **Verify:** Button is disabled until operation completes

### ☁️ Cloud Modal Testing
- Set environment: `PUBLIC_CONSOLE_MODE=cloud`
- Run: `npm run dev`
- Repeat the same steps as above

✅ **Verify:** Both modals now have identical loading behavior

---

## Visual Confirmation

- **Self-hosted:** No region selector + loading spinner ✅  
- **Cloud:** Region selector + loading spinner ✅

---

## Related PRs and Issues

Resolves the inconsistency where only the Cloud project creation modal showed loading feedback, while the Self-hosted version provided no visual indication during project creation.

---

## Have you read the Contributing Guidelines on issues?

Yes ✅

<img width="915" height="536" alt="image" src="https://github.com/user-attachments/assets/f5f7c97e-8a4f-4292-9f5c-bf380f02f4da" />
