### PR TITLE
fix: changed gap from xxl to l

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(components)/deploymentCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(components)/deploymentCard.svelte
@@ -78,7 +78,7 @@
 {/snippet}
 
 <Card padding="m" radius="m" {variant}>
-    <Layout.Stack gap="xxl">
+    <Layout.Stack gap="l">
         <Layout.GridFraction start={4} end={6}>
             <Layout.Stack>
                 <Layout.Stack direction="row" alignItems="center" gap="s" wrap="wrap">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Functions deployment card was using gap="xxl"

## Test Plan

<img width="1517" height="662" alt="image" src="https://github.com/user-attachments/assets/f41e1bd4-b87f-4245-a2f4-c23b7de1c467" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes