### PR TITLE
feat:  show 4xx status codes as warning (orange) in Functions and Sites

### DIFF
--- a/src/lib/helpers/httpStatus.ts
+++ b/src/lib/helpers/httpStatus.ts
@@ -1,0 +1,23 @@
+/**
+ * determines the badge color based on HTTP status code
+ *
+ * @param statusCode
+ * @returns badge coklor
+ */
+export function getBadgeTypeFromStatusCode(
+    statusCode: number
+): 'error' | 'warning' | 'success' | undefined {
+    if (statusCode >= 500) {
+        return 'error';
+    }
+
+    if (statusCode >= 400) {
+        return 'warning';
+    }
+
+    if (statusCode === 0) {
+        return undefined;
+    }
+
+    return 'success';
+}

--- a/src/lib/helpers/httpStatus.ts
+++ b/src/lib/helpers/httpStatus.ts
@@ -2,7 +2,7 @@
  * determines the badge color based on HTTP status code
  *
  * @param statusCode
- * @returns badge coklor
+ * @returns badge color
  */
 export function getBadgeTypeFromStatusCode(
     statusCode: number

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/sheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/sheet.svelte
@@ -98,11 +98,13 @@
                                     <Badge
                                         content={selectedLog.responseStatusCode.toString()}
                                         variant="secondary"
-                                        type={selectedLog?.responseStatusCode >= 400
+                                        type={selectedLog?.responseStatusCode >= 500
                                             ? 'error'
-                                            : selectedLog.responseStatusCode === 0
-                                              ? undefined
-                                              : 'success'} />
+                                            : selectedLog.responseStatusCode >= 400
+                                              ? 'warning'
+                                              : selectedLog.responseStatusCode === 0
+                                                ? undefined
+                                                : 'success'} />
                                 </span>
                             </Layout.Stack>
                             <Layout.Stack gap="xs" inline>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/sheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/sheet.svelte
@@ -17,6 +17,7 @@
     } from '@appwrite.io/pink-svelte';
     import { timeFromNow, toLocaleDateTime } from '$lib/helpers/date';
     import { capitalize } from '$lib/helpers/string';
+    import { getBadgeTypeFromStatusCode } from '$lib/helpers/httpStatus';
     import { Copy } from '$lib/components';
     import { logStatusConverter } from './store';
     import { LogsRequest, LogsResponse } from '$lib/components/logs';
@@ -98,13 +99,9 @@
                                     <Badge
                                         content={selectedLog.responseStatusCode.toString()}
                                         variant="secondary"
-                                        type={selectedLog?.responseStatusCode >= 500
-                                            ? 'error'
-                                            : selectedLog.responseStatusCode >= 400
-                                              ? 'warning'
-                                              : selectedLog.responseStatusCode === 0
-                                                ? undefined
-                                                : 'success'} />
+                                        type={getBadgeTypeFromStatusCode(
+                                            selectedLog.responseStatusCode
+                                        )} />
                                 </span>
                             </Layout.Stack>
                             <Layout.Stack gap="xs" inline>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
@@ -96,11 +96,13 @@
                     {:else if column.id === 'responseStatusCode'}
                         <Badge
                             variant="secondary"
-                            type={log.responseStatusCode >= 400
+                            type={log.responseStatusCode >= 500
                                 ? 'error'
-                                : log.responseStatusCode === 0
-                                  ? undefined
-                                  : 'success'}
+                                : log.responseStatusCode >= 400
+                                  ? 'warning'
+                                  : log.responseStatusCode === 0
+                                    ? undefined
+                                    : 'success'}
                             content={log.responseStatusCode.toString()} />
                     {:else if column.id === 'requestMethod'}
                         <Typography.Code size="m">

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
@@ -14,6 +14,7 @@
     import Sheet from './sheet.svelte';
     import { capitalize } from '$lib/helpers/string';
     import { calculateTime } from '$lib/helpers/timeConversion';
+    import { getBadgeTypeFromStatusCode } from '$lib/helpers/httpStatus';
     import { logStatusConverter } from './store';
     import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { func } from '../store';
@@ -96,13 +97,7 @@
                     {:else if column.id === 'responseStatusCode'}
                         <Badge
                             variant="secondary"
-                            type={log.responseStatusCode >= 500
-                                ? 'error'
-                                : log.responseStatusCode >= 400
-                                  ? 'warning'
-                                  : log.responseStatusCode === 0
-                                    ? undefined
-                                    : 'success'}
+                            type={getBadgeTypeFromStatusCode(log.responseStatusCode)}
                             content={log.responseStatusCode.toString()} />
                     {:else if column.id === 'requestMethod'}
                         <Typography.Code size="m">

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/sheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/sheet.svelte
@@ -15,6 +15,7 @@
     } from '@appwrite.io/pink-svelte';
     import { timeFromNow } from '$lib/helpers/date';
     import { capitalize } from '$lib/helpers/string';
+    import { getBadgeTypeFromStatusCode } from '$lib/helpers/httpStatus';
     import { Copy } from '$lib/components';
     import { LogsRequest, LogsResponse } from '$lib/components/logs';
     import { site } from '../store';
@@ -99,11 +100,9 @@
                                         <Badge
                                             content={selectedLog.responseStatusCode.toString()}
                                             variant="secondary"
-                                            type={selectedLog?.responseStatusCode >= 500
-                                                ? 'error'
-                                                : selectedLog.responseStatusCode >= 400
-                                                  ? 'warning'
-                                                  : 'success'} />
+                                            type={getBadgeTypeFromStatusCode(
+                                                selectedLog.responseStatusCode
+                                            )} />
                                     </span>
                                 </Layout.Stack>
                                 <Layout.Stack gap="xs" inline>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/sheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/sheet.svelte
@@ -99,9 +99,11 @@
                                         <Badge
                                             content={selectedLog.responseStatusCode.toString()}
                                             variant="secondary"
-                                            type={selectedLog?.responseStatusCode >= 400
+                                            type={selectedLog?.responseStatusCode >= 500
                                                 ? 'error'
-                                                : 'success'} />
+                                                : selectedLog.responseStatusCode >= 400
+                                                  ? 'warning'
+                                                  : 'success'} />
                                     </span>
                                 </Layout.Stack>
                                 <Layout.Stack gap="xs" inline>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/table.svelte
@@ -12,6 +12,7 @@
     import { invalidate } from '$app/navigation';
     import { Dependencies } from '$lib/constants';
     import { calculateTime } from '$lib/helpers/timeConversion';
+    import { getBadgeTypeFromStatusCode } from '$lib/helpers/httpStatus';
     import { Button } from '$lib/elements/forms';
 
     export let columns: Column[];
@@ -87,11 +88,7 @@
                         <div>
                             <Badge
                                 variant="secondary"
-                                type={log.responseStatusCode >= 500
-                                    ? 'error'
-                                    : log.responseStatusCode >= 400
-                                      ? 'warning'
-                                      : 'success'}
+                                type={getBadgeTypeFromStatusCode(log.responseStatusCode)}
                                 content={log.responseStatusCode.toString()} />
                         </div>
                     {:else if column.id === 'requestPath'}

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/table.svelte
@@ -87,7 +87,11 @@
                         <div>
                             <Badge
                                 variant="secondary"
-                                type={log.responseStatusCode >= 400 ? 'error' : 'success'}
+                                type={log.responseStatusCode >= 500
+                                    ? 'error'
+                                    : log.responseStatusCode >= 400
+                                      ? 'warning'
+                                      : 'success'}
                                 content={log.responseStatusCode.toString()} />
                         </div>
                     {:else if column.id === 'requestPath'}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Update status code badge coloring so client errors (4xx) are orange and server errors (5xx) remain red across Functions Executions and Sites Logs (tables and sheets).

## Test Plan

<img width="1541" height="485" alt="image" src="https://github.com/user-attachments/assets/21e40ec2-4433-45cd-9276-1a10a4e23278" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status badges updated across Function Executions and Site Logs: 5xx = Error, 4xx = Warning, 2xx–3xx = Success, 0 = unclassified.
  * Badge behavior now consistent between detail (sheet) views and tables for functions and sites.
  * Visual indicators adjusted to reflect the new three-tier mapping without other UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->