### PR TITLE
Fix: remove right-edge spacing  when no vertical scrollbar is not present

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -290,8 +290,7 @@
     }
 
     /* Fix when no vertical scrollbar is present, some environments reserve a gutter by default */
-    html,
-    body {
+    html {
         scrollbar-gutter: auto !important;
     }
 


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan
<img width="1914" height="1021" alt="image" src="https://github.com/user-attachments/assets/2cd3da67-f53b-478d-9870-b427124a8fb4" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improves visual stability by reserving space for the vertical scrollbar to prevent content shifting when pages begin or stop scrolling. Reduces layout jumpiness across browsers and OS configurations; purely a rendering/appearance improvement with no change to app behavior or performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->