### PR TITLE
fix: Hide redeploy button when `sourceSize` is 0

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/+page.svelte
@@ -98,7 +98,7 @@
                                 </Button>
                                 <svelte:fragment slot="menu" let:toggle>
                                     <ActionMenu.Root>
-                                        {#if $canWriteFunctions}
+                                        {#if $canWriteFunctions && activeDeployment.sourceSize !== 0}
                                             <ActionMenu.Item.Button
                                                 trailingIcon={IconRefresh}
                                                 on:click={() => {

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/deployment-[deployment]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/deployment-[deployment]/+page.svelte
@@ -97,7 +97,7 @@
                     </Button>
                     <svelte:fragment slot="menu" let:toggle>
                         <ActionMenu.Root>
-                            {#if $canWriteFunctions}
+                            {#if $canWriteFunctions && data.deployment.sourceSize !== 0}
                                 <ActionMenu.Item.Button
                                     trailingIcon={IconRefresh}
                                     on:click={() => {

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/deployment-[deployment]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/deployment-[deployment]/+page.svelte
@@ -56,7 +56,9 @@
                 </Button>
             {/if}
 
-            <Button secondary on:click={() => (showRedeploy = true)}>Redeploy</Button>
+            {#if deployment?.sourceSize !== 0}
+                <Button secondary on:click={() => (showRedeploy = true)}>Redeploy</Button>
+            {/if}
             <DeploymentActionMenu
                 inCard
                 {deployment}


### PR DESCRIPTION
## What does this PR do?

Following the pattern established in [DeploymentActionMenu](https://github.com/appwrite/console/blob/main/src/routes/(console)/project-%5Bregion%5D-%5Bproject%5D/sites/(components)/deploymentActionMenu.svelte#L58-L68), this PR hides the `Redeploy` action/button in other places when `sourceSize` is 0.

## Test Plan

Manual QA: verified `Redeploy` button is hidden when deployment `sourceSize` is 0.

## Related PRs and Issues

#1894 where `Redeploy` item was first hidden in `DeploymentActionMenu`.