### PR TITLE
feat: add Create more to column creation flow

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
@@ -72,6 +72,10 @@
     let selectedOption: Option['name'] = 'String';
     let createMoreColumns = false;
 
+    $: if (!$showCreateColumnSheet.show) {
+        createMoreColumns = false;
+    }
+
     /**
      * adding a lot of fake data will trigger the realtime below
      * and will keep invalidating the `Dependencies.TABLE` making a lot of API noise!
@@ -337,7 +341,7 @@
 <slot />
 
 <SideSheet
-    closeOnBlur
+    closeOnBlur={false}
     title={$showCreateColumnSheet.title}
     titleBadge={selectedOption === 'Relationship' ? 'Experimental' : undefined}
     bind:show={$showCreateColumnSheet.show}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
@@ -72,10 +72,6 @@
     let selectedOption: Option['name'] = 'String';
     let createMoreColumns = false;
 
-    $: if (!$showCreateColumnSheet.show) {
-        createMoreColumns = false;
-    }
-
     /**
      * adding a lot of fake data will trigger the realtime below
      * and will keep invalidating the `Dependencies.TABLE` making a lot of API noise!
@@ -331,6 +327,10 @@
         isWaterfallFromFaker = false;
 
         spreadsheetRenderKey.set(hash(rowIds));
+    }
+
+    $: if (!$showCreateColumnSheet.show) {
+        createMoreColumns = false;
     }
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
@@ -52,7 +52,7 @@
     import EditColumn from './columns/edit.svelte';
     import RowActivity from './rows/activity.svelte';
     import EditRowPermissions from './rows/editPermissions.svelte';
-    import { Dialog, Layout, Typography } from '@appwrite.io/pink-svelte';
+    import { Dialog, Layout, Typography, Selector } from '@appwrite.io/pink-svelte';
     import { Button, Seekbar } from '$lib/elements/forms';
     import { generateFakeRecords, generateColumns } from '$lib/helpers/faker';
     import { addNotification } from '$lib/stores/notifications';
@@ -70,6 +70,7 @@
     let createIndex: CreateIndex;
     let createColumn: CreateColumn;
     let selectedOption: Option['name'] = 'String';
+    let createMoreColumns = false;
 
     /**
      * adding a lot of fake data will trigger the realtime below
@@ -342,14 +343,21 @@
     bind:show={$showCreateColumnSheet.show}
     submit={{
         text: 'Create',
-        onClick: async () => {
-            await createColumn?.submit();
-        },
+        onClick: async () => await createColumn?.submit(),
         disabled: !selectedOption
     }}>
+    {#snippet footer()}
+        <Layout.Stack inline direction="row" alignItems="center">
+            <Selector.Switch
+                id="create-more-columns"
+                bind:checked={createMoreColumns}
+                label="Create more" />
+        </Layout.Stack>
+    {/snippet}
     <CreateColumn
         bind:selectedOption
         bind:this={createColumn}
+        bind:createMore={createMoreColumns}
         column={$showCreateColumnSheet.column}
         columns={$showCreateColumnSheet.columns}
         direction={$showCreateColumnSheet.direction}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/createColumn.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/createColumn.svelte
@@ -19,6 +19,7 @@
         columnId = $bindable(null),
         columnsOrder = $bindable(null),
         selectedOption = $bindable('String'),
+        createMore = $bindable(false),
         onColumnsReorder = null
     }: {
         column?: Columns;
@@ -27,6 +28,7 @@
         columnsOrder?: string[];
         direction: ColumnDirection;
         selectedOption: Option['name'];
+        createMore?: boolean;
         onColumnsReorder?: (newOrder: string[]) => void;
     } = $props();
 
@@ -148,12 +150,19 @@
                 message: `Column ${key ?? data?.key} has been created`
             });
             trackEvent(Submit.ColumnCreate);
+
+            if (createMore) {
+                init();
+                return true; // keep sheet open
+            }
+            return false; // close sheet
         } catch (e) {
             addNotification({
                 type: 'error',
                 message: e.message
             });
             trackError(e, Submit.ColumnCreate);
+            return true; // keep open on error
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add a “create more” toggle to createColumn.svelte that can be bound.
workking same as create more in create row form

## Test Plan

<img width="1000" height="903" alt="image" src="https://github.com/user-attachments/assets/47f026c1-9c60-42b5-b25a-0100542de6be" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Create more” toggle in the Create Column panel so you can add multiple columns in sequence — when enabled the form resets after each successful creation and the panel stays open.
  * Create panel no longer closes when clicking outside (prevents accidental dismissals).
  * The “Create more” toggle resets when the panel is closed.

* **Bug Fixes**
  * After a failed column creation, the panel remains open so you can correct and retry quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->