### PR TITLE
fix(auth/teams): initialize team id to null

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
@@ -14,7 +14,9 @@
 
     const dispatch = createEventDispatcher();
 
-    let name: string, id: string, error: string;
+    let name: string;
+    let id: string | null = null;
+    let error: string;
     let showCustomId = false;
 
     const create = async () => {

--- a/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
@@ -14,7 +14,7 @@
 
     const dispatch = createEventDispatcher();
 
-    let name = $state<string>('');
+    let name = $state('');
     let id = $state<string | null>(null);
     let error = $state<string | null>(null);
     let showCustomId = $state(false);

--- a/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
@@ -10,14 +10,14 @@
     import { Icon, Tag } from '@appwrite.io/pink-svelte';
     import { createEventDispatcher } from 'svelte';
 
-    export let showCreate = false;
+    let { showCreate = $bindable(false) }: { showCreate: boolean } = $props();
 
     const dispatch = createEventDispatcher();
 
-    let name: string;
-    let id: string | null = null;
-    let error: string;
-    let showCustomId = false;
+    let name = $state<string>('');
+    let id = $state<string | null>(null);
+    let error = $state<string | null>(null);
+    let showCustomId = $state(false);
 
     const create = async () => {
         try {
@@ -44,10 +44,12 @@
         }
     };
 
-    $: if (!showCreate) {
-        showCustomId = false;
-        error = null;
-    }
+    $effect(() => {
+        if (!showCreate) {
+            showCustomId = false;
+            error = null;
+        }
+    });
 </script>
 
 <Modal title="Create team" {error} size="m" bind:show={showCreate} onSubmit={create}>

--- a/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/createTeam.svelte
@@ -47,6 +47,7 @@
     $effect(() => {
         if (!showCreate) {
             showCustomId = false;
+            id = null;
             error = null;
         }
     });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When opening team id, customid sets id = $bindable(null).
But svvelte doesnt allow binding undefined

## Test Plan


<img width="258" height="572" alt="image" src="https://github.com/user-attachments/assets/1993ddea-f83b-401a-90df-1ae16126a41d" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal state handling for the team-creation modal was modernized; behavior for optional team IDs still auto-generates an ID when none is provided.
  * No changes to UI, workflow, validation, or error messaging; visible behavior and compatibility remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->