### PR TITLE
fix:unlimited upload copy fixed

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
@@ -214,9 +214,11 @@
                                         >Only .tar.gz files allowed</svelte:fragment>
                                 </Tooltip>
                             </Layout.Stack>
-                            <Typography.Caption variant="400"
-                                >Max file size: {readableMaxSize.value +
-                                    readableMaxSize.unit}</Typography.Caption>
+                            {#if maxSize > 0}
+                                <Typography.Caption variant="400"
+                                    >Max file size: {readableMaxSize.value +
+                                        readableMaxSize.unit}</Typography.Caption>
+                            {/if}
                         </Layout.Stack>
                     </Layout.Stack>
                 </Upload.Dropzone>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createManual.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createManual.svelte
@@ -101,9 +101,11 @@
                                 >Only .tar.gz files allowed</svelte:fragment>
                         </Tooltip>
                     </Layout.Stack>
-                    <Typography.Caption variant="400"
-                        >Max file size: {readableMaxSize.value +
-                            readableMaxSize.unit}</Typography.Caption>
+                    {#if maxSize > 0}
+                        <Typography.Caption variant="400"
+                            >Max file size: {readableMaxSize.value +
+                                readableMaxSize.unit}</Typography.Caption>
+                    {/if}
                 </Layout.Stack>
             </Layout.Stack>
         </Upload.Dropzone>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -209,9 +209,11 @@
                                         >Only .tar.gz files allowed</svelte:fragment>
                                 </Tooltip>
                             </Layout.Stack>
-                            <Typography.Caption variant="400"
-                                >Max file size: {readableMaxSize.value +
-                                    readableMaxSize.unit}</Typography.Caption>
+                            {#if maxSize > 0}
+                                <Typography.Caption variant="400"
+                                    >Max file size: {readableMaxSize.value +
+                                        readableMaxSize.unit}</Typography.Caption>
+                            {/if}
                         </Layout.Stack>
                     </Layout.Stack>
                 </Upload.Dropzone>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createManualDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createManualDeploymentModal.svelte
@@ -95,9 +95,11 @@
                                 >Only .tar.gz files allowed</svelte:fragment>
                         </Tooltip>
                     </Layout.Stack>
-                    <Typography.Caption variant="400"
-                        >Max file size: {readableMaxSize.value +
-                            readableMaxSize.unit}</Typography.Caption>
+                    {#if maxSize > 0}
+                        <Typography.Caption variant="400"
+                            >Max file size: {readableMaxSize.value +
+                                readableMaxSize.unit}</Typography.Caption>
+                    {/if}
                 </Layout.Stack>
             </Layout.Stack>
         </Upload.Dropzone>


### PR DESCRIPTION
### Fix: Hide upload limit label when unlimited (`limit = 0`)

#### Problem  
Pro users with unlimited uploads saw confusing `Max file size: 0B` text in upload modals.

#### Solution  
Hide the "Max file size" label entirely when `maxSize === 0` (unlimited).

#### Changes  
- Applied to `+page.svelte`

#### Files Modified  
- Site deployment modal  
- Function deployment modal  
- Manual site creation  
- Manual function creation  

#### Result  
- Unlimited (`limit = 0`): No limit label shown  
- Limited (`limit > 0`): Normal "Max file size: XMB" shown  
<img width="783" height="507" alt="image" src="https://github.com/user-attachments/assets/72147e7d-d286-48cc-81c0-f3bcbbfbff4b" />

#### Fixes  
- `SER-60`

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes