### PR TITLE
fix: remove dollar sign prefix from usage statistics tooltips

### DIFF
--- a/src/lib/components/progressbar/ProgressBar.svelte
+++ b/src/lib/components/progressbar/ProgressBar.svelte
@@ -29,7 +29,8 @@
                 style:width={`${(item.size / maxSize) * 100}%`}>
             </div>
             <div slot="tooltip">
-                <span class="u-bold">{item.tooltip.title}</span> ${item.tooltip.label}
+                <span class="u-bold">{item.tooltip.title}</span>
+                {item.tooltip.label}
             </div>
         </Tooltip>
     {/each}


### PR DESCRIPTION


## What does this PR do?

Remove hardcoded $ symbol from ProgressBar tooltip labels
- Prevents confusion where users might think usage stats are currency amounts
- Affects all progress bars showing storage, GB hours, and other usage metrics
- Fixes issue where "Builds storage 51.96MB" was displaying as "$51.96MB"

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes