### PR TITLE
fix: Use Alert.Inline title for single-line alerts across console

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/templates/resetEmail.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/templates/resetEmail.svelte
@@ -54,7 +54,7 @@
         </p>
 
         {#if error}
-            <Alert.Inline status="warning">{error}</Alert.Inline>
+            <Alert.Inline status="warning" title={error} />
         {/if}
     </Layout.Stack>
 

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(suggestions)/indexes.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(suggestions)/indexes.svelte
@@ -398,9 +398,7 @@
             }
         }}>
         {#if modalError}
-            <Alert.Inline status="error">
-                {modalError}
-            </Alert.Inline>
+            <Alert.Inline status="error" title={modalError} />
         {/if}
 
         {#await loadIndexSuggestions()}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
@@ -1153,7 +1153,7 @@
         </Table.Root>
 
         <Layout.Stack direction="column" gap="m">
-            <Alert.Inline>To change the selection edit the relationship settings.</Alert.Inline>
+            <Alert.Inline title="To change the selection edit the relationship settings." />
         </Layout.Stack>
     {:else}
         <p class="u-bold">This action is irreversible.</p>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/+page.svelte
@@ -86,10 +86,11 @@
                     </svelte:fragment>
                 </Alert.Inline>
             {:else}
-                <Alert.Inline status="info" dismissible on:dismiss={() => (showAlert = false)}>
-                    Some configuration changes are not live yet. Your function is redeploying —
-                    changes will be applied once the build is complete.
-                </Alert.Inline>
+                <Alert.Inline
+                    status="info"
+                    dismissible
+                    on:dismiss={() => (showAlert = false)}
+                    title="Some configuration changes are not live yet. Your function is redeploying — changes will be applied once the build is complete." />
             {/if}
         {/if}
         <Layout.Stack gap="xxxl">

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/+page.svelte
@@ -89,9 +89,12 @@
                     </svelte:fragment>
                 </Alert.Inline>
             {:else}
-                <Alert.Inline status="info" dismissible on:dismiss={() => (showAlert = false)}>
-                    Some configuration changes are not live yet. Your site is redeploying — changes
-                    will be applied once the build is complete.
+                <Alert.Inline
+                    status="info"
+                    title="Some configuration changes are not live yet. Your site is redeploying — changes
+            will be applied once the build is complete."
+                    dismissible
+                    on:dismiss={() => (showAlert = false)}>
                 </Alert.Inline>
             {/if}
         {/if}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Several single-line Alert.Inline usages used slot content use title prop instead

## Test Plan

<img width="1575" height="334" alt="image" src="https://github.com/user-attachments/assets/c2d0dabe-08b3-4b05-8563-5814fb44e5ba" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes