### PR TITLE
fix: binding the paginator to data.projects.total

### DIFF
--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -157,7 +157,7 @@
     {#if activeProjects.length > 0}
         <CardContainer
             disableEmpty={!$canWriteProjects}
-            total={activeProjects.length}
+            total={data.projects.total}
             offset={data.offset}
             on:click={handleCreateProject}>
             {#each activeProjects as project}
@@ -242,7 +242,7 @@
         name="Projects"
         limit={data.limit}
         offset={data.offset}
-        total={activeProjects.length} />
+        total={data.projects.total} />
 
     <!-- Archived Projects Section -->
     <ArchiveProject


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

<img width="1738" height="793" alt="image" src="https://github.com/user-attachments/assets/c64c318f-94f7-432d-84f5-d526420a211d" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization Projects page now displays the overall number of projects (including inactive/archived) in both the summary card and pagination.
  * Ensures accurate totals and page counts, aligning the list view with navigation controls.
  * Improves clarity for users managing full project inventories; no changes to other page behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->