### PR TITLE
Fix: adding payment method error when PM is empty

### DIFF
--- a/src/lib/components/billing/paymentModal.svelte
+++ b/src/lib/components/billing/paymentModal.svelte
@@ -42,7 +42,7 @@
 
             const card = await submitStripeCard(name, page?.params?.organization ?? null);
             if (card && Object.hasOwn(card, 'id')) {
-                if ((card as PaymentMethod).card.country === 'US') {
+                if ((card as PaymentMethod).card?.country === 'US') {
                     paymentMethod = card as PaymentMethod;
                     showState = true;
                     return;

--- a/src/lib/stores/stripe.ts
+++ b/src/lib/stores/stripe.ts
@@ -102,7 +102,7 @@ export async function submitStripeCard(name: string, organizationId?: string) {
         }
 
         if (setupIntent && setupIntent.status === 'succeeded') {
-            if ((setupIntent.payment_method as PaymentMethod).card.country === 'US') {
+            if ((setupIntent.payment_method as PaymentMethod).card?.country === 'US') {
                 // need to get state
                 return setupIntent.payment_method as PaymentMethod;
             }

--- a/src/routes/(console)/organization-[organization]/billing/replaceCard.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/replaceCard.svelte
@@ -54,7 +54,7 @@
                 } else {
                     const card = await submitStripeCard(name, organization.$id);
                     if (card && Object.hasOwn(card, 'id')) {
-                        if ((card as PaymentMethod).card.country === 'US') {
+                        if ((card as PaymentMethod).card?.country === 'US') {
                             paymentMethod = card as PaymentMethod;
                             showState = true;
                             return;

--- a/src/routes/(console)/organization-[organization]/billing/retryPaymentModal.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/retryPaymentModal.svelte
@@ -66,7 +66,7 @@
                     } else {
                         const card = await submitStripeCard(name, $organization.$id);
                         if (card && Object.hasOwn(card, 'id')) {
-                            if ((card as PaymentMethod).card.country === 'US') {
+                            if ((card as PaymentMethod).card?.country === 'US') {
                                 paymentMethod = card as PaymentMethod;
                                 showState = true;
                                 return;

--- a/src/routes/(console)/organization-[organization]/billing/wizard/paymentDetails.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/wizard/paymentDetails.svelte
@@ -34,7 +34,7 @@
             } else {
                 const card = await submitStripeCard(name, $organization.$id);
                 if (card && Object.hasOwn(card, 'id')) {
-                    if ((card as PaymentMethod).card.country === 'US') {
+                    if ((card as PaymentMethod).card?.country === 'US') {
                         paymentMethod = card as PaymentMethod;
                         showState = true;
                         return;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Add null operator to access country to make sure it doesn't throw error when card is empty or undefined

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)