### PR TITLE
fix: correct project limit warnings for multi-organization users

### DIFF
--- a/src/lib/components/billing/alerts/selectProjectCloud.svelte
+++ b/src/lib/components/billing/alerts/selectProjectCloud.svelte
@@ -24,7 +24,11 @@
     let error = $state<string | null>(null);
 
     onMount(() => {
-        projects = page.data.allProjects?.projects || [];
+        const currentOrgId = page.data.organization?.$id;
+        projects =
+            page.data.currentOrgId === currentOrgId
+                ? page.data.allProjects?.projects || []
+                : [];
     });
 
     let projectsToArchive = $derived(

--- a/src/lib/components/billing/alerts/selectProjectCloud.svelte
+++ b/src/lib/components/billing/alerts/selectProjectCloud.svelte
@@ -11,7 +11,6 @@
     import { page } from '$app/state';
     import { toLocaleDate, toLocaleDateTime } from '$lib/helpers/date';
     import { currentPlan } from '$lib/stores/organization';
-    import { Query } from '@appwrite.io/console';
 
     let {
         showSelectProject = $bindable(false),
@@ -24,21 +23,8 @@
     let projects = $state<Array<Models.Project>>([]);
     let error = $state<string | null>(null);
 
-    onMount(async () => {
-        if (page.data.organization?.$id) {
-            try {
-                const orgProjects = await sdk.forConsole.projects.list([
-                    Query.equal('teamId', page.data.organization.$id),
-                    Query.limit(1000)
-                ]);
-                projects = orgProjects.projects;
-            } catch (e) {
-                error = 'Failed to load projects';
-                projects = [];
-            }
-        } else {
-            projects = [];
-        }
+    onMount(() => {
+        projects = page.data.allProjects?.projects || [];
     });
 
     let projectsToArchive = $derived(
@@ -48,7 +34,7 @@
     async function updateSelected() {
         try {
             await sdk.forConsole.billing.updateSelectedProjects(
-                page.data.organization.$id,
+                projects[0].teamId,
                 selectedProjects
             );
             showSelectProject = false;

--- a/src/lib/components/billing/alerts/selectProjectCloud.svelte
+++ b/src/lib/components/billing/alerts/selectProjectCloud.svelte
@@ -26,9 +26,7 @@
     onMount(() => {
         const currentOrgId = page.data.organization?.$id;
         projects =
-            page.data.currentOrgId === currentOrgId
-                ? page.data.allProjects?.projects || []
-                : [];
+            page.data.currentOrgId === currentOrgId ? page.data.allProjects?.projects || [] : [];
     });
 
     let projectsToArchive = $derived(

--- a/src/lib/layout/createProject.svelte
+++ b/src/lib/layout/createProject.svelte
@@ -47,7 +47,9 @@
         <Typography.Title size="l">Create your project</Typography.Title>
     {/if}
     {#if projectsLimited}
-        <Alert.Inline status="warning" title="You've reached your limit of 2 projects">
+        <Alert.Inline
+            status="warning"
+            title={`You've reached your limit of ${$currentPlan?.projects || 2} projects`}>
             Extra projects are available on paid plans for an additional fee
             <svelte:fragment slot="actions">
                 <Button

--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -325,7 +325,7 @@ export async function checkForProjectsLimit(org: Organization, orgProjectCount?:
     if (plan.$id !== BillingPlan.FREE) return;
     if (org.projects?.length > 0) return;
 
-    let projectCount = orgProjectCount;
+    const projectCount = orgProjectCount;
     if (projectCount === undefined) return;
 
     if (plan.projects > 0 && projectCount > plan.projects) {

--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -317,15 +317,24 @@ export function calculateTrialDay(org: Organization) {
     return days;
 }
 
-export async function checkForProjectsLimit(org: Organization, projects: number) {
+export async function checkForProjectsLimit(org: Organization, orgProjectCount?: number) {
     if (!isCloud) return;
-    if (!org || !projects) return;
+    if (!org) return;
     const plan = await sdk.forConsole.billing.getOrganizationPlan(org.$id);
     if (!plan) return;
     if (plan.$id !== BillingPlan.FREE) return;
     if (org.projects?.length > 0) return;
 
-    if (plan.projects > 0 && projects > plan.projects) {
+    let projectCount = orgProjectCount;
+    if (projectCount === undefined) {
+        const orgProjects = await sdk.forConsole.projects.list([
+            Query.equal('teamId', org.$id),
+            Query.limit(1000)
+        ]);
+        projectCount = orgProjects.projects.length;
+    }
+
+    if (plan.projects > 0 && projectCount > plan.projects) {
         headerAlert.add({
             id: 'projectsLimitReached',
             component: ProjectsLimit,

--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -326,13 +326,7 @@ export async function checkForProjectsLimit(org: Organization, orgProjectCount?:
     if (org.projects?.length > 0) return;
 
     let projectCount = orgProjectCount;
-    if (projectCount === undefined) {
-        const orgProjects = await sdk.forConsole.projects.list([
-            Query.equal('teamId', org.$id),
-            Query.limit(1000)
-        ]);
-        projectCount = orgProjects.projects.length;
-    }
+    if (projectCount === undefined) return;
 
     if (plan.projects > 0 && projectCount > plan.projects) {
         headerAlert.add({

--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -297,7 +297,11 @@
         if (currentOrganizationId === org.$id) return;
         if (isCloud) {
             currentOrganizationId = org.$id;
-            checkForProjectsLimit(org, data.allProjects?.projects?.length || 0);
+            const orgProjectCount =
+                data.allProjects && data.currentOrgId === org.$id
+                    ? data.allProjects.projects.length
+                    : undefined;
+            checkForProjectsLimit(org, orgProjectCount);
             checkForEnterpriseTrial(org);
             await checkForUsageLimit(org);
             checkForMarkedForDeletion(org);

--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -41,7 +41,6 @@
     import { currentPlan, regions as regionsStore } from '$lib/stores/organization';
     import SelectProjectCloud from '$lib/components/billing/alerts/selectProjectCloud.svelte';
     import { toLocaleDate } from '$lib/helpers/date';
-    import { BillingPlan } from '$lib/constants';
 
     export let data;
 
@@ -168,7 +167,7 @@
         </DropList>
     </div>
 
-    {#if isCloud && $currentPlan?.projects && $currentPlan?.projects > 0 && data.organization.projects.length > 0 && data.projects.total > $currentPlan.projects && $canWriteProjects && data.organization.billingPlan === BillingPlan.FREE}
+    {#if isCloud && $currentPlan?.projects && $currentPlan?.projects > 0 && data.organization.projects.length > 0 && data.projects.total > $currentPlan.projects && $canWriteProjects}
         <Alert.Inline
             title={`${data.projects.total - data.organization.projects.length} projects will be archived on ${toLocaleDate(billingProjectsLimitDate)}`}>
             <Typography.Text>

--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -41,6 +41,7 @@
     import { currentPlan, regions as regionsStore } from '$lib/stores/organization';
     import SelectProjectCloud from '$lib/components/billing/alerts/selectProjectCloud.svelte';
     import { toLocaleDate } from '$lib/helpers/date';
+    import { BillingPlan } from '$lib/constants';
 
     export let data;
 
@@ -167,7 +168,7 @@
         </DropList>
     </div>
 
-    {#if isCloud && $currentPlan?.projects && $currentPlan?.projects > 0 && data.organization.projects.length > 0 && data.projects.total > 2 && $canWriteProjects}
+    {#if isCloud && $currentPlan?.projects && $currentPlan?.projects > 0 && data.organization.projects.length > 0 && data.projects.total > $currentPlan.projects && $canWriteProjects && data.organization.billingPlan === BillingPlan.FREE}
         <Alert.Inline
             title={`${data.projects.total - data.organization.projects.length} projects will be archived on ${toLocaleDate(billingProjectsLimitDate)}`}>
             <Typography.Text>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes issue where users with multiple organizations (Free/Pro/Scale) 
saw incorrect project limit warnings and "Manage projects" modal 
showing projects from other organizations.

## Test Plan

<img width="1903" height="810" alt="image" src="https://github.com/user-attachments/assets/b74b6929-da6b-4704-a71f-f502f234bbb0" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes