### PR TITLE
Fix: `NULL` not shown on boolean types in inline edit mode.

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/boolean.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/boolean.svelte
@@ -13,18 +13,20 @@
         label = undefined;
         optionalText = undefined;
     }
+
+    $: options = [
+        !column.required && { label: 'NULL', value: null },
+        { label: limited ? 'true' : 'True', value: true },
+        { label: limited ? 'false' : 'False', value: false }
+    ].filter(Boolean);
 </script>
 
 <InputSelect
     {id}
     {label}
     bind:value
+    {options}
     {optionalText}
     autofocus={limited}
     placeholder="Select a value"
-    required={column.required}
-    options={[
-        !column.required && { label: 'NULL', value: null },
-        { label: 'True', value: true },
-        { label: 'False', value: false }
-    ].filter(Boolean)} />
+    required={column.required} />

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/boolean.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/boolean.svelte
@@ -13,40 +13,18 @@
         label = undefined;
         optionalText = undefined;
     }
-
-    const onChange = (event: CustomEvent) => {
-        if (limited) {
-            value = event.detail as boolean;
-        }
-    };
 </script>
 
-{#if limited}
-    <InputSelect
-        {id}
-        {label}
-        {value}
-        {optionalText}
-        autofocus={limited}
-        placeholder="Select a value"
-        required={column.required}
-        options={[
-            { label: 'True', value: true },
-            { label: 'False', value: false }
-        ].filter(Boolean)}
-        on:change={onChange} />
-{:else}
-    <InputSelect
-        {id}
-        {label}
-        bind:value
-        {optionalText}
-        autofocus={limited}
-        placeholder="Select a value"
-        required={column.required}
-        options={[
-            !column.required && { label: 'NULL', value: null },
-            { label: 'True', value: true },
-            { label: 'False', value: false }
-        ].filter(Boolean)} />
-{/if}
+<InputSelect
+    {id}
+    {label}
+    bind:value
+    {optionalText}
+    autofocus={limited}
+    placeholder="Select a value"
+    required={column.required}
+    options={[
+        !column.required && { label: 'NULL', value: null },
+        { label: 'True', value: true },
+        { label: 'False', value: false }
+    ].filter(Boolean)} />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

`NULL` was missing for a nullable column type.

<img width="777" height="285" alt="Screenshot 2025-08-29 at 7 35 13 PM" src="https://github.com/user-attachments/assets/9ef255bd-a163-4db4-a93d-83a905cd78f0" />

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified the Boolean field editor to always use a single dropdown with two-way selection.
  - Preserved choices: True, False, and NULL when a column is optional.
  - Maintained autofocus; interaction is now smoother and more consistent across modes.
  - No changes to user-facing settings or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->