### PR TITLE
fix Messaging Topics empty state

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/updateTopics.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/updateTopics.svelte
@@ -143,8 +143,8 @@
                 <Card.Base padding="none">
                     <PinkEmpty
                         type="secondary"
-                        title="No topics have been selected"
-                        description="Need a hand? Check out our documentation.">
+                        title="No topics were selected"
+                        description="No topics were selected for this message. Need a hand? Check out our documentation.">
                         <svelte:fragment slot="actions">
                             <Button
                                 secondary


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

clean up Topics empty state in message view:

## Test Plan

<img width="1441" height="295" alt="image" src="https://github.com/user-attachments/assets/f93e3913-fbfe-48e6-a689-3e06fb74d342" />



## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the “no topics” fallback with a new card-based empty state, showing a clearer title, description, and a Documentation button for guidance.
  * Aligns visuals with the latest design system for a more consistent experience.

* **Refactor**
  * Standardized the empty-state implementation by replacing the legacy empty component with the new design system component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->