### PR TITLE
feat:  hide Scale tier in plan comparison via filtered tabs

### DIFF
--- a/src/lib/components/billing/planComparisonBox.svelte
+++ b/src/lib/components/billing/planComparisonBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { BillingPlan } from '$lib/constants';
     import { formatNum } from '$lib/helpers/string';
-    import { plansInfo, tierFree, tierPro, tierScale, type Tier } from '$lib/stores/billing';
+    import { plansInfo, tierToPlan, type Tier } from '$lib/stores/billing';
     import { Card, Layout, Tabs, Typography } from '@appwrite.io/pink-svelte';
 
     export let downgrade = false;
@@ -12,19 +12,6 @@
 
     const allTiers: Tier[] = [BillingPlan.FREE, BillingPlan.PRO, BillingPlan.SCALE];
     $: visibleTiers = allTiers.filter((tier) => tier !== BillingPlan.SCALE);
-
-    function getTierName(tier: Tier): string {
-        switch (tier) {
-            case BillingPlan.FREE:
-                return tierFree.name;
-            case BillingPlan.PRO:
-                return tierPro.name;
-            case BillingPlan.SCALE:
-                return tierScale.name;
-            default:
-                return '';
-        }
-    }
 </script>
 
 <Card.Base>
@@ -35,7 +22,7 @@
                     {root}
                     active={selectedTab === tier}
                     on:click={() => (selectedTab = tier)}>
-                    {getTierName(tier)}
+                    {tierToPlan(tier).name}
                 </Tabs.Item.Button>
             {/each}
         </Tabs.Root>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

hide Scale tier in plan comparison via filtered tabs 

## Test Plan

<img width="1612" height="627" alt="image" src="https://github.com/user-attachments/assets/07388d9b-8549-4ad7-af9a-ba202c56caa1" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan tabs now adapt dynamically to available tiers.
  * The Scale tier tab is hidden from the plan comparison interface.

* **Refactor**
  * Simplified tab rendering by generating tab items from the visible tier set rather than hardcoded entries.
  * Unified selection and active-state logic to rely on tier values, and consolidated plan label resolution for display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->