### PR TITLE
normalize framework icon size in onboarding card

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/components/OnboardingPlatformCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/components/OnboardingPlatformCard.svelte
@@ -49,6 +49,10 @@
             height: var(--icon-size);
             color: var(--icon-color);
         }
+
+        & :global(img) {
+            inline-size: var(--icon-size) !important;
+        }
     }
 
     :global(.theme-dark) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Force SvgIcon <img> to use var(--icon-size) via inline-size override so the left icon matches Appwrite icon in “Add web platform” modal. Changes in OnboardingPlatformCard.svelte.

## Test Plan
before
<img width="1597" height="717" alt="image" src="https://github.com/user-attachments/assets/6684866c-356b-4d68-ba5f-0a5c48ac78d1" />
after
<img width="1603" height="692" alt="image" src="https://github.com/user-attachments/assets/d8422346-5c58-4896-8d2d-beeccf415a55" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes