### PR TITLE
fix: correct spreadsheetRenderKey update in CSV import completion

### DIFF
--- a/src/lib/components/csvImportBox.svelte
+++ b/src/lib/components/csvImportBox.svelte
@@ -90,7 +90,7 @@
             }
         }
 
-        if (tableName === null) {
+        if (tableId && tableName === null) {
             importItems.update((items) => {
                 const next = new Map(items);
                 next.delete(importData.$id);


### PR DESCRIPTION

## What does this PR do?

 use .set() method to update spreadsheetRenderKey in CSV import
 
 Remove import items tied to deleted tables/databases (stale migrations)

## Test Plan

<img width="626" height="306" alt="image" src="https://github.com/user-attachments/assets/7f8bccb2-00ca-421f-8700-af99c481beca" />

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - CSV import now skips and removes unresolved/invalid items, preventing partial or erroneous entries and reducing user confusion.
- Refactor
  - Improved completion notification handling in the CSV import flow so on-screen updates are more reliable and consistent after import, yielding cleaner imported data and clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->