### PR TITLE
Default to `providerBranch` for manual VCS re-deployment

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
@@ -51,7 +51,10 @@
                 .vcs.listRepositoryBranches($installation.$id, selectedRepository);
 
             const sorted = sortBranches(branchList.branches);
-            branch = sorted[0]?.name ?? null;
+
+            branch = sorted.find((b) => b.name === $func.providerBranch)
+                ? $func.providerBranch
+                : (sorted[0]?.name ?? null);
 
             if (!branch) {
                 branch = 'main';

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
@@ -57,7 +57,10 @@
                 .vcs.listRepositoryBranches($installation.$id, selectedRepository);
 
             const sorted = sortBranches(branchList.branches);
-            branch = sorted[0]?.name ?? null;
+
+            branch = sorted.find((b) => b.name === site.providerBranch)
+                ? site.providerBranch
+                : (sorted[0]?.name ?? null);
 
             if (!branch) {
                 branch = 'main';


### PR DESCRIPTION
## What does this PR do?

Default to `providerBranch` for manual VCS re-deployment

## Test Plan

- Verified valid `providerBranch` is set in deployment modal
- When `providerBranch` is not in the repo's branch list, `main` is used as fallback.