### PR TITLE
fix: project-count-grammar

### DIFF
--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -134,8 +134,9 @@
 
     {#if isCloud && $currentPlan?.projects && $currentPlan?.projects > 0 && data.organization.projects.length > 0 && $canWriteProjects && (projectsToArchive.length > 0 || data.projects.total > $currentPlan.projects)}
         {@const difference = projectsToArchive.length}
-        {@const messagePrefix = difference > 1 ? `${difference} projects` : `${difference} project`}
-        <Alert.Inline title={`${messagePrefix} are archived`}>
+        {@const messagePrefix =
+            difference !== 1 ? `${difference} projects are` : `${difference} project is`}
+        <Alert.Inline title={`${messagePrefix} archived`}>
             <Typography.Text>Upgrade your plan to restore archived projects</Typography.Text>
             <svelte:fragment slot="actions">
                 <Button


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the archived projects message on the organization console page to use proper singular/plural grammar and verb forms for all counts (e.g., “0 projects are archived,” “1 project is archived,” “2 projects are archived”).
  * Improved alert title text generation by combining pluralization and verb agreement into a single dynamic prefix for consistency and clarity.
  * No changes to functionality; only the displayed copy in the alert was refined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->