### PR TITLE
fix:sync domain verification status after retry

### DIFF
--- a/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.svelte
@@ -26,7 +26,8 @@
     import { sdk } from '$lib/stores/sdk';
     import { addNotification } from '$lib/stores/notifications';
     import RetryDomainModal from '$routes/(console)/organization-[organization]/domains/retryDomainModal.svelte';
-    import { invalidateAll } from '$app/navigation';
+    import { invalidate } from '$app/navigation';
+    import { Dependencies } from '$lib/constants';
 
     export let data;
 
@@ -37,7 +38,7 @@
     let selectedPreset = '';
 
     async function reloadDomainData() {
-        await invalidateAll();
+        await Promise.all([invalidate(Dependencies.DOMAIN), invalidate(Dependencies.DOMAINS)]);
     }
 
     async function downloadRecords() {

--- a/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.svelte
@@ -26,6 +26,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { addNotification } from '$lib/stores/notifications';
     import RetryDomainModal from '$routes/(console)/organization-[organization]/domains/retryDomainModal.svelte';
+    import { invalidateAll } from '$app/navigation';
 
     export let data;
 
@@ -36,7 +37,6 @@
     let selectedPreset = '';
 
     async function reloadDomainData() {
-        const { invalidateAll } = await import('$app/navigation');
         await invalidateAll();
     }
 

--- a/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.svelte
@@ -35,6 +35,11 @@
     let showImportModal = false;
     let selectedPreset = '';
 
+    async function reloadDomainData() {
+        const { invalidateAll } = await import('$app/navigation');
+        await invalidateAll();
+    }
+
     async function downloadRecords() {
         try {
             const zone = await sdk.forConsole.domains.getZone(data.domain.$id);
@@ -149,5 +154,8 @@
 {/if}
 
 {#if showRetry}
-    <RetryDomainModal bind:show={showRetry} selectedDomain={data.domain} />
+    <RetryDomainModal
+        bind:show={showRetry}
+        selectedDomain={data.domain}
+        on:verified={reloadDomainData} />
 {/if}

--- a/src/routes/(console)/organization-[organization]/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/retryDomainModal.svelte
@@ -10,6 +10,7 @@
     import { Link } from '$lib/elements';
     import { consoleVariables } from '$routes/(console)/store';
     import type { Models } from '@appwrite.io/console';
+    import { createEventDispatcher } from 'svelte';
 
     let {
         show = $bindable(),
@@ -18,6 +19,8 @@
         show: boolean;
         selectedDomain: Models.Domain;
     } = $props();
+
+    const dispatch = createEventDispatcher();
 
     const nameservers = $consoleVariables?._APP_DOMAINS_NAMESERVERS.split(',') ?? [
         'ns1.appwrite.io',
@@ -35,6 +38,7 @@
                     type: 'success',
                     message: `${selectedDomain.domain} has been verified`
                 });
+                dispatch('verified');
             } else {
                 error =
                     'Domain verification failed. Please check your domain settings or try again later';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR ensures the domain verification status label in the UI updates immediately after a successful verification retry.
It dispatches a custom event from the retry modal and triggers a data refresh in the parent page, keeping the UI and backend state in sync without requiring a manual page reload.

## Test Plan 
<img width="1703" height="815" alt="image" src="https://github.com/user-attachments/assets/5a54d993-f1d2-49aa-ac1c-5404d325782c" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes