### PR TITLE
fix: coerce numeric values, and handle nullable correctly

### DIFF
--- a/src/lib/elements/forms/inputNumber.svelte
+++ b/src/lib/elements/forms/inputNumber.svelte
@@ -20,14 +20,15 @@
 
     function coerceToNumber(event: Event & { currentTarget: EventTarget & HTMLInputElement }) {
         const raw = event.currentTarget?.value ?? '';
-
         if (raw === '') {
             value = nullable ? null : (undefined as unknown as number);
             return;
         }
 
-        const parsed = step === 'any' ? Number.parseFloat(raw) : Number.parseInt(raw, 10);
-        value = Number.isNaN(parsed) ? null : parsed;
+        const parsed = Number(raw);
+        if (Number.isFinite(parsed)) {
+            value = parsed;
+        }
     }
 
     const handleInvalid = (event: Event & { currentTarget: EventTarget & HTMLInputElement }) => {

--- a/src/lib/elements/forms/inputNumber.svelte
+++ b/src/lib/elements/forms/inputNumber.svelte
@@ -18,6 +18,18 @@
 
     let error: string;
 
+    function coerceToNumber(event: Event & { currentTarget: EventTarget & HTMLInputElement }) {
+        const raw = event.currentTarget?.value ?? '';
+
+        if (raw === '') {
+            value = nullable ? null : (undefined as unknown as number);
+            return;
+        }
+
+        const parsed = step === 'any' ? Number.parseFloat(raw) : Number.parseInt(raw, 10);
+        value = Number.isNaN(parsed) ? null : parsed;
+    }
+
     const handleInvalid = (event: Event & { currentTarget: EventTarget & HTMLInputElement }) => {
         event.preventDefault();
 
@@ -39,7 +51,7 @@
         error = event.currentTarget.validationMessage;
     };
 
-    $: if (value) {
+    $: if (value !== null && value !== undefined && !Number.isNaN(value)) {
         error = null;
     }
 </script>
@@ -61,7 +73,8 @@
     helper={error || helper}
     state={error ? 'error' : 'default'}
     on:invalid={handleInvalid}
-    on:input>
+    on:input={coerceToNumber}
+    on:change={coerceToNumber}>
     <svelte:fragment slot="info">
         <slot name="info" slot="info" />
     </svelte:fragment>


### PR DESCRIPTION

## What does this PR do?

- Coerce input[type=number] string → number on input/change
- Treat '' as null when nullable; otherwise keep undefined for required to trigger
- Remove custom integer/min/max/error checks; use native validity + invalid handler
- Prevents sending string/empty values for integer attrs

## Test Plan

before:
<img width="710" height="234" alt="image" src="https://github.com/user-attachments/assets/482a5844-2967-42f1-b050-53a2a8f9c7be" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes