### PR TITLE
feat: add hidden email input to password reset form for password manager

### DIFF
--- a/src/lib/elements/forms/inputPassword.svelte
+++ b/src/lib/elements/forms/inputPassword.svelte
@@ -10,7 +10,7 @@
     export let required = false;
     export let disabled = false;
     export let autofocus = false;
-    export let autocomplete = false;
+    export let autocomplete: boolean | string = false;
     export let minlength = 8;
     export let maxlength: number = null;
     export let leadingIcon: ComponentType | undefined = undefined;
@@ -47,7 +47,11 @@
     {leadingIcon}
     state={error ? 'error' : 'default'}
     autofocus={autofocus || undefined}
-    autocomplete={autocomplete ? 'on' : 'off'}
+    autocomplete={typeof autocomplete === 'string'
+        ? (autocomplete as HTMLInputElement['autocomplete'])
+        : autocomplete
+          ? 'on'
+          : 'off'}
     helper={helper || error}
     on:invalid={handleInvalid}
     bind:value>

--- a/src/routes/(public)/recover/+page.svelte
+++ b/src/routes/(public)/recover/+page.svelte
@@ -13,6 +13,7 @@
     let email: string;
     let userId: string;
     let secret: string;
+    let userEmail: string;
 
     let password: string;
     let confirmPassword: string;
@@ -20,6 +21,7 @@
     onMount(() => {
         userId = page.url.searchParams.get('userId');
         secret = page.url.searchParams.get('secret');
+        userEmail = page.url.searchParams.get('email') || '';
     });
 
     async function recover() {
@@ -76,18 +78,30 @@
         {#if userId && secret}
             <Form onSubmit={setPassword}>
                 <Layout.Stack>
+                    <!-- hidden email input for password managers -->
+                    <input
+                        type="email"
+                        name="email"
+                        value={userEmail}
+                        style="position: absolute; left: -9999px; opacity: 0; pointer-events: none;"
+                        tabindex="-1"
+                        autocomplete="username"
+                        aria-hidden="true" />
+
                     <InputPassword
                         label="New password"
                         placeholder="Enter password"
                         id="password"
                         autofocus={true}
                         required={true}
+                        autocomplete={true}
                         bind:value={password} />
                     <InputPassword
                         label="Confirm password"
                         placeholder="Confirm password"
                         id="confirm-password"
                         required={true}
+                        autocomplete={true}
                         bind:value={confirmPassword} />
 
                     <Button fullWidth submit>Update</Button>

--- a/src/routes/(public)/recover/+page.svelte
+++ b/src/routes/(public)/recover/+page.svelte
@@ -94,14 +94,14 @@
                         id="password"
                         autofocus={true}
                         required={true}
-                        autocomplete={true}
+                        autocomplete="new-password"
                         bind:value={password} />
                     <InputPassword
                         label="Confirm password"
                         placeholder="Confirm password"
                         id="confirm-password"
                         required={true}
-                        autocomplete={true}
+                        autocomplete="new-password"
                         bind:value={confirmPassword} />
 
                     <Button fullWidth submit>Update</Button>


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email is auto-populated from the URL into an off-screen hidden email field (for credential helpers); it is not submitted with the form.
  * Autocomplete enabled for "New password" and "Confirm password" inputs (autocomplete="new-password").
  * Password fields now accept more flexible autocomplete behavior to better support different password managers.
  * No layout or navigation changes; existing password bindings and submission behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->