### PR TITLE
fix: hide email verification banner on wizard pages

### DIFF
--- a/src/lib/components/alerts/emailVerificationBanner.svelte
+++ b/src/lib/components/alerts/emailVerificationBanner.svelte
@@ -12,7 +12,9 @@
     const needsEmailVerification = $derived(hasUser && !$user.emailVerification);
     const notOnOnboarding = $derived(!$page.route.id.includes('/onboarding'));
     const notOnWizard = $derived(!$wizard.show && !$isNewWizardStatusOpen);
-    const shouldShowEmailBanner = $derived(isCloud && hasUser && needsEmailVerification && notOnOnboarding && notOnWizard);
+    const shouldShowEmailBanner = $derived(
+        isCloud && hasUser && needsEmailVerification && notOnOnboarding && notOnWizard
+    );
 
     let showSendVerification = $state(false);
 </script>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

<img width="1884" height="954" alt="image" src="https://github.com/user-attachments/assets/c4657886-7f98-44d7-99db-86cc8f4fd765" />
<img width="1713" height="889" alt="image" src="https://github.com/user-attachments/assets/e6272b35-c74b-455b-b8c5-d64554459be9" />
<img width="1883" height="536" alt="image" src="https://github.com/user-attachments/assets/5b03a0cc-90ea-4061-bea1-bdd4f79e3be7" />



## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification banner no longer appears while the setup wizard is active or when a new wizard status is open, preventing overlap and reducing distraction.
  * Banner now only displays in Cloud environments.
  * Existing visibility rules preserved: it shows only for signed-in users who need verification and who are not on onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->