### PR TITLE
refactor: display "Buckets" instead of "Databases" in storage tab

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/storage/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/+page.svelte
@@ -60,7 +60,7 @@
         {/if}
 
         <PaginationWithLimit
-            name="Databases"
+            name="Buckets"
             limit={data.limit}
             offset={data.offset}
             total={data.buckets.total} />


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Shows the correct tab description pagination (e.g. "48 Buckets per page" instead of "48 Databases"), likely caused by a copy and paste mistake when duplicating the Storage tab from the Databases tab..

Fixes https://github.com/appwrite/console/issues/2655

## Test Plan

This only changes one string

## Related PRs and Issues

* https://github.com/appwrite/console/issues/2655

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

I have read the Contributing Guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pagination label on the Storage page to display “Buckets” instead of “Databases,” aligning the UI with the content being viewed. Pagination behavior (limit, offset, total) remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->