### PR TITLE
Update: improved prefs

### DIFF
--- a/src/lib/components/columnSelector.svelte
+++ b/src/lib/components/columnSelector.svelte
@@ -59,23 +59,23 @@
     };
 
     const saveColumnPreferences = () => {
-        const shownColumns = $columns.filter((n) => n.hide === true).map((n) => n.id);
+        const hiddenColumns = $columns.filter((n) => n.hide === true).map((n) => n.id);
 
         if (isCustomTable) {
             onPreferencesUpdated?.();
-            preferences.setCustomTableColumns(page.params.table, shownColumns);
+            preferences.setCustomTableColumns(page.params.table, hiddenColumns);
         } else {
-            preferences.setColumns(shownColumns);
+            preferences.setColumns(hiddenColumns);
         }
     };
 
     onMount(() => {
         if (isCustomTable) {
-            const shownColumns = preferences.getCustomTableColumns(page.params.table);
+            const hiddenColumns = preferences.getCustomTableColumns(page.params.table);
 
             columns.update((n) =>
                 n.map((column) => {
-                    column.hide = shownColumns?.includes(column.id) ?? false;
+                    column.hide = hiddenColumns?.includes(column.id) ?? false;
                     return column;
                 })
             );

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/settings/displayName.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/settings/displayName.svelte
@@ -93,8 +93,11 @@
                     {#each names as name, index}
                         <Layout.Stack direction="row" gap="xxs">
                             {@const options = getOptions(index)}
+                            {@const onlyId = names.length === 1 && name === '$id'}
                             {@const disabled =
-                                (!!names[index] && names.length > index + 1) || hasExhaustedOptions}
+                                !onlyId &&
+                                ((!!names[index] && names.length > index + 1) ||
+                                    hasExhaustedOptions)}
 
                             <InputSelect
                                 id={name}


### PR DESCRIPTION
## What does this PR do?

1. Prevents an edge case when some top level or nested key becomes array when it should be an object. Due to this, the changes don't persist after a reload.

2. Fixes showing an empty disabled item for display names when only `$id` is the value.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - You can now select the single “$id” option as a display name when it’s the only available choice.
  - Column visibility preferences load and save consistently across standard and custom tables, preventing mismatches.

- Refactor
  - Streamlined how column visibility is stored for consistency.
  - Hardened preference handling to better tolerate missing or malformed data and ensure reliable syncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->