### PR TITLE
Fix: don't show default date/time is value is `null`

### DIFF
--- a/src/lib/components/dualTimeView.svelte
+++ b/src/lib/components/dualTimeView.svelte
@@ -10,7 +10,7 @@
     import { Badge, InteractiveText, Layout, Popover, Typography } from '@appwrite.io/pink-svelte';
     import { menuOpen } from '$lib/components/menu/store';
 
-    export let time: string = '';
+    export let time: string | null = null;
     export let placement: ComponentProps<Popover>['placement'] = 'bottom';
 
     function timeDifference(dateString: string): string {
@@ -75,64 +75,68 @@
     $: timeToString = time ? timeDifference(time) : 'Invalid time';
 </script>
 
-<Popover let:show let:hide {placement} portal>
-    <button
-        on:mouseenter={() => {
-            if (!$menuOpen) {
-                setTimeout(show, 150);
-            }
-        }}
-        on:mouseleave={() => hidePopover(hide)}>
-        <slot>{capitalize(timeFromNow(time))}</slot>
-    </button>
+{#if time}
+    <Popover let:show let:hide {placement} portal>
+        <button
+            on:mouseenter={() => {
+                if (!$menuOpen) {
+                    setTimeout(show, 150);
+                }
+            }}
+            on:mouseleave={() => hidePopover(hide)}>
+            <slot>{capitalize(timeFromNow(time))}</slot>
+        </button>
 
-    <div
-        let:hide
-        slot="tooltip"
-        role="tooltip"
-        style:padding="1rem"
-        style:margin="-1rem"
-        on:mouseenter={() => (isMouseOverTooltip = true)}
-        on:mouseleave={() => hidePopover(hide, false)}>
-        <Layout.Stack gap="s" alignContent="flex-start">
-            <!-- `Raw time` as per design -->
-            <Typography.Caption color="--fgcolor-neutral-tertiary" variant="400">
-                {#if $$slots.title}
-                    <slot name="title" />
-                {:else}
-                    {timeToString}
-                {/if}
-            </Typography.Caption>
+        <div
+            let:hide
+            slot="tooltip"
+            role="tooltip"
+            style:padding="1rem"
+            style:margin="-1rem"
+            on:mouseenter={() => (isMouseOverTooltip = true)}
+            on:mouseleave={() => hidePopover(hide, false)}>
+            <Layout.Stack gap="s" alignContent="flex-start">
+                <!-- `Raw time` as per design -->
+                <Typography.Caption color="--fgcolor-neutral-tertiary" variant="400">
+                    {#if $$slots.title}
+                        <slot name="title" />
+                    {:else}
+                        {timeToString}
+                    {/if}
+                </Typography.Caption>
 
-            <!-- `Absolute time` as per design -->
-            <Layout.Stack gap="xxs">
-                <Layout.Stack
-                    direction="row"
-                    alignItems="center"
-                    alignContent="center"
-                    justifyContent="space-between">
-                    <InteractiveText
-                        isVisible
-                        variant="copy"
-                        text={toLocaleDateTime(time, false, 'UTC')}
-                        value={toISOString(time)} />
+                <!-- `Absolute time` as per design -->
+                <Layout.Stack gap="xxs">
+                    <Layout.Stack
+                        direction="row"
+                        alignItems="center"
+                        alignContent="center"
+                        justifyContent="space-between">
+                        <InteractiveText
+                            isVisible
+                            variant="copy"
+                            text={toLocaleDateTime(time, false, 'UTC')}
+                            value={toISOString(time)} />
 
-                    <Badge variant="secondary" content="UTC" size="xs" />
-                </Layout.Stack>
+                        <Badge variant="secondary" content="UTC" size="xs" />
+                    </Layout.Stack>
 
-                <Layout.Stack
-                    direction="row"
-                    alignItems="center"
-                    alignContent="center"
-                    justifyContent="space-between">
-                    <InteractiveText
-                        isVisible
-                        variant="copy"
-                        text={toLocaleDateTime(time)}
-                        value={toLocalDateTimeISO(time)} />
-                    <Badge variant="secondary" content="Local" size="xs" />
+                    <Layout.Stack
+                        direction="row"
+                        alignItems="center"
+                        alignContent="center"
+                        justifyContent="space-between">
+                        <InteractiveText
+                            isVisible
+                            variant="copy"
+                            text={toLocaleDateTime(time)}
+                            value={toLocalDateTimeISO(time)} />
+                        <Badge variant="secondary" content="Local" size="xs" />
+                    </Layout.Stack>
                 </Layout.Stack>
             </Layout.Stack>
-        </Layout.Stack>
-    </div>
-</Popover>
+        </div>
+    </Popover>
+{:else}
+    <Typography.Text>{time === null || time === undefined ? 'null' : time}</Typography.Text>
+{/if}


### PR DESCRIPTION
## What does this PR do?

Fixes wrong date ui when the value is not valid.

## Test Plan

Manual.

Before -

<img width="2464" height="730" alt="image" src="https://github.com/user-attachments/assets/807f0b7a-cd99-4cab-afc1-316601d42c7c" />

After -

<img width="2470" height="586" alt="image" src="https://github.com/user-attachments/assets/d1fa11ba-4007-415a-a4e1-374827af038b" />


## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.