### PR TITLE
Fix: inconsistent sidebar state on mobile/tablet viewport

### DIFF
--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -101,10 +101,10 @@
      *
      * This needs to be handled like this because
      * the setup around the sidebar is very tightly configured with 2 states sync.
+     *
+     * The sidebar is **always closed** on mobile and tablet devices!
      */
     afterNavigate((navigation) => {
-        // always closed on
-        // mobile and tablets!
         if ($isTabletViewport) {
             state = 'closed';
             return;

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -103,12 +103,19 @@
      * the setup around the sidebar is very tightly configured with 2 states sync.
      */
     afterNavigate((navigation) => {
+        // always closed on
+        // mobile and tablets!
+        if ($isTabletViewport) {
+            state = 'closed';
+            return;
+        }
+
         const isEnteringDatabase = isInDatabasesRoute(navigation.to.route);
         const isLeavingDatabase =
             isInDatabasesRoute(navigation.from.route) && !isInDatabasesRoute(navigation.to.route);
 
         if (isEnteringDatabase) {
-            state = $isTabletViewport ? 'closed' : 'icons';
+            state = 'icons';
         } else if (isLeavingDatabase) {
             state = getSidebarState();
             $noWidthTransition = false;

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -18,6 +18,7 @@
     import { page } from '$app/stores';
     import type { Models } from '@appwrite.io/console';
     import { getSidebarState, isInDatabasesRoute, updateSidebarState } from '$lib/helpers/sidebar';
+    import { isTabletViewport } from '$lib/stores/viewport';
 
     export let showHeader = true;
     export let showFooter = true;
@@ -107,7 +108,7 @@
             isInDatabasesRoute(navigation.from.route) && !isInDatabasesRoute(navigation.to.route);
 
         if (isEnteringDatabase) {
-            state = 'icons';
+            state = $isTabletViewport ? 'closed' : 'icons';
         } else if (isLeavingDatabase) {
             state = getSidebarState();
             $noWidthTransition = false;

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
@@ -134,7 +134,7 @@
             </div>
         </section>
     </Sidebar.Base>
-{:else}
+{:else if data?.database?.name}
     <Navbar.Base>
         <div slot="left">
             <Layout.Stack direction="row" alignItems="center" gap="s">


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with sidebar always opening on small viewports on databases screens.

## Test Plan

Manual.

https://github.com/user-attachments/assets/dc903fe4-725d-424e-99c6-c79cd1d7d1af

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved responsive behavior: the sidebar now remains closed on tablet and mobile after navigation for a cleaner, focused view.

* **Bug Fixes**
  * Prevented the sub-navigation bar from rendering when database details are unavailable, avoiding empty or misleading headers on certain routes.

* **Chores**
  * Minor navigation logic adjustments to ensure consistent state transitions across viewports without affecting desktop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->