### PR TITLE
fix: Update file tokens docs link

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/file-[file]/manageFileToken.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/file-[file]/manageFileToken.svelte
@@ -70,15 +70,13 @@
     </Confirm>
 {:else}
     <Modal bind:show size="s" onSubmit={handleFileToken} title={getModalTitle()}>
-        <!-- TODO: docs link needed-->
         <svelte:fragment slot="description">
             {#if fileToken}
                 {@const formattedDate = cleanFormattedDate(fileToken.$createdAt)}
                 Edit the expiry of the file token created on <b>{formattedDate}</b>.
             {:else}
                 Create a file token to grant access to a file.
-                <!-- TODO: @itznotabug, @adityaoberai need documentations link -->
-                <Link.Anchor href="https://appwrite.com/docs/">Learn more</Link.Anchor>.
+                <Link.Anchor href="https://appwrite.io/docs/products/storage/file-tokens">Learn more</Link.Anchor>.
             {/if}
         </svelte:fragment>
 

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/file-[file]/manageFileToken.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/file-[file]/manageFileToken.svelte
@@ -76,7 +76,9 @@
                 Edit the expiry of the file token created on <b>{formattedDate}</b>.
             {:else}
                 Create a file token to grant access to a file.
-                <Link.Anchor href="https://appwrite.io/docs/products/storage/file-tokens">Learn more</Link.Anchor>.
+                <Link.Anchor href="https://appwrite.io/docs/products/storage/file-tokens"
+                    >Learn more</Link.Anchor
+                >.
             {/if}
         </svelte:fragment>
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates file tokens docs link

## Test Plan

Visit the manage file tokens section on a file

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the help/“Learn more” link in the Manage File Token modal to point to the current Appwrite Storage file-tokens documentation for clearer guidance.
* **Bug Fixes**
  * Replaced an outdated docs URL in the modal description so users are directed to the correct resource for creating and managing file tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->