### PR TITLE
feat: add View source button to template detail page #10325

### DIFF
--- a/src/lib/helpers/templateSource.ts
+++ b/src/lib/helpers/templateSource.ts
@@ -1,26 +1,26 @@
-import type { Models } from "@appwrite.io/console";
+import type { Models } from '@appwrite.io/console';
 
 /**
  * Build VCS repo URL from the template response model.
  * Example (GitHub): https://github.com/appwrite/templates-for-sites
  */
 export function getTemplateSourceUrl(
-  t: Models.TemplateSite | Models.TemplateFunction
+    t: Models.TemplateSite | Models.TemplateFunction
 ): string | null {
-  const owner = t.providerOwner;
-  const repo  = t.providerRepositoryId;
-  const provider = t.vcsProvider; // e.g., "github"
+    const owner = t.providerOwner;
+    const repo = t.providerRepositoryId;
+    const provider = t.vcsProvider; // e.g., "github"
 
-  if (!owner || !repo || !provider) return null;
+    if (!owner || !repo || !provider) return null;
 
-  // Map provider → host (extend if needed)
-  const hostMap: Record<string, string> = {
-    github: "github.com",
-    gitlab: "gitlab.com",
-    bitbucket: "bitbucket.org",
-  };
+    // Map provider → host (extend if needed)
+    const hostMap: Record<string, string> = {
+        github: 'github.com',
+        gitlab: 'gitlab.com',
+        bitbucket: 'bitbucket.org'
+    };
 
-  const host = hostMap[provider.toLowerCase()] ?? provider; // fallback
+    const host = hostMap[provider.toLowerCase()] ?? provider; // fallback
 
-  return `https://${host}/${owner}/${repo}`;
+    return `https://${host}/${owner}/${repo}`;
 }

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/aside.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/aside.svelte
@@ -62,7 +62,7 @@
                         </Typography.Text>
                     </Layout.Stack>
                 </Layout.Stack>
-                    <slot name="framework-actions" />
+                <slot name="framework-actions" />
             {/if}
 
             {#if domain && showAfter}

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
@@ -352,15 +352,11 @@
                     alt={data.template.name}
                     ratio="16/9" />
             </Layout.Stack>
-            
-            <svelte:fragment slot="framework-actions" >
+
+            <svelte:fragment slot="framework-actions">
                 {@const sourceUrl = getTemplateSourceUrl(data.template)}
                 {#if sourceUrl}
-                    <Button 
-                        secondary 
-                        size="s" 
-                        external 
-                        href={sourceUrl}>
+                    <Button secondary size="s" external href={sourceUrl}>
                         View source
                         <Icon icon={IconExternalLink} slot="end" size="s" />
                     </Button>


### PR DESCRIPTION
## What does this PR do?
Fixes: #10325
This PR adds a **"View source"** button to the template detail page, placed next to the framework section.  
- Button opens the GitHub source repository for the selected template  
- Styled with `size="s"` (32px height), sentence-case text ("View source"), and proper alignment with the icon  
- Added spacing to ensure consistent layout with surrounding elements  

<img width="1919" height="915" alt="image" src="https://github.com/user-attachments/assets/0a6154f9-c06e-4515-91ed-12b957b1e74a" />


## Test Plan

1. Go to **Create Site → Choose a template → Template detail page**  
2. Confirm that a "View source" button is visible next to the framework section  
3. Verify:
   - Button opens the template’s GitHub repository in a new tab  
   - Alignment between text and icon is centered  
   - Spacing above and below matches design guidelines  

## Related PRs and Issues


- [Feature Request: View source button on template detail page](https://github.com/appwrite/appwrite/issues/10325) appwrite#10325

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes ✅
