### PR TITLE
Fix: e2e flow

### DIFF
--- a/e2e/journeys/upgrade-free-tier.spec.ts
+++ b/e2e/journeys/upgrade-free-tier.spec.ts
@@ -13,7 +13,9 @@ test('upgrade - free tier', async ({ page }) => {
 
         await page
             .locator('#no-payments-card-stack')
-            .getByRole('button', { name: 'add' }).first().click();
+            .getByRole('button', { name: 'add' })
+            .first()
+            .click();
 
         await enterCreditCard(page);
 

--- a/e2e/journeys/upgrade-free-tier.spec.ts
+++ b/e2e/journeys/upgrade-free-tier.spec.ts
@@ -11,12 +11,6 @@ test('upgrade - free tier', async ({ page }) => {
         await page.waitForURL(/\/organization-[^/]+\/change-plan/);
         await page.locator('input[value="tier-1"]').click();
 
-        await page
-            .locator('#no-payments-card-stack')
-            .getByRole('button', { name: 'add' })
-            .first()
-            .click();
-
         await enterCreditCard(page);
 
         // wait for a second after adding a card to update the UI.

--- a/e2e/journeys/upgrade-free-tier.spec.ts
+++ b/e2e/journeys/upgrade-free-tier.spec.ts
@@ -10,7 +10,10 @@ test('upgrade - free tier', async ({ page }) => {
         await page.getByRole('link', { name: 'Upgrade', exact: true }).click();
         await page.waitForURL(/\/organization-[^/]+\/change-plan/);
         await page.locator('input[value="tier-1"]').click();
-        await page.getByRole('button', { name: 'add' }).first().click();
+
+        await page
+            .locator('#no-payments-card-stack')
+            .getByRole('button', { name: 'add' }).first().click();
 
         await enterCreditCard(page);
 

--- a/e2e/steps/pro-project.ts
+++ b/e2e/steps/pro-project.ts
@@ -7,12 +7,15 @@ type Metadata = {
 };
 
 export async function enterCreditCard(page: Page) {
-    const dialog = page.locator('.modal').filter({
-        hasText: 'add payment method'
-    });
-    await dialog.waitFor({
-        state: 'visible'
-    });
+    // click the add payment method and open the modal
+    await page
+        .locator('#no-payments-card-stack')
+        .getByRole('button', { name: 'add' })
+        .first()
+        .click();
+
+    const dialog = page.locator('.modal').filter({ hasText: 'add payment method' });
+    await dialog.waitFor({ state: 'visible' });
     await page.getByPlaceholder('cardholder').fill('Test User');
     const stripe = page.locator('[title="Secure payment input frame"]').nth(0).contentFrame();
     await stripe.locator('id=Field-numberInput').fill('4242424242424242');
@@ -35,7 +38,6 @@ export async function createProProject(page: Page): Promise<Metadata> {
         await page.getByRole('radio', { name: /^Pro\b/ }).check();
         // `create organization` because there's already free created on start!
         await page.getByRole('button', { name: 'create organization' }).click();
-        await page.getByRole('button', { name: 'add' }).first().click();
         await enterCreditCard(page);
         // skip members
         await page.getByRole('button', { name: 'create organization' }).click();

--- a/src/lib/components/billing/selectPaymentMethod.svelte
+++ b/src/lib/components/billing/selectPaymentMethod.svelte
@@ -78,7 +78,7 @@
         </Layout.Stack>
     {:else}
         <Card.Base variant="secondary" radius="s" padding="xs">
-            <Layout.Stack direction="row">
+            <Layout.Stack direction="row" id="no-payments-card-stack">
                 <Layout.Stack direction="row" gap="xxs" alignItems="center">
                     <Icon
                         icon={IconExclamationCircle}

--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -143,11 +143,13 @@
                 null
             );
 
-            trackDowngradeFeedback();
-
-            await invalidate(Dependencies.ORGANIZATION);
+            await Promise.all([
+                await trackDowngradeFeedback(),
+                await invalidate(Dependencies.ORGANIZATION),
+            ])
 
             await goto(previousPage);
+            
             addNotification({
                 type: 'success',
                 message: `${$organization.name} plan has been successfully updated.`

--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -145,11 +145,11 @@
 
             await Promise.all([
                 await trackDowngradeFeedback(),
-                await invalidate(Dependencies.ORGANIZATION),
-            ])
+                await invalidate(Dependencies.ORGANIZATION)
+            ]);
 
             await goto(previousPage);
-            
+
             addNotification({
                 type: 'success',
                 message: `${$organization.name} plan has been successfully updated.`

--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -144,8 +144,8 @@
             );
 
             await Promise.all([
-                await trackDowngradeFeedback(),
-                await invalidate(Dependencies.ORGANIZATION)
+                trackDowngradeFeedback(),
+                invalidate(Dependencies.ORGANIZATION)
             ]);
 
             await goto(previousPage);

--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -143,10 +143,7 @@
                 null
             );
 
-            await Promise.all([
-                trackDowngradeFeedback(),
-                invalidate(Dependencies.ORGANIZATION)
-            ]);
+            await Promise.all([trackDowngradeFeedback(), invalidate(Dependencies.ORGANIZATION)]);
 
             await goto(previousPage);
 


### PR DESCRIPTION
## What does this PR do?

E2E failed due to another button in the view. Added explicit ID and a locator for correct target fetch!

## Test Plan

Manual via `pnpm e2e:ui`

<img width="1198" height="229" alt="Screenshot 2025-08-29 at 12 15 27 PM" src="https://github.com/user-attachments/assets/e875a3e0-653d-41db-bfe4-79444e0bc05c" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when opening the payment-method area during upgrade flows.
  - Made plan change/downgrade flow more robust by running feedback tracking and data refresh together, improving navigation and error handling.

- Tests
  - Streamlined end-to-end upgrade journey to consistently open the payment modal and proceed directly to entering payment details, reducing flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->