### PR TITLE
Sort dns records by lock and creation date

### DIFF
--- a/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.ts
+++ b/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.ts
@@ -14,13 +14,21 @@ export const load = async ({ parent, depends, url, route }) => {
     const offset = pageToOffset(page, limit);
     const { domain } = await parent();
 
+    const records = await sdk.forConsole.domains.listRecords({
+        domainId: domain.$id,
+        queries: [Query.offset(offset), Query.limit(limit)]
+    });
+
+    records.dnsRecords = records.dnsRecords.sort((a, b) => {
+        return (
+            Number(b.lock) - Number(a.lock) || Date.parse(b.$createdAt) - Date.parse(a.$createdAt)
+        );
+    });
+
     return {
-        domain,
-        recordList: await sdk.forConsole.domains.listRecords({
-            domainId: domain.$id,
-            queries: [Query.offset(offset), Query.limit(limit)]
-        }),
+        limit,
         offset,
-        limit
+        domain,
+        recordList: records,
     };
 };

--- a/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.ts
+++ b/src/routes/(console)/organization-[organization]/domains/domain-[domain]/+page.ts
@@ -29,6 +29,6 @@ export const load = async ({ parent, depends, url, route }) => {
         limit,
         offset,
         domain,
-        recordList: records,
+        recordList: records
     };
 };

--- a/src/routes/(console)/organization-[organization]/domains/domain-[domain]/createRecordModal.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/domain-[domain]/createRecordModal.svelte
@@ -98,7 +98,7 @@
             </Input.Helper>
         </Layout.Stack>
 
-        <InputText id="value" label="Value" {placeholder} bind:value>
+        <InputText id="value" label="Value" {placeholder} bind:value required>
             <Tooltip slot="info">
                 <Icon icon={IconInfo} size="s" />
                 <span slot="tooltip">


### PR DESCRIPTION
## What does this PR do?

Sort dns records by lock and creation date.

## Test Plan

Manual.

## Related PRs and Issues

<img width="1840" height="1191" alt="Screenshot 2025-09-10 at 1 37 47 PM" src="https://github.com/user-attachments/assets/172b02e7-6fc5-44ef-b3d6-8bb6f3857f28" />

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain records are sorted by lock status and recency for clearer visibility.
  * A page-size limit is applied to domain record lists to keep results manageable.
  * Record listings now load consistently, preserving pagination and domain context.

* **Bug Fixes**
  * Create DNS record modal now requires a Value before submission, preventing empty entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->