### PR TITLE
fix: Enable Update button for any field change in all OAuth provider …

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/appleOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/appleOAuth.svelte
@@ -73,10 +73,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && keyID && teamID && p8)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/auth0OAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/auth0OAuth.svelte
@@ -77,10 +77,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && clientSecret && auth0Domain)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/authentikOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/authentikOAuth.svelte
@@ -81,10 +81,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && clientSecret && authentikDomain)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/gitlabOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/gitlabOAuth.svelte
@@ -76,10 +76,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && clientSecret)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/googleOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/googleOAuth.svelte
@@ -72,11 +72,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={!appId ||
-                !secret ||
-                (appId === provider.appId &&
-                    secret === provider.secret &&
-                    enabled === provider.enabled)}
+            disabled={secret === provider.secret &&
+                enabled === provider.enabled &&
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -71,11 +71,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={!appId ||
-                !secret ||
-                (appId === provider.appId &&
-                    secret === provider.secret &&
-                    enabled === provider.enabled)}
+            disabled={secret === provider.secret &&
+                enabled === provider.enabled &&
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/microsoftOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/microsoftOAuth.svelte
@@ -42,9 +42,8 @@
         clientSecret && tenantID ? JSON.stringify({ clientSecret, tenantID }) : provider.secret;
 </script>
 
-<Modal {error} onSubmit={update} bind:show on:close>
-    <svelte:fragment slot="title">{provider.name} OAuth2 settings</svelte:fragment>
-    <p>
+<Modal {error} onSubmit={update} bind:show on:close title={`${provider.name} OAuth2 settings`}>
+    <p slot="description">
         To use {provider.name} authentication in your application, first fill in this form. For more
         info you can
         <a class="link" href={oAuthProvider?.docs} target="_blank" rel="noopener noreferrer">
@@ -78,10 +77,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && clientSecret && tenantID)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/oidcOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/oidcOAuth.svelte
@@ -115,10 +115,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && isValidSecret)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/oktaOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/oktaOAuth.svelte
@@ -47,9 +47,14 @@
             : provider.secret;
 </script>
 
-<Modal {error} onSubmit={update} size="l" bind:show on:close>
-    <svelte:fragment slot="title">{provider.name} OAuth2 settings</svelte:fragment>
-    <p>
+<Modal
+    {error}
+    onSubmit={update}
+    size="m"
+    bind:show
+    on:close
+    title={`${provider.name} OAuth2 settings`}>
+    <p slot="description">
         To use {provider.name} authentication in your application, first fill in this form. For more
         info you can
         <a class="link" href={oAuthProvider?.docs} target="_blank" rel="noopener noreferrer"
@@ -88,10 +93,9 @@
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (provider = null)}>Cancel</Button>
         <Button
-            disabled={(secret === provider.secret &&
+            disabled={secret === provider.secret &&
                 enabled === provider.enabled &&
-                appId === provider.appId) ||
-                !(appId && clientSecret && oktaDomain && authorizationServerId)}
+                appId === provider.appId}
             submit>Update</Button>
     </svelte:fragment>
 </Modal>


### PR DESCRIPTION
…modals

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Updates all OAuth provider modals so the "Update" button is enabled as long as any change is made, regardless of which fields are filled.
Ensures the UI matches the "optional" label and backend/API behavior for all OAuth providers.
Improves user experience by removing unnecessary required-field enforcement in the UI.
Keeps the "Enabled" toggle as a control for activating or deactivating the provider for authentication, but does not restrict editing of other fields.
UI changes for Microsoft and Okta modals
Microsoft: Ensures the modal title always displays correctly and matches the style of other provider modals.
Okta: Adds a proper modal title and sets the modal width to be consistent with other OAuth modals.


## Test Plan

<img width="752" height="832" alt="image" src="https://github.com/user-attachments/assets/c05f027c-9250-42b2-8c5c-1abba21402c9" />
<img width="736" height="862" alt="image" src="https://github.com/user-attachments/assets/6fb5cad3-c4da-4c9d-970f-cb91e8f3a61c" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yes