### PR TITLE
Fix: edge cases for banner spacing and overlay empty sheet

### DIFF
--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -34,7 +34,7 @@
     import { showSupportModal } from '$routes/(console)/wizard/support/store';
     import MobileSupportModal from '$routes/(console)/wizard/support/mobileSupportModal.svelte';
     import MobileFeedbackModal from '$routes/(console)/wizard/feedback/mobileFeedbackModal.svelte';
-    import { getSidebarState, updateSidebarState } from '$lib/helpers/sidebar';
+    import { getSidebarState, isInDatabasesRoute, updateSidebarState } from '$lib/helpers/sidebar';
     import { isTabletViewport, isSmallViewport } from '$lib/stores/viewport';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import { bannerSpacing } from '$lib/layout/headerAlert.svelte';
@@ -73,8 +73,6 @@
         }
     }
 
-    $: state = $isTabletViewport ? 'closed' : getSidebarState();
-
     const projectOptions = [
         { name: 'Auth', icon: IconUserGroup, slug: 'auth', category: 'build' },
         { name: 'Databases', icon: IconDatabase, slug: 'databases', category: 'build' },
@@ -93,6 +91,13 @@
     const isSelected = (service: string): boolean => {
         return $page.route.id?.includes(service);
     };
+
+    $: state = $isTabletViewport
+        ? 'closed'
+        : // example: manual resize
+          isInDatabasesRoute($page.route)
+          ? 'icons'
+          : getSidebarState();
 </script>
 
 <div
@@ -359,15 +364,16 @@
     </Sidebar.Base>
 </div>
 
-{#if subNavigation}
-    <div
-        class="sub-navigation"
-        class:icons={state === 'icons'}
-        class:no-transitions={$noWidthTransition}
-        style:--banner-spacing={$bannerSpacing ? $bannerSpacing : undefined}>
-        <svelte:component this={subNavigation} />
-    </div>
-{/if}
+<div style:--banner-spacing={$bannerSpacing ? $bannerSpacing : undefined}>
+    {#if subNavigation}
+        <div
+            class="sub-navigation"
+            class:icons={state === 'icons'}
+            class:no-transitions={$noWidthTransition}>
+            <svelte:component this={subNavigation} />
+        </div>
+    {/if}
+</div>
 
 <style lang="scss">
     .sidebar {
@@ -634,7 +640,7 @@
             background-color: var(--bgcolor-neutral-primary, #fff);
             z-index: 14;
             position: fixed;
-            top: 48px;
+            top: var(--banner-spacing, 48px);
             transition: width 0.2s linear;
 
             &.icons {

--- a/src/lib/layout/headerAlert.svelte
+++ b/src/lib/layout/headerAlert.svelte
@@ -11,6 +11,7 @@
     import { Button } from '$lib/elements/forms';
     import { Icon } from '@appwrite.io/pink-svelte';
     import { IconX } from '@appwrite.io/pink-icons-svelte';
+    import { afterNavigate } from '$app/navigation';
 
     export let title: string;
     export let type: 'info' | 'success' | 'warning' | 'error' | 'default' = 'info';
@@ -33,8 +34,12 @@
             sidebar.style.top = `${alertHeight + ($isTabletViewport ? 0 : header.getBoundingClientRect().height)}px`;
             sidebar.style.height = `calc(100vh - (${alertHeight + ($isTabletViewport ? 0 : header.getBoundingClientRect().height)}px))`;
 
-            // for sidebar and sub-navigation!
-            bannerSpacing.set(`${alertHeight}px`);
+            if (alertHeight) {
+                // for sidebar and sub-navigation!
+                bannerSpacing.set(`${alertHeight}px`);
+            } else {
+                bannerSpacing.set(undefined);
+            }
         }
 
         if (contentSection) {
@@ -50,6 +55,8 @@
         container = null;
         setNavigationHeight();
     });
+
+    afterNavigate(() => setNavigationHeight());
 </script>
 
 <svelte:window on:resize={setNavigationHeight} />


### PR DESCRIPTION
## What does this PR do?

1. Banner spacing was not correctly updated when a child snippet's content increased in height due to overflowing content.
2. Manual resize would show opened state sidebar on sheets screen, edge case but fixed.
3. Fixes incorrect height on empty sheet's overlay unless resized manually. This would also cover clickable buttons making them useless.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sidebar now auto-switches to icon-only view on database pages for better focus.

- Bug Fixes
  - Corrected header/alert spacing so sidebar and content align reliably after navigation.
  - Resolved occasional incorrect panel heights during resizes.

- Style
  - Sub-navigation spacing now respects the global banner spacing for consistent visuals.

- Refactor
  - Replaced window resize listeners with ResizeObserver for smoother, more efficient layout updates.
  - Debounced height recalculations to reduce jank and improve responsiveness.
  - Adjusted empty sheet overlay default height for better initial fit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->