### PR TITLE
Use defaultBranch from VCS in ProductionBranch field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@8836b0c",
+        "@appwrite.io/console": "https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@2289",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "^2.0.0-RC.1",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.1.24
         version: 1.1.24(svelte@5.25.3)(zod@3.24.3)
       '@appwrite.io/console':
-        specifier: https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@8836b0c
-        version: https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@8836b0c
+        specifier: https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@2289
+        version: https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@2289
       '@appwrite.io/pink-icons':
         specifier: 0.25.0
         version: 0.25.0
@@ -257,8 +257,8 @@ packages:
   '@analytics/type-utils@0.6.2':
     resolution: {integrity: sha512-TD+xbmsBLyYy/IxFimW/YL/9L2IEnM7/EoV9Aeh56U64Ify8o27HJcKjo38XY9Tcn0uOq1AX3thkKgvtWvwFQg==}
 
-  '@appwrite.io/console@https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@8836b0c':
-    resolution: {tarball: https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@8836b0c}
+  '@appwrite.io/console@https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@2289':
+    resolution: {tarball: https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@2289}
     version: 1.9.0
 
   '@appwrite.io/pink-icons-svelte@https://pkg.pr.new/appwrite/pink/@appwrite.io/pink-icons-svelte@fee5c539136e15c93cd3f2398d25cb217caa8dc8':
@@ -3661,7 +3661,7 @@ snapshots:
 
   '@analytics/type-utils@0.6.2': {}
 
-  '@appwrite.io/console@https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@8836b0c': {}
+  '@appwrite.io/console@https://pkg.pr.new/appwrite-labs/cloud/@appwrite.io/console@2289': {}
 
   '@appwrite.io/pink-icons-svelte@https://pkg.pr.new/appwrite/pink/@appwrite.io/pink-icons-svelte@fee5c539136e15c93cd3f2398d25cb217caa8dc8(svelte@5.25.3)':
     dependencies:

--- a/src/lib/components/git/productionBranchFieldset.svelte
+++ b/src/lib/components/git/productionBranchFieldset.svelte
@@ -16,17 +16,17 @@
     let show = false;
 
     async function loadBranches() {
+        const repo = await sdk
+            .forProject(page.params.region, page.params.project)
+            .vcs.getRepository(installationId, repositoryId);
+
+        branch = repo.defaultBranch ?? 'main';
+
         const { branches } = await sdk
             .forProject(page.params.region, page.params.project)
             .vcs.listRepositoryBranches(installationId, repositoryId);
-        const sorted = sortBranches(branches);
-        branch = sorted[0]?.name ?? null;
 
-        if (!branch) {
-            branch = 'main';
-        }
-
-        return sorted;
+        return sortBranches(branches);
     }
 </script>
 


### PR DESCRIPTION
## What does this PR do?

By default, we were showing `main` as the default branch when connecting an existing repository. But repositories can customise the default-branch on GitHub - this PR will show it.

## Test Plan

- Change the default branch in an existing GitHub repo.
- Connect the repo when deploying a site (or) function.
- Verify that the `ProductionBranch` value is set to customised branch on load. 

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/10190