### PR TITLE
fix: auto-dismiss SideSheet on navigation to prevent lingering Duplicate/Update row sheets(Sidesheets)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/layout/sidesheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/layout/sidesheet.svelte
@@ -12,7 +12,6 @@
         show = $bindable(false),
         title,
         closeOnBlur = false,
-        autoCloseOnNavigate = true,
         submit,
         cancel,
         children = null,
@@ -25,7 +24,6 @@
         title: string;
         titleBadge?: string;
         closeOnBlur?: boolean;
-        autoCloseOnNavigate?: boolean;
         topAction?:
             | {
                   text: string;
@@ -58,7 +56,7 @@
 
     let copyText = $state(undefined);
     beforeNavigate(() => {
-        if (autoCloseOnNavigate) show = false;
+        show = false;
     });
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/layout/sidesheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/layout/sidesheet.svelte
@@ -6,11 +6,13 @@
     import { isTabletViewport } from '$lib/stores/viewport';
     import { Badge, Divider, Layout, Sheet, Tag, Typography } from '@appwrite.io/pink-svelte';
     import type { HTMLAttributes } from 'svelte/elements';
+    import { beforeNavigate } from '$app/navigation';
 
     let {
         show = $bindable(false),
         title,
         closeOnBlur = false,
+        autoCloseOnNavigate = true,
         submit,
         cancel,
         children = null,
@@ -23,6 +25,7 @@
         title: string;
         titleBadge?: string;
         closeOnBlur?: boolean;
+        autoCloseOnNavigate?: boolean;
         topAction?:
             | {
                   text: string;
@@ -54,6 +57,9 @@
     let submitting = $state(writable(false));
 
     let copyText = $state(undefined);
+    beforeNavigate(() => {
+        if (autoCloseOnNavigate) show = false;
+    });
 </script>
 
 <div class="sheet-container" data-side-sheet-visible={show} {...restProps}>


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add beforeNavigate handler in SideSheet to set show = false on route change
~Introduce autoCloseOnNavigate prop (default: true) for opt-out~

## Test Plan
<img width="1740" height="760" alt="image" src="https://github.com/user-attachments/assets/8b0a324b-64ad-484f-b2c8-f4a2e3e9689e" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side sheet now automatically closes when navigating to a new page, preventing lingering overlays and improving navigation flow. Enabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->