### PR TITLE
feat(mfa): show single secondary option on OTP screen

### DIFF
--- a/src/lib/components/mfaChallengeFormList.svelte
+++ b/src/lib/components/mfaChallengeFormList.svelte
@@ -110,8 +110,7 @@
                     <Icon icon={IconMail} slot="start" size="s" />
                     Email verification
                 </Button>
-            {:else if (challengeType === AuthenticationFactor.Recoverycode && !factors.email) ||
-                      challengeType === AuthenticationFactor.Email}
+            {:else if (challengeType === AuthenticationFactor.Recoverycode && !factors.email) || challengeType === AuthenticationFactor.Email}
                 <Button
                     secondary
                     fullWidth


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Make Authenticator app primary when TOTP is enabled
Show only one toggle button: Email ↔ Authenticator
Keep “Use recovery code” as text link
Remove extra options when TOTP is present 

## Test Plan

<img width="621" height="612" alt="image" src="https://github.com/user-attachments/assets/8d6545ee-50db-4e21-a76a-993bab626d54" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined MFA challenge flow: when an authenticator app is available, the interface toggles between Email verification and Authenticator app instead of showing all options simultaneously.
  * Phone verification is hidden when authenticator app support is available to reduce clutter and guide users to stronger options.
  * When exactly one non-recovery factor exists, the system auto-selects or auto-initiates the appropriate challenge (Email, Phone, or Authenticator).
  * Recovery code interactions are preserved within the toggling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->