### PR TITLE
Fix broken domain docs link

### DIFF
--- a/src/routes/(console)/organization-[organization]/domains/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/+page.svelte
@@ -196,7 +196,7 @@
                 <svelte:fragment slot="actions">
                     <Button
                         external
-                        href="https://appwrite.io/docs/advanced/platform/custom-domains"
+                        href="https://appwrite.io/docs/products/network/dns"
                         text
                         event="empty_documentation"
                         size="s"

--- a/src/routes/(console)/organization-[organization]/domains/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/+page.svelte
@@ -196,7 +196,7 @@
                 <svelte:fragment slot="actions">
                     <Button
                         external
-                        href="#/"
+                        href="https://appwrite.io/docs/advanced/platform/custom-domains"
                         text
                         event="empty_documentation"
                         size="s"

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/+page.svelte
@@ -64,7 +64,7 @@
                 <svelte:fragment slot="actions">
                     <Button
                         external
-                        href="#/"
+                        href="https://appwrite.io/docs/products/functions/domains"
                         text
                         event="empty_documentation"
                         size="s"


### PR DESCRIPTION
## What does this PR do?

Currently the link redirects to the console itself but a new page instead of the docs as the button states.
Added the link so now it goes to the docs regarding custom domains.

Added this link instead of the functions one as this is project-wide domain addition.

Added the function link in the functions documentation button.
