### PR TITLE
Fix: overriding timestamps on row duplicate action

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
@@ -97,7 +97,7 @@
     export let data: PageData;
     export let showRowCreateSheet: {
         show: boolean;
-        row: Models.Row | null;
+        row: Partial<Models.Row> | null;
     };
 
     $: rows = writable(data.rows);
@@ -543,7 +543,13 @@
             }
 
             if (action === 'duplicate-row') {
-                showRowCreateSheet.row = row;
+                /**
+                 * remove dates because
+                 * console can override timestamps!
+                 */
+                const { $createdAt, $updatedAt, ...rowWithoutDates } = row;
+
+                showRowCreateSheet.row = rowWithoutDates;
                 showRowCreateSheet.show = true;
             }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duplicating a table row now pre-fills the create-row sheet with partial data while automatically excluding system-managed date fields (e.g., created/updated timestamps). This streamlines duplication, avoids unintended carryover of timestamps, and ensures cleaner starting values. The sheet accepts partial entries for easier adjustment before saving. No other user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->