### PR TITLE
fix: cross‑region realtime for deployment logs (NYC)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploying/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploying/+page.svelte
@@ -7,7 +7,7 @@
     import Aside from '../aside.svelte';
     import Logs from '../../(components)/logs.svelte';
     import { Copy, SvgIcon } from '$lib/components';
-    import { sdk } from '$lib/stores/sdk';
+    import { realtime } from '$lib/stores/sdk';
     import { goto } from '$app/navigation';
     import { onMount } from 'svelte';
     import { getFrameworkIcon } from '$lib/stores/sites';
@@ -18,9 +18,9 @@
     let deployment = $state(data.deployment);
 
     onMount(() => {
-        return sdk.forConsole.client.subscribe(
-            'console',
-            async (response: RealtimeResponseEvent<Models.Deployment>) => {
+        const unsubscribe = realtime
+            .forProject(page.params.region, page.params.project)
+            .subscribe('console', async (response: RealtimeResponseEvent<Models.Deployment>) => {
                 if (
                     response.events.includes(
                         `sites.${data.site.$id}.deployments.${data.deployment.$id}.update`
@@ -33,8 +33,11 @@
                         );
                     }
                 }
-            }
-        );
+            });
+
+        return () => {
+            unsubscribe();
+        };
     });
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/deployment-[deployment]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/deployment-[deployment]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Container } from '$lib/layout';
-    import { sdk } from '$lib/stores/sdk';
+    import { realtime } from '$lib/stores/sdk';
     import { onMount } from 'svelte';
     import type { Models, RealtimeResponseEvent } from '@appwrite.io/console';
     import SiteCard from '../../../(components)/siteCard.svelte';
@@ -30,9 +30,9 @@
     let showCancel = $state(false);
 
     onMount(() => {
-        return sdk.forConsole.client.subscribe(
-            'console',
-            async (response: RealtimeResponseEvent<Models.Deployment>) => {
+        const unsubscribe = realtime
+            .forProject(page.params.region, page.params.project)
+            .subscribe('console', async (response: RealtimeResponseEvent<Models.Deployment>) => {
                 if (
                     response.events.includes(
                         `sites.${page.params.site}.deployments.${page.params.deployment}.update`
@@ -40,8 +40,11 @@
                 ) {
                     await invalidate(Dependencies.DEPLOYMENT);
                 }
-            }
-        );
+            });
+
+        return () => {
+            unsubscribe();
+        };
     });
 </script>
 


### PR DESCRIPTION
…ions pattern

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

use region-scoped realtime realtime.forProject(...).subscribe on Sites deploying and deployment pages
invalidate on deployment updates to refresh build logs; remove forced remount key in logs component

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes