### PR TITLE
Fix: Password Field Not Reset On Email Update

### DIFF
--- a/src/routes/(console)/account/updateEmail.svelte
+++ b/src/routes/(console)/account/updateEmail.svelte
@@ -25,6 +25,7 @@
                 type: 'success'
             });
             trackEvent(Submit.AccountUpdateEmail);
+            emailPassword = null;
         } catch (error) {
             addNotification({
                 message: error.message,

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -17,6 +17,7 @@
 
     async function updateVerificationEmail() {
         showVerificationDropdown = false;
+        let displayName: string;
         try {
             await sdk
                 .forProject(page.params.region, page.params.project)
@@ -39,6 +40,7 @@
     }
     async function updateVerificationPhone() {
         showVerificationDropdown = false;
+        let displayName: string;
         try {
             await sdk
                 .forProject(page.params.region, page.params.project)

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -46,7 +46,7 @@
             await invalidate(Dependencies.USER);
             addNotification({
                 message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
-                    $user.phoneVerification ? 'unverified' : 'verified'
+                    !$user.phoneVerification ? 'unverified' : 'verified'
                 }`,
                 type: 'success'
             });

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -23,6 +23,12 @@
                 .forProject(page.params.region, page.params.project)
                 .users.updateEmailVerification($user.$id, !$user.emailVerification);
             await invalidate(Dependencies.USER);
+
+            if ($user.name) {
+                // name formatter
+                displayName = $user.name;
+                displayName = `${displayName}${displayName[displayName.length - 1].toLowerCase() === 's' ? "' email" : "'s email"}`;
+            }
             addNotification({
                 message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
                     !$user.emailVerification ? 'unverified' : 'verified'

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -30,7 +30,7 @@
                 displayName = `${displayName}${displayName[displayName.length - 1].toLowerCase() === 's' ? "' email" : "'s email"}`;
             }
             addNotification({
-                message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
+                message: `${displayName || $user.email || $user.phone} has been ${
                     !$user.emailVerification ? 'unverified' : 'verified'
                 }`,
                 type: 'success'
@@ -59,7 +59,7 @@
                 displayName = `${displayName}${displayName[displayName.length - 1].toLowerCase() === 's' ? "' phone" : "'s phone"}`;
             }
             addNotification({
-                message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
+                message: `${displayName || $user.phone} has been ${
                     !$user.phoneVerification ? 'unverified' : 'verified'
                 }`,
                 type: 'success'

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -52,6 +52,12 @@
                 .forProject(page.params.region, page.params.project)
                 .users.updatePhoneVerification($user.$id, !$user.phoneVerification);
             await invalidate(Dependencies.USER);
+
+            if ($user.name || $user.email) {
+                // name email formatter
+                displayName = $user[$user.name ? 'name' : 'email'];
+                displayName = `${displayName}${displayName[displayName.length - 1].toLowerCase() === 's' ? "' phone" : "'s phone"}`;
+            }
             addNotification({
                 message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
                     !$user.phoneVerification ? 'unverified' : 'verified'


### PR DESCRIPTION
## What does this PR do?

This is a fix for `Password Field Not Reset On Email Update` Issue #976, There was another PR which had conflicts and the PR owner didn't resolve that for 1 month and I took the initiative for doing this.
- Just set the `emailPassword to null` after email updated successfully.

## Test Plan

> There is nothing to check the code only sets the password to null after successfully updating email

## Related PRs and Issues

There was this PR #1136 but it had conflicts and wasn't resolved till now (1 month has been passed)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/console/blob/master/CONTRIBUTING.md)?

- [X] I have read and followed the Guidelines showing above.