### PR TITLE
fix: update Git installation link in updateInstallations.svelte

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -171,7 +171,10 @@
                 Before installing Git in a locally hosted Appwrite project, ensure your environment
                 variables are configured.
                 <svelte:fragment slot="actions">
-                    <Button compact href="#" external>Learn more</Button>
+                    <Button
+                        compact
+                        href="https://appwrite.io/docs/advanced/self-hosting/configuration/version-control"
+                        external>Learn more</Button>
                 </svelte:fragment>
             </Alert.Inline>
         {:else}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Prior to this, the link didn't take you anywhere. This updates the link to take you to the self-hosted VCS docs.

## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Learn more” button in the “Installing Git on a self-hosted instance” alert now opens the official Appwrite documentation for version-control configuration instead of a placeholder link, ensuring users can access accurate setup guidance directly. No other UI or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->