### PR TITLE
fix: nowrap on spans of selection of deployments on both functions and s…

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/table.svelte
@@ -227,7 +227,7 @@
     <FloatingActionBar>
         <svelte:fragment slot="start">
             <Badge content={selectedRows.length.toString()} />
-            <span>
+            <span style="white-space: nowrap">
                 {selectedRows.length > 1 ? 'deployments' : 'deployment'}
                 selected
             </span>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/table.svelte
@@ -155,7 +155,7 @@
     <FloatingActionBar>
         <svelte:fragment slot="start">
             <Badge content={selectedRows.length.toString()} />
-            <span>
+            <span style="white-space: nowrap">
                 {selectedRows.length > 1 ? 'deployments' : 'deployment'}
                 selected
             </span>


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
 
nowrap on spans of selection of deployments on both functions and sites

## Test Plan

Before:
<img width="888" height="186" alt="image" src="https://github.com/user-attachments/assets/6f767ddb-52b1-4d95-b6f7-36dfec97a7d0" />


After:
<img width="268" height="581" alt="image" src="https://github.com/user-attachments/assets/53c2ef1f-1f34-4355-aed0-fec73ae31111" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes