### PR TITLE
fix: always send valid spec

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.svelte
@@ -60,7 +60,10 @@
     {#key data.site.providerRepositoryId}
         <UpdateRepository site={data.site} installations={data.installations} />
     {/key}
-    <UpdateBuildSettings site={data.site} frameworks={data.frameworks.frameworks} />
+    <UpdateBuildSettings
+        site={data.site}
+        frameworks={data.frameworks.frameworks}
+        specs={data.specificationsList} />
     <UpdateRuntimeSettings site={data.site} frameworks={data.frameworks.frameworks} />
     <UpdateVariables
         {sdkCreateVariable}

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
@@ -33,6 +33,11 @@ export const load = async ({ params, depends, parent }) => {
         }
     });
 
+    const enabledSpecs = specificationsList?.specifications?.filter((s) => s.enabled) ?? [];
+    if (!enabledSpecs.some((s) => s.slug === site.specification)) {
+        site.specification = enabledSpecs[0]?.slug;
+    }
+
     return {
         site,
         frameworks,

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -15,7 +15,15 @@
     import { getFrameworkIcon } from '$lib/stores/sites';
     import { page } from '$app/state';
 
-    let { site, frameworks, specs } = $props();
+    let {
+        site,
+        frameworks,
+        specs
+    }: {
+        site: Models.Site;
+        frameworks: Models.Framework[];
+        specs: Models.SpecificationList;
+    } = $props();
 
     let frameworkKey = $state(site.framework);
     let installCommand = $state(site?.installCommand);

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -82,25 +82,33 @@
         }
     });
 
+    $effect(() => {
+        if (selectedFramework) {
+            if (!selectedFramework.adapters.some((a) => a.key === adapter)) {
+                adapter = selectedFramework.adapters[0].key as Adapter;
+                site.adapter = adapter;
+            }
+            if (specs && specs.specifications?.length) {
+                if (!specs.specifications.some((s) => s.slug === site.specification)) {
+                    site.specification = specs.specifications[0].slug;
+                }
+            }
+        }
+    });
+
     async function update() {
         let adptr = selectedFramework.adapters.find((a) => a.key === adapter);
         if (!adptr?.key && selectedFramework.adapters?.length) {
             adapter = selectedFramework.adapters[0].key as Adapter;
             adptr = selectedFramework.adapters[0];
+            site.adapter = adapter;
         }
-        let specToSend = site?.specification;
-        if (!specToSend && specs && specs.specifications?.length) {
-            specToSend = specs.specifications[0].slug;
-            site.specification = specToSend;
-        }
-        if (
-            specs &&
-            specs.specifications?.length &&
-            !specs.specifications.some((s) => s.slug === specToSend)
-        ) {
-            specToSend = specs.specifications[0].slug;
-            site.specification = specToSend;
-        }
+        // only allow enabled specsification for it
+        const enabledSpecs = specs?.specifications?.filter((s) => s.enabled) ?? [];
+        let specToSend = enabledSpecs.some((s) => s.slug === site.specification)
+            ? site.specification
+            : enabledSpecs[0]?.slug;
+        site.specification = specToSend;
         try {
             await sdk
                 .forProject(page.params.region, page.params.project)

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -15,13 +15,7 @@
     import { getFrameworkIcon } from '$lib/stores/sites';
     import { page } from '$app/state';
 
-    let {
-        site,
-        frameworks
-    }: {
-        site: Models.Site;
-        frameworks: Models.Framework[];
-    } = $props();
+    let { site, frameworks, specs } = $props();
 
     let frameworkKey = $state(site.framework);
     let installCommand = $state(site?.installCommand);
@@ -94,6 +88,19 @@
             adapter = selectedFramework.adapters[0].key as Adapter;
             adptr = selectedFramework.adapters[0];
         }
+        let specToSend = site?.specification;
+        if (!specToSend && specs && specs.specifications?.length) {
+            specToSend = specs.specifications[0].slug;
+            site.specification = specToSend;
+        }
+        if (
+            specs &&
+            specs.specifications?.length &&
+            !specs.specifications.some((s) => s.slug === specToSend)
+        ) {
+            specToSend = specs.specifications[0].slug;
+            site.specification = specToSend;
+        }
         try {
             await sdk
                 .forProject(page.params.region, page.params.project)
@@ -115,7 +122,7 @@
                     site.providerBranch || undefined,
                     site.providerSilentMode || undefined,
                     site.providerRootDirectory || undefined,
-                    site?.specification || undefined
+                    specToSend || undefined
                 );
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -19,8 +19,6 @@
     let specification = site.specification;
     let originalSpecification = site.specification;
 
-    $: originalSpecification = site.specification;
-
     async function updateLogging() {
         try {
             await sdk

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -65,14 +65,6 @@
         value: spec.slug,
         disabled: !spec.enabled
     }));
-
-    $: {
-        const enabledSpecs = specs?.specifications?.filter((s) => s.enabled) ?? [];
-        if (!enabledSpecs.some((s) => s.slug === specification)) {
-            specification = enabledSpecs[0]?.slug;
-            site.specification = specification;
-        }
-    }
 </script>
 
 <Form onSubmit={updateLogging}>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -65,6 +65,14 @@
         value: spec.slug,
         disabled: !spec.enabled
     }));
+
+    $: {
+        const enabledSpecs = specs?.specifications?.filter((s) => s.enabled) ?? [];
+        if (!enabledSpecs.some((s) => s.slug === specification)) {
+            specification = enabledSpecs[0]?.slug;
+            site.specification = specification;
+        }
+    }
 </script>
 
 <Form onSubmit={updateLogging}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Add guard in build settings to ensure only valid specification slugs are sent to the backend; default to smallest spec if missing or invalid.
- Pass specs list to UpdateBuildSettings for validation.
- Clean up props destructuring to include specs.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes