### PR TITLE
Use `getFilePreview` for screenshots in Console

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
@@ -51,8 +51,8 @@
             .storage.getFilePreview(
                 'screenshots',
                 fileId,
-                undefined,
-                undefined,
+                1024,
+                576,
                 undefined,
                 undefined,
                 undefined,

--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
@@ -2,7 +2,7 @@
     import { Card } from '$lib/components/index.js';
     import { humanFileSize } from '$lib/helpers/sizeConvertion';
     import { formatTimeDetailed } from '$lib/helpers/timeConversion';
-    import type { Models } from '@appwrite.io/console';
+    import { ImageFormat, type Models } from '@appwrite.io/console';
     import { page } from '$app/state';
     import {
         Badge,
@@ -46,7 +46,23 @@
     }
 
     function getFilePreview(fileId: string) {
-        return sdk.forConsoleIn(page.params.region).storage.getFileView('screenshots', fileId);
+        return sdk
+            .forConsoleIn(page.params.region)
+            .storage.getFilePreview(
+                'screenshots',
+                fileId,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                ImageFormat.Webp
+            );
     }
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
@@ -2,7 +2,7 @@
     import { base } from '$app/paths';
     import { page } from '$app/state';
     import { timeFromNow } from '$lib/helpers/date';
-    import type { Models } from '@appwrite.io/console';
+    import { ImageFormat, type Models } from '@appwrite.io/console';
     import { Card, Icon, Layout, Popover, Tooltip, Typography } from '@appwrite.io/pink-svelte';
     import { generateSiteDeploymentDesc } from './store';
     import { SvgIcon } from '$lib/components';
@@ -33,7 +33,23 @@
     }
 
     function getFilePreview(fileId: string) {
-        return sdk.forConsoleIn(page.params.region).storage.getFileView('screenshots', fileId);
+        return sdk
+            .forConsoleIn(page.params.region)
+            .storage.getFilePreview(
+                'screenshots',
+                fileId,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                ImageFormat.Webp
+            );
     }
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
@@ -38,8 +38,8 @@
             .storage.getFilePreview(
                 'screenshots',
                 fileId,
-                undefined,
-                undefined,
+                1024,
+                576,
                 undefined,
                 undefined,
                 undefined,


### PR DESCRIPTION
## What does this PR do?

- Uses `file-preview` API to load `webp` images shown in the site cards.

## Test Plan

- Verified images load successfully
- Massive reduction in image size from ~170kb(png) to ~25kb(webp).

## Related PRs and Issues

Blocked by https://github.com/appwrite/appwrite/pull/10181
