### PR TITLE
Fix: float and integer fake data gen

### DIFF
--- a/src/lib/helpers/faker.ts
+++ b/src/lib/helpers/faker.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 import type { Columns } from '$routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/store';
 import { ID, type Models } from '@appwrite.io/console';
 import { sdk } from '$lib/stores/sdk';
+import { isWithinSafeRange } from '$lib/helpers/numbers';
 
 export async function generateColumns(
     project: Models.Project,
@@ -167,19 +168,18 @@ function generateSingleValue(column: Columns): string | number | boolean | null 
 
         case 'integer': {
             const intAttr = column as Models.ColumnInteger;
-            const min = intAttr.min ?? 0;
-            const max = intAttr.max ?? 10000;
+            const min = !isWithinSafeRange(intAttr.min) ? 0 : intAttr.min;
+            const max = !isWithinSafeRange(intAttr.max) ? 100 : intAttr.max;
             return faker.number.int({ min, max });
         }
 
-        case 'float': {
+        case 'double': {
             const floatAttr = column as Models.ColumnFloat;
-            const min = floatAttr.min ?? 0;
-            const max = floatAttr.max ?? 1000000;
-            const precision = 2;
-            return parseFloat(
-                faker.number.float({ min, max, fractionDigits: precision }).toFixed(precision)
-            );
+            const min = !isWithinSafeRange(floatAttr.min) ? 0 : floatAttr.min;
+            const max = !isWithinSafeRange(floatAttr.max) ? 100 : floatAttr.max;
+            const precision = 4;
+
+            return faker.number.float({ min, max, fractionDigits: precision });
         }
 
         case 'boolean': {

--- a/src/lib/helpers/numbers.ts
+++ b/src/lib/helpers/numbers.ts
@@ -32,3 +32,7 @@ export function formatCurrency(number: number, locale = 'en-US', currency = 'USD
     });
     return formatter.format(number);
 }
+
+export function isWithinSafeRange(val: number) {
+    return Math.abs(val) < Number.MAX_SAFE_INTEGER;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When the limit range is not defined for integer and float columns, backend uses PHP's limits which goes way out of bounds on Console. This fixes it.

## Test Plan

Manual -

https://github.com/user-attachments/assets/4e47449f-cf09-4126-bf80-28a92e0d5325

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased precision for generated double values from 2 to 4 decimal places.

- Bug Fixes
  - Numeric data generation now constrained to safe ranges to prevent unrealistic or overflow values.
  - Adjusted default ranges for integers and doubles to produce more reliable mock data.
  - Standardized handling of floating-point type as “double” for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->