### PR TITLE
feat: Add relative time tooltips in tables; fix Messaging Topics empty state

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentHistory.svelte
@@ -3,7 +3,7 @@
     import { onMount } from 'svelte';
     import { CardGrid, PaginationInline } from '$lib/components';
     import { Button } from '$lib/elements/forms';
-    import { toLocaleDate } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { formatCurrency } from '$lib/helpers/numbers';
     import type { Invoice, InvoiceList } from '$lib/sdk/billing';
     import { getApiEndpoint, sdk } from '$lib/stores/sdk';
@@ -112,8 +112,9 @@
                     {#each invoiceList?.invoices as invoice (invoice.$id)}
                         {@const status = invoice.status}
                         <Table.Row.Base {root}>
-                            <Table.Cell column="dueDate" {root}
-                                >{toLocaleDate(invoice.dueAt)}</Table.Cell>
+                            <Table.Cell column="dueDate" {root}>
+                                <DualTimeView time={invoice.dueAt} />
+                            </Table.Cell>
                             <Table.Cell column="status" {root}>
                                 {@const isDanger =
                                     status === 'overdue' ||

--- a/src/routes/(console)/organization-[organization]/domains/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/+page.svelte
@@ -4,7 +4,7 @@
     import { EmptySearch, PaginationWithLimit, ViewSelector } from '$lib/components/index.js';
     import { Button } from '$lib/elements/forms';
     import Link from '$lib/elements/link.svelte';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import Container from '$lib/layout/container.svelte';
     import { protocol } from '$routes/(console)/store.js';
     import {
@@ -103,9 +103,13 @@
                                 {:else if column.id === 'nameservers'}
                                     {domain.nameservers || '-'}
                                 {:else if column.id === 'expiry_date'}
-                                    {domain?.expire ? toLocaleDateTime(domain.expire) : '-'}
+                                    {#if domain?.expire}
+                                        <DualTimeView time={domain.expire} />
+                                    {:else}-{/if}
                                 {:else if column.id === 'renewal'}
-                                    {domain?.renewal ? toLocaleDateTime(domain.renewal) : '-'}
+                                    {#if domain?.renewal}
+                                        <DualTimeView time={domain.renewal} />
+                                    {:else}-{/if}
                                 {:else if column.id === 'auto_renewal'}
                                     {domain?.autoRenewal ? 'On' : 'Off'}
                                 {/if}

--- a/src/routes/(console)/project-[region]-[project]/auth/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/+page.svelte
@@ -15,7 +15,8 @@
         SearchQuery
     } from '$lib/components';
     import { Button } from '$lib/elements/forms';
-    import { toLocaleDate, toLocaleDateTime } from '$lib/helpers/date';
+    import { toLocaleDate } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { Container } from '$lib/layout';
     import type { Models } from '@appwrite.io/console';
     import { writable } from 'svelte/store';
@@ -196,9 +197,13 @@
                                     {user.labels.join(', ')}
                                 </Typography.Text>
                             {:else if id === 'joined'}
-                                {toLocaleDateTime(user.registration)}
+                                <DualTimeView time={user.registration} />
                             {:else if id === 'lastActivity'}
-                                {user.accessedAt ? toLocaleDate(user.accessedAt) : 'never'}
+                                {#if user.accessedAt}
+                                    <DualTimeView time={user.accessedAt} />
+                                {:else}
+                                    never
+                                {/if}
                             {:else}
                                 {user[id]}
                             {/if}

--- a/src/routes/(console)/project-[region]-[project]/auth/teams/team-[team]/members/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/teams/team-[team]/members/+page.svelte
@@ -6,7 +6,7 @@
     import type { Models } from '@appwrite.io/console';
     import { invalidate } from '$app/navigation';
     import { base } from '$app/paths';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import type { PageData } from './$types';
     import CreateMember from '../createMembership.svelte';
     import DeleteMembership from '../deleteMembership.svelte';
@@ -117,7 +117,7 @@
                         {membership.roles}
                     </Table.Cell>
                     <Table.Cell column="joined" {root}>
-                        {toLocaleDateTime(membership.joined)}
+                        <DualTimeView time={membership.joined} />
                     </Table.Cell>
                     <Table.Cell column="actions" {root}>
                         <button

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/identities/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/identities/table.svelte
@@ -2,7 +2,7 @@
     import { Id } from '$lib/components';
     import { Button } from '$lib/elements/forms';
     import type { PageData } from './$types';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { sdk } from '$lib/stores/sdk';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
     import { Dependencies } from '$lib/constants';
@@ -87,7 +87,7 @@
                         {#if !identity[column.id]}
                             -
                         {:else}
-                            {toLocaleDateTime(identity[column.id])}
+                            <DualTimeView time={identity[column.id]} />
                         {/if}
                     {:else}
                         {identity[column.id]}

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/memberships/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/memberships/+page.svelte
@@ -7,7 +7,7 @@
     import DeleteMembership from '../deleteMembership.svelte';
     import type { Models } from '@appwrite.io/console';
     import { trackEvent, Submit, trackError } from '$lib/actions/analytics';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import {
         Table,
         Layout,
@@ -108,7 +108,7 @@
                         {membership.roles}
                     </Table.Cell>
                     <Table.Cell column="joined" {root}>
-                        {toLocaleDateTime(membership.joined)}
+                        <DualTimeView time={membership.joined} />
                     </Table.Cell>
                     <Table.Cell column="actions" {root}>
                         <button

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/targets/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/targets/table.svelte
@@ -3,7 +3,7 @@
     import { Button } from '$lib/elements/forms';
     import type { PageData } from './$types';
     import { columns } from './store';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import ProviderType from '$routes/(console)/project-[region]-[project]/messaging/providerType.svelte';
     import Provider from '$routes/(console)/project-[region]-[project]/messaging/provider.svelte';
     import { sdk } from '$lib/stores/sdk';
@@ -83,7 +83,7 @@
                             <Provider provider={provider.provider} />
                         {/if}
                     {:else if column.id === '$createdAt'}
-                        {toLocaleDateTime(target[column.id])}
+                        <DualTimeView time={target[column.id]} />
                     {:else}
                         {target[column.id]}
                     {/if}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/delete.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/delete.svelte
@@ -8,7 +8,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { database } from './store';
-    import { toLocaleDate } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { type Models, Query } from '@appwrite.io/console';
     import { Spinner, Table } from '@appwrite.io/pink-svelte';
 
@@ -126,7 +126,9 @@
                 {#each tableItems as table}
                     <Table.Row.Base {root}>
                         <Table.Cell {root}>{table.name}</Table.Cell>
-                        <Table.Cell {root}>{toLocaleDate(table.updatedAt)}</Table.Cell>
+                        <Table.Cell {root}>
+                            <DualTimeView time={table.updatedAt} />
+                        </Table.Cell>
                     </Table.Row.Base>
                 {/each}
             </Table.Root>

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table.svelte
@@ -6,7 +6,7 @@
     import { Id } from '$lib/components';
     import { Dependencies } from '$lib/constants';
     import { Button } from '$lib/elements/forms';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { addNotification } from '$lib/stores/notifications';
     import { canWriteTables } from '$lib/stores/roles';
     import { sdk } from '$lib/stores/sdk';
@@ -76,7 +76,7 @@
                     {:else if column.id === 'name'}
                         {table.name}
                     {:else}
-                        {toLocaleDateTime(table[column.id])}
+                        <DualTimeView time={table[column.id]} />
                     {/if}
                 </Table.Cell>
             {/each}

--- a/src/routes/(console)/project-[region]-[project]/messaging/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/+page.svelte
@@ -4,7 +4,7 @@
     import { Empty, EmptyFilter, EmptySearch, Id, PaginationWithLimit } from '$lib/components';
     import { hasPageQueries } from '$lib/components/filters';
     import { Button } from '$lib/elements/forms';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { Container, ResponsiveContainerHeader } from '$lib/layout';
     import { MessagingProviderType } from '@appwrite.io/console';
     import CreateMessageDropdown from './createMessageDropdown.svelte';
@@ -208,7 +208,7 @@
                                 {#if !message[column.id]}
                                     -
                                 {:else}
-                                    {toLocaleDateTime(message[column.id])}
+                                    <DualTimeView time={message[column.id]} />
                                 {/if}
                             {:else}
                                 {message[column.id]}

--- a/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/updateTopics.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/updateTopics.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { type Models, MessagingProviderType } from '@appwrite.io/console';
-    import { CardGrid, Empty, PaginationInline, EmptySearch } from '$lib/components';
+    import { CardGrid, Empty, PaginationInline } from '$lib/components';
+    import { Card, Empty as PinkEmpty } from '@appwrite.io/pink-svelte';
     import TopicsModal from '../topicsModal.svelte';
     import { sdk } from '$lib/stores/sdk';
     import { invalidate } from '$app/navigation';
@@ -139,17 +140,21 @@
             {:else if message.status === 'draft'}
                 <Empty on:click={() => (showTopics = true)}>Add a topic</Empty>
             {:else}
-                <EmptySearch hidePagination>
-                    <div class="u-text-center">
-                        No topics have been selected.
-                        <p>
-                            Need a hand? Check out our <Button
-                                href="https://appwrite.io/docs/products/messaging/topics">
-                                documentation</Button
-                            >.
-                        </p>
-                    </div>
-                </EmptySearch>
+                <Card.Base padding="none">
+                    <PinkEmpty
+                        type="secondary"
+                        title="No topics have been selected"
+                        description="Need a hand? Check out our documentation.">
+                        <svelte:fragment slot="actions">
+                            <Button
+                                secondary
+                                href="https://appwrite.io/docs/products/messaging/topics"
+                                external>
+                                Documentation
+                            </Button>
+                        </svelte:fragment>
+                    </PinkEmpty>
+                </Card.Base>
             {/if}
         </svelte:fragment>
         <svelte:fragment slot="actions">

--- a/src/routes/(console)/project-[region]-[project]/messaging/topics/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/topics/table.svelte
@@ -8,7 +8,7 @@
     import { invalidate } from '$app/navigation';
     import { Dependencies } from '$lib/constants';
     import { sdk } from '$lib/stores/sdk';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import type { Column } from '$lib/helpers/types';
     import { page } from '$app/state';
     import { canWriteTopics } from '$lib/stores/roles';
@@ -72,7 +72,9 @@
                             <Id value={topic.$id}>{topic.$id}</Id>
                         {/key}
                     {:else if column.type === 'datetime'}
-                        {topic[column.id] ? toLocaleDateTime(topic[column.id]) : '-'}
+                        {#if topic[column.id]}
+                            <DualTimeView time={topic[column.id]} />
+                        {:else}-{/if}
                     {:else if column.id === 'total'}
                         {topic.emailTotal + topic.smsTotal + topic.pushTotal}
                     {:else}

--- a/src/routes/(console)/project-[region]-[project]/messaging/topics/topic-[topic]/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/topics/topic-[topic]/table.svelte
@@ -8,7 +8,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import type { PageData } from './$types';
     import ProviderType from '../../providerType.svelte';
-    import { toLocaleDateTime } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { project } from '$routes/(console)/project-[region]-[project]/store';
     import { sdk } from '$lib/stores/sdk';
     import { page } from '$app/state';
@@ -109,7 +109,7 @@
                     {:else if column.id === 'type'}
                         <ProviderType type={subscriber.target.providerType} size="xs" />
                     {:else if column.id === '$createdAt'}
-                        {toLocaleDateTime(subscriber[column.id])}
+                        <DualTimeView time={subscriber[column.id]} />
                     {:else}
                         {subscriber[column.id]}
                     {/if}

--- a/src/routes/(console)/project-[region]-[project]/overview/(components)/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/(components)/table.svelte
@@ -6,7 +6,8 @@
     import { Button } from '$lib/elements/forms';
     import { canWriteKeys } from '$lib/stores/roles';
     import type { Models } from '@appwrite.io/console';
-    import { diffDays, toLocaleDate, toLocaleDateTime } from '$lib/helpers/date';
+    import { diffDays } from '$lib/helpers/date';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { devKeyColumns, keyColumns, showDevKeysCreateModal } from '../store';
     import { Badge, FloatingActionBar, Layout, Table } from '@appwrite.io/pink-svelte';
     import DeleteBatch from './deleteBatch.svelte';
@@ -69,12 +70,20 @@
                     {key.name}
                 </Table.Cell>
                 <Table.Cell {root}>
-                    {key.accessedAt ? toLocaleDate(key.accessedAt) : 'never'}
+                    {#if key.accessedAt}
+                        <DualTimeView time={key.accessedAt} />
+                    {:else}
+                        never
+                    {/if}
                 </Table.Cell>
                 <Table.Cell {root}>
                     {@const expiration = getExpiryDetails(key)}
                     <Layout.Stack gap="s" direction="row">
-                        {key.expire ? toLocaleDateTime(key.expire) : 'never'}
+                        {#if key.expire}
+                            <DualTimeView time={key.expire} />
+                        {:else}
+                            never
+                        {/if}
 
                         {#if expiration.status}
                             <Badge


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Use DualTimeView in table date cells across console (Auth, Messaging, Databases, Domains, Billing, Overview, Targets) for hover UTC/Local popover; 
clean up Topics empty state in message view:


## Test Plan

<img width="1568" height="672" alt="image" src="https://github.com/user-attachments/assets/9dbc6f36-7193-4f22-8332-1447a0e8ff2e" />

<img width="1486" height="285" alt="image" src="https://github.com/user-attachments/assets/4c778b40-c6bb-4b46-96e3-ce2f4628483c" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes