### PR TITLE
Fix: prefs corruption

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/create.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/create.svelte
@@ -119,12 +119,6 @@
             createMore = false;
         }
     });
-
-    $effect(() => {
-        if ($createRow) {
-            console.log($createRow.row);
-        }
-    });
 </script>
 
 {#if $createRow}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Using `$id` as a key for maintaining column widths broke the prefs. Now uses `$uid`

Before -

<img width="832" height="248" alt="Screenshot 2025-08-27 at 5 08 28 PM" src="https://github.com/user-attachments/assets/48375a9e-3b93-419c-8240-82d8c5594d95" />

After -

<img width="834" height="238" alt="Screenshot 2025-08-27 at 5 08 58 PM" src="https://github.com/user-attachments/assets/1337f962-1f70-4d53-9c95-98a9004be29c" />

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)