### PR TITLE
feat: added modal for email verfication

### DIFF
--- a/src/lib/components/account/sendVerificationEmailModal.svelte
+++ b/src/lib/components/account/sendVerificationEmailModal.svelte
@@ -5,16 +5,17 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { user } from '$lib/stores/user';
+    import { get } from 'svelte/store';
     import { page } from '$app/state';
     import { Card, Layout, Typography } from '@appwrite.io/pink-svelte';
     import { Dependencies } from '$lib/constants';
     import { onMount } from 'svelte';
 
-    export let show = false;
-    let creating = false;
-    let emailSent = false;
+    let { show = $bindable(false) } = $props();
+    let creating = $state(false);
+    let emailSent = $state(false);
 
-    $: cleanUrl = page.url.origin + page.url.pathname;
+    let cleanUrl = $derived(page.url.origin + page.url.pathname);
 
     async function onSubmit() {
         if (creating) return;
@@ -64,10 +65,10 @@
 <Modal bind:show title="Send verification email" {onSubmit}>
     <Card.Base variant="secondary" padding="s">
         <Layout.Stack gap="m">
-            <Typography.Text variant="m-400" gap="m">
+            <Typography.Text gap="m">
                 To continue using Appwrite Cloud, please verify your email address. An email will be
-                sent to <Typography.Text variant="m-600" style="display:inline"
-                    >{$user?.email}</Typography.Text>
+                sent to <Typography.Text variant="m-600" style="display: inline;"
+                    >{get(user)?.email}</Typography.Text>
             </Typography.Text>
         </Layout.Stack>
     </Card.Base>

--- a/src/lib/components/account/sendVerificationEmailModal.svelte
+++ b/src/lib/components/account/sendVerificationEmailModal.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import { Modal } from '$lib/components';
+    import { Button } from '$lib/elements/forms';
+    import { addNotification } from '$lib/stores/notifications';
+    import { sdk } from '$lib/stores/sdk';
+    import { user } from '$lib/stores/user';
+    import { page } from '$app/state';
+    import { Card, Layout, Typography } from '@appwrite.io/pink-svelte';
+
+    export let show = false;
+    let creating = false;
+
+    $: cleanUrl = page.url.origin + page.url.pathname;
+
+    async function onSubmit() {
+        if (creating) return;
+        creating = true;
+        try {
+            await sdk.forConsole.account.createVerification({ url: cleanUrl });
+            addNotification({ message: 'Verification email has been sent', type: 'success' });
+            show = false;
+        } catch (error) {
+            addNotification({ message: error.message, type: 'error' });
+        } finally {
+            creating = false;
+        }
+    }
+</script>
+
+<Modal bind:show title="Send verification email" {onSubmit}>
+    <Card.Base variant="secondary" padding="s">
+        <Layout.Stack gap="m">
+            <Typography.Text variant="m-400" gap="m">
+                To continue using Appwrite Cloud, please verify your email address. An email will be
+                sent to <Typography.Text variant="m-600" style="display:inline"
+                    >{$user?.email}</Typography.Text>
+            </Typography.Text>
+        </Layout.Stack>
+    </Card.Base>
+
+    <svelte:fragment slot="footer">
+        <Button submit disabled={creating}>Send email</Button>
+    </svelte:fragment>
+</Modal>

--- a/src/lib/components/alerts/emailVerificationBanner.svelte
+++ b/src/lib/components/alerts/emailVerificationBanner.svelte
@@ -3,12 +3,12 @@
     import { HeaderAlert } from '$lib/layout';
     import { Typography } from '@appwrite.io/pink-svelte';
     import { user } from '$lib/stores/user';
-    import SendVerificationEmailModal from '$lib/components/account/sendVerificationEmailModal.svelte';
-    import { page } from '$app/state';
+    import SendVerificationEmailModal from '../account/sendVerificationEmailModal.svelte';
+    import { page } from '$app/stores';
 
     const hasUser = $derived(!!$user);
     const needsEmailVerification = $derived(hasUser && !$user.emailVerification);
-    const notOnOnboarding = $derived(!page.url?.pathname?.includes('/console/onboarding'));
+    const notOnOnboarding = $derived(!$page.route.id.includes('/onboarding'));
     const shouldShowEmailBanner = $derived(hasUser && needsEmailVerification && notOnOnboarding);
 
     let showSendVerification = $state(false);

--- a/src/lib/components/alerts/emailVerificationBanner.svelte
+++ b/src/lib/components/alerts/emailVerificationBanner.svelte
@@ -1,55 +1,21 @@
 <script lang="ts">
-    import { base } from '$app/paths';
-    import { goto } from '$app/navigation';
     import { Button } from '$lib/elements/forms';
     import { HeaderAlert } from '$lib/layout';
     import { Typography } from '@appwrite.io/pink-svelte';
-    import { hideNotification, shouldShowNotification } from '$lib/helpers/notifications';
     import { user } from '$lib/stores/user';
-    import { wizard } from '$lib/stores/wizard';
+    import SendVerificationEmailModal from '$lib/components/account/sendVerificationEmailModal.svelte';
     import { page } from '$app/state';
-
-    const { emailBannerClosed, onEmailBannerClose } = $props<{
-        emailBannerClosed: boolean;
-        onEmailBannerClose: (closed: boolean) => void;
-    }>();
-
-    const isOnOnboarding = $derived(page.url?.pathname?.includes('/console/onboarding'));
 
     const hasUser = $derived(!!$user);
     const needsEmailVerification = $derived(hasUser && !$user.emailVerification);
-    const shouldShowNotificationBanner = $derived.by(() =>
-        shouldShowNotification('email-verification-banner')
-    );
-    const wizardNotActive = $derived(!$wizard.show && !$wizard.cover);
-    const bannerNotClosed = $derived(!emailBannerClosed);
-    const notOnOnboarding = $derived(!isOnOnboarding);
+    const notOnOnboarding = $derived(!page.url?.pathname?.includes('/console/onboarding'));
+    const shouldShowEmailBanner = $derived(hasUser && needsEmailVerification && notOnOnboarding);
 
-    const shouldShowEmailBanner = $derived(
-        hasUser &&
-            needsEmailVerification &&
-            shouldShowNotificationBanner &&
-            wizardNotActive &&
-            bannerNotClosed &&
-            notOnOnboarding
-    );
-
-    function navigateToAccount() {
-        goto(`${base}/account`);
-    }
-
-    function handleDismiss() {
-        onEmailBannerClose(true);
-        hideNotification('email-verification-banner', { coolOffPeriod: 24 * 365 * 100 });
-    }
+    let showSendVerification = $state(false);
 </script>
 
 {#if shouldShowEmailBanner}
-    <HeaderAlert
-        type="warning"
-        title="Your email address needs to be verified"
-        dismissible
-        on:dismiss={handleDismiss}>
+    <HeaderAlert type="warning" title="Your email address needs to be verified">
         <svelte:fragment>
             To avoid losing access to your projects, make sure <Typography.Text
                 variant="m-500"
@@ -57,7 +23,9 @@
             verification will be required soon.
         </svelte:fragment>
         <svelte:fragment slot="buttons">
-            <Button secondary size="s" on:click={navigateToAccount}>Update email address</Button>
+            <Button secondary size="s" on:click={() => (showSendVerification = true)}
+                >Verify email</Button>
         </svelte:fragment>
     </HeaderAlert>
+    <SendVerificationEmailModal bind:show={showSendVerification} />
 {/if}

--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -59,7 +59,6 @@
     import type { LayoutData } from './$types';
 
     export let data: LayoutData;
-    let emailBannerClosed = false;
 
     function kebabToSentenceCase(str: string) {
         return str
@@ -347,9 +346,7 @@
     <Footer slot="footer" />
 </Shell>
 
-<EmailVerificationBanner
-    {emailBannerClosed}
-    onEmailBannerClose={(closed) => (emailBannerClosed = closed)} />
+<EmailVerificationBanner />
 
 {#if $wizard.show && $wizard.component}
     <svelte:component this={$wizard.component} {...$wizard.props} />

--- a/src/routes/(console)/account/updateEmail.svelte
+++ b/src/routes/(console)/account/updateEmail.svelte
@@ -8,6 +8,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { user } from '$lib/stores/user';
     import { onMount } from 'svelte';
+    import { Badge } from '@appwrite.io/pink-svelte';
 
     let email: string = null;
     let emailPassword: string = null;
@@ -40,7 +41,14 @@
 
 <Form onSubmit={updateEmail}>
     <CardGrid>
-        <svelte:fragment slot="title">Email</svelte:fragment>
+        <svelte:fragment slot="title">
+            <div class="email-badge">
+                Email
+                {#if $user.emailVerification}
+                    <Badge variant="secondary" type="success" size="s" content="verified" />
+                {/if}
+            </div>
+        </svelte:fragment>
         <svelte:fragment slot="aside">
             <InputText
                 id="email"
@@ -65,3 +73,11 @@
         </svelte:fragment>
     </CardGrid>
 </Form>
+
+<style>
+    .email-badge {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+</style>

--- a/src/routes/(console)/account/updateEmail.svelte
+++ b/src/routes/(console)/account/updateEmail.svelte
@@ -8,7 +8,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { user } from '$lib/stores/user';
     import { onMount } from 'svelte';
-    import { Badge } from '@appwrite.io/pink-svelte';
+    import { Badge, Layout } from '@appwrite.io/pink-svelte';
 
     let email: string = null;
     let emailPassword: string = null;
@@ -42,12 +42,12 @@
 <Form onSubmit={updateEmail}>
     <CardGrid>
         <svelte:fragment slot="title">
-            <div class="email-badge">
+            <Layout.Stack direction="row" gap="s" alignItems="center">
                 Email
                 {#if $user.emailVerification}
                     <Badge variant="secondary" type="success" size="s" content="verified" />
                 {/if}
-            </div>
+            </Layout.Stack>
         </svelte:fragment>
         <svelte:fragment slot="aside">
             <InputText
@@ -73,11 +73,3 @@
         </svelte:fragment>
     </CardGrid>
 </Form>
-
-<style>
-    .email-badge {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-    }
-</style>

--- a/src/routes/(console)/account/updateMfa.svelte
+++ b/src/routes/(console)/account/updateMfa.svelte
@@ -80,11 +80,15 @@
             await sdk.forConsole.account.updateMFA({ mfa: !$user.mfa });
 
             if (!$user.mfa && $user.emailVerification && !$factors.email) {
+                // Automatically set up email MFA when enabling MFA if the user has a verified email
+                // This provides a fallback authentication method without requiring user interaction
                 try {
                     await sdk.forConsole.account.createMFAChallenge({
                         factor: AuthenticationFactor.Email
                     });
-                } catch (emailError) {}
+                } catch (emailError) {
+                    // Silently ignore - email MFA is optional and shouldn't block MFA enablement
+                }
             }
 
             await Promise.all([invalidate(Dependencies.ACCOUNT), invalidate(Dependencies.FACTORS)]);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Add verified badge to account email settings when email is verified
- Auto-enable email MFA factor when MFA is turned on and email is verified
- Integrate existing MFA verification flow with email verification modal

## Test Plan

<img width="1886" height="770" alt="image" src="https://github.com/user-attachments/assets/4e2f06b7-fa5e-43b8-9d9a-2d36239179f2" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Send Verification Email" modal to send/resend verification links and handle inline verification when visiting a verification URL.

* **Changes**
  * Email verification banner is now non-dismissible and uses a "Verify email" button to open the modal.
  * Account layout simplified to use the updated banner (props removed).
  * Email view shows a "verified" badge when verified.
  * Enabling MFA may trigger an automatic email challenge and broader account/factors refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->