### PR TITLE
feat:  Add info alert for Free plan users with no archived projects

### DIFF
--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -103,7 +103,7 @@
     function dismissFreePlanAlert() {
         freePlanAlertDismissed = true;
         const notificationId = `freePlanAlert_${data.organization.$id}`;
-        hideNotification(notificationId, { coolOffPeriod: 36 });
+        hideNotification(notificationId, { coolOffPeriod: 24 });
 
         trackEvent(Click.OrganizationClickUpgrade, {
             from: 'button',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
added an alert

## Test Plan

<img width="1601" height="820" alt="image" src="https://github.com/user-attachments/assets/3f42b561-22f2-4a53-8547-1457b2dda5e1" />



## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible in-app alert on the organization console for Free plan cloud accounts when no projects are pending archive, highlighting limits (up to 2 projects, limited resources) and offering an "Upgrade to Pro" button.
  * Dismissal persists and respects a cooldown so the alert stays hidden after dismissal.
  * Button clicks and dismissals are tracked for analytics to improve upgrade flow visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->