### PR TITLE
Fix: pagination on billing

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
@@ -95,7 +95,7 @@
                     <Table.Header.Cell column="dueDate" {root}>Due date</Table.Header.Cell>
                     <Table.Header.Cell column="status" {root}>Status</Table.Header.Cell>
                     <Table.Header.Cell column="amount" {root}>Amount due</Table.Header.Cell>
-                    <Table.Header.Cell column="action" {root} />
+                    <Table.Header.Cell column="actions" {root} />
                 </svelte:fragment>
 
                 {#if isLoadingInvoices}
@@ -150,7 +150,7 @@
                             <Table.Cell column="amount" {root}>
                                 {formatCurrency(invoice.grossAmount)}
                             </Table.Cell>
-                            <Table.Cell column="status" {root}>
+                            <Table.Cell column="actions" {root}>
                                 <Popover let:toggle placement="bottom-start" padding="none">
                                     <Button text icon ariaLabel="more options" on:click={toggle}>
                                         <Icon icon={IconDotsHorizontal} size="s" />

--- a/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
@@ -81,7 +81,7 @@
         { id: 'dueDate', width: { min: 120 } },
         { id: 'status', width: { min: hasPaymentError ? 200 : 100 } },
         { id: 'amount', width: { min: 120 } },
-        { id: 'action', width: 40 }
+        { id: 'actions', width: 40 }
     ]);
 </script>
 

--- a/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from '$app/state';
+    import { onMount } from 'svelte';
     import { CardGrid, PaginationInline } from '$lib/components';
     import { Button } from '$lib/elements/forms';
     import { toLocaleDate } from '$lib/helpers/date';
@@ -27,7 +28,6 @@
         IconExternalLink,
         IconRefresh
     } from '@appwrite.io/pink-icons-svelte';
-    import { onMount } from 'svelte';
 
     let limit = $state(5);
     let offset = $state(0);


### PR DESCRIPTION
## What does this PR do?

Fixes pagination logic since the invoice logic is handled differently for display.

## Test Plan

Manual.

Before -

https://github.com/user-attachments/assets/b28fb876-5c8d-48e6-8b86-8240faf904d6

After -

https://github.com/user-attachments/assets/f0556eae-9510-4fd0-990c-8f0186fb75b3

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment History now auto-loads on open and updates via interactive pagination (default page size: 5).
  * Per-invoice action menu added with View, Download PDF, and Retry payment for overdue/failed/abandoned invoices.

* **Bug Fixes**
  * First page now correctly includes the current-cycle invoice.
  * Pagination shown when results meet the page-size threshold (>= limit).

* **Style**
  * 4-column layout (due date, status, amount, actions) and five loading placeholder rows.
  * Column header renamed to "actions" and status badges refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->