### PR TITLE
Fix: project creation using old org.

### DIFF
--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -210,4 +210,7 @@
 
 <CreateOrganization bind:show={addOrganization} />
 <CreateProject bind:show={showCreate} teamId={page.params.organization} />
-<CreateProjectCloud bind:showCreateProjectCloud regions={$regionsStore.regions} />
+<CreateProjectCloud
+    bind:showCreateProjectCloud
+    regions={$regionsStore.regions}
+    teamId={page.params.organization} />

--- a/src/routes/(console)/organization-[organization]/createProjectCloud.svelte
+++ b/src/routes/(console)/organization-[organization]/createProjectCloud.svelte
@@ -2,7 +2,6 @@
     import { sdk } from '$lib/stores/sdk';
     import { onDestroy } from 'svelte';
     import { goto, invalidate } from '$app/navigation';
-    import { page } from '$app/state';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
     import { ID, type Models, Region as ConsoleRegion, Region } from '@appwrite.io/console';
     import { base } from '$app/paths';
@@ -11,6 +10,7 @@
     import { Button } from '$lib/elements/forms';
     import { Dependencies } from '$lib/constants';
 
+    export let teamId: string;
     export let showCreateProjectCloud: boolean;
     export let regions: Array<Models.ConsoleRegion> = [];
 
@@ -20,7 +20,6 @@
     let region: ConsoleRegion = Region.Fra;
 
     let showSubmissionLoader = false;
-    const teamId = page.params.organization;
 
     async function create() {
         let project: Models.Project;


### PR DESCRIPTION
## What does this PR do?

The project creation modal was added on page load and therefore the `teamId` never changed on subsequent navigation. This PR fixes that.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.