### PR TITLE
fix: move security headers to API-only location block

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -6,12 +6,6 @@ server {
 
     root /usr/share/nginx/html;
 
-    # Security headers for all locations
-    add_header X-UA-Compatible "IE=Edge";
-    add_header X-Frame-Options SAMEORIGIN;
-    add_header X-XSS-Protection "1; mode=block;";
-    add_header X-Content-Type-Options nosniff;
-
     # Only cache files in /console/_app/immutable/ for 1 year
     location /console/_app/immutable/ {
         try_files $uri =404;
@@ -35,6 +29,12 @@ server {
         expires 0;
         add_header Cache-Control "no-cache, no-store";
         add_header Pragma "no-cache";
+
+        # Security headers
+        add_header X-UA-Compatible "IE=Edge";
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-XSS-Protection "1; mode=block;";
+        add_header X-Content-Type-Options nosniff;
     }
 
     location / {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited security headers to the Console section to avoid unintended restrictions on other pages.
* **Chores**
  * Updated server configuration to scope headers to the Console path only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->