### PR TITLE
Fix: faker

### DIFF
--- a/src/lib/helpers/faker.ts
+++ b/src/lib/helpers/faker.ts
@@ -148,6 +148,14 @@ function generateSingleValue(column: Columns): string | number | boolean | null 
                     case 'url': {
                         return faker.internet.url();
                     }
+
+                    case 'enum': {
+                        const enumAttr = column as Models.ColumnEnum;
+                        if (enumAttr.elements?.length > 0) {
+                            return faker.helpers.arrayElement(enumAttr.elements);
+                        }
+                        return null;
+                    }
                 }
                 return '';
             } else {
@@ -180,14 +188,6 @@ function generateSingleValue(column: Columns): string | number | boolean | null 
 
         case 'datetime': {
             return faker.date.recent({ days: 365 }).toISOString();
-        }
-
-        case 'enum': {
-            const enumAttr = column as Models.ColumnEnum;
-            if (enumAttr.elements && enumAttr.elements.length > 0) {
-                return faker.helpers.arrayElement(enumAttr.elements);
-            }
-            return null;
         }
 
         default: {

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
@@ -252,8 +252,9 @@
 
         let columns = $table.columns;
         const hasAnyRelationships = columns.some((column) => isRelationship(column));
+        const filteredColumns = columns.filter((col) => col.type !== 'relationship');
 
-        if (!columns.length) {
+        if (!filteredColumns.length) {
             try {
                 columns = await generateColumns($project, page.params.database, page.params.table);
 


### PR DESCRIPTION
## What does this PR do?

1. If all columns were relationships, no real columns existed and the faker tried to add rows without columns.
2. Enum generation was skewed because its a String type with enum format.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enum fields now generate valid sample values when creating mock data, improving consistency for string fields with enum formats.
  - Columns are now auto-generated even when a table contains only relationship columns, avoiding blocked setup in the table view.
  - Other data type generation remains unchanged, ensuring stability across integer, float, boolean, and datetime fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->