### PR TITLE
fix: redirect issue after deleting api key is resolved

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/(components)/delete.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/(components)/delete.svelte
@@ -17,7 +17,7 @@
 
     const isApiKey = keyType === 'api';
     const label = isApiKey ? 'API' : 'Dev';
-    const slug = isApiKey ? 'keys' : 'dev-keys';
+    const slug = isApiKey ? 'api-keys' : 'dev-keys';
     const event = isApiKey ? Submit.KeyDelete : Submit.DevKeyDelete;
     const dependency = isApiKey ? Dependencies.KEYS : Dependencies.DEV_KEYS;
 

--- a/src/routes/(console)/project-[region]-[project]/overview/(components)/deleteBatch.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/(components)/deleteBatch.svelte
@@ -19,7 +19,7 @@
     const projectId = page.params.project;
 
     async function handleDelete() {
-        const slug = isApiKey ? 'keys' : 'dev-keys';
+        const slug = isApiKey ? 'api-keys' : 'dev-keys';
         const event = isApiKey ? Submit.KeyDelete : Submit.DevKeyDelete;
         const dependency = isApiKey ? Dependencies.KEYS : Dependencies.DEV_KEYS;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR fixes the redirect after deleting an API key in the Console.
Previously, after deleting an API key, users were redirected to /overview/keys, which resulted in a 404 error.
Now, the redirect path is corrected to /overview/api-keys everywhere in the Console.
No other references to the old path remain.


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes