### PR TITLE
Fix: remove extra divider

### DIFF
--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -250,8 +250,6 @@
                         </Tooltip>
                     {/each}
                     {#if project && $isSmallViewport}
-                        <Divider />
-
                         <div class="mobile-tablet-settings">
                             <Tooltip placement="right" disabled={state !== 'icons'}>
                                 <a


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Removes an extra divider.

## Test Plan

Manual.

Before -

<img width="416" height="898" alt="Screenshot 2025-09-04 at 10 24 01 AM" src="https://github.com/user-attachments/assets/03915b71-f057-4a78-a6a9-216f710081f5" />

After -

<img width="416" height="900" alt="Screenshot 2025-09-04 at 10 23 42 AM" src="https://github.com/user-attachments/assets/a389a42b-bba3-46bc-8ea9-8d49402d279c" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed an extra divider in the sidebar on small screens (phones/tablets), creating a cleaner look and reducing visual clutter before the mobile/tablet settings section. This tweak improves visual continuity and spacing without altering functionality or interaction. Other layouts and behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->