### PR TITLE
Fix: layout flex.

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/+page.svelte
@@ -51,7 +51,6 @@
     import { type Models } from '@appwrite.io/console';
     import { preferences } from '$lib/stores/preferences';
     import { page } from '$app/state';
-    import { formatName } from '$lib/helpers/string';
 
     const updatedColumnsForSheet = $derived.by(() => {
         const baseAttrs = [
@@ -251,8 +250,17 @@
                     column['system'] || column.type === 'relationship' ? 'disabled' : true}
                 <Spreadsheet.Row.Base {root} select={isSelectable} id={column.key}>
                     <Spreadsheet.Cell column="key" {root} isEditable={false}>
-                        <Layout.Stack direction="row" justifyContent="space-between">
-                            <Layout.Stack direction="row" alignItems="center" inline>
+                        <Layout.Stack
+                            direction="row"
+                            alignItems="center"
+                            justifyContent="space-between"
+                            style="min-width:0">
+                            <Layout.Stack
+                                gap="s"
+                                inline
+                                direction="row"
+                                alignItems="center"
+                                style="min-width:0; flex:1 1 auto;">
                                 {#if isRelationship(column)}
                                     <Icon
                                         size="s"
@@ -268,33 +276,35 @@
                                     <Icon icon={option.icon} size="s" />
                                 {/if}
 
-                                <Layout.Stack direction="row" alignItems="center" gap="s">
-                                    <Layout.Stack
-                                        inline
-                                        direction="row"
-                                        alignItems="center"
-                                        gap="xxs">
-                                        <Typography.Text truncate>
-                                            {#if isSystemColumnKey(column)}
-                                                {column.key}
-                                            {:else}
-                                                {@const key = !column.required
-                                                    ? column.key
-                                                    : formatName(column.key, 6)}
-                                                {key}
-                                                {column.array ? '[]' : undefined}
-                                            {/if}
-                                        </Typography.Text>
-                                        {#if isString(column) && column.encrypt}
-                                            <Tooltip>
-                                                <Icon
-                                                    size="s"
-                                                    icon={IconLockClosed}
-                                                    color="--fgcolor-neutral-tertiary" />
-                                                <div slot="tooltip">Encrypted</div>
-                                            </Tooltip>
+                                <Layout.Stack
+                                    gap="s"
+                                    inline
+                                    direction="row"
+                                    alignItems="center"
+                                    style="min-width:0; flex:1 1 auto; overflow:hidden;">
+                                    <Typography.Text truncate>
+                                        {#if isSystemColumnKey(column)}
+                                            {column.key}
+                                        {:else}
+                                            {column.key}{column.array ? '[]' : undefined}
                                         {/if}
-                                    </Layout.Stack>
+                                    </Typography.Text>
+                                    {#if isString(column) && column.encrypt}
+                                        <Tooltip>
+                                            <Icon
+                                                size="s"
+                                                icon={IconLockClosed}
+                                                color="--fgcolor-neutral-tertiary" />
+                                            <div slot="tooltip">Encrypted</div>
+                                        </Tooltip>
+                                    {/if}
+                                </Layout.Stack>
+                                <Layout.Stack
+                                    gap="s"
+                                    inline
+                                    direction="row"
+                                    alignItems="center"
+                                    style="flex:0 0 auto; white-space:nowrap;">
                                     {#if column.status !== 'available'}
                                         <Badge
                                             size="s"


### PR DESCRIPTION
## What does this PR do?

Fixes layout flex on columns page.

## Test Plan

Manual.

Before -

<img width="419" height="666" alt="Screenshot 2025-10-03 at 8 00 51 PM" src="https://github.com/user-attachments/assets/febb210b-22b4-4fce-8b94-302a5cf784b3" />

After -
<img width="419" height="668" alt="Screenshot 2025-10-03 at 8 00 21 PM" src="https://github.com/user-attachments/assets/5618a5da-aa4f-4680-9b7b-43b42b3f36e9" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Column keys now display in full (no abbreviation), with smart truncation when space is limited.
- Style
  - Improved layout and alignment of the column key area for better readability.
  - Enhanced overflow handling and responsive behavior to prevent wrapping and clipping.
  - More consistent spacing and positioning for icons, tooltips, and status badges.
- Refactor
  - Simplified and consolidated the UI structure of the column key cell for a more compact, maintainable layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->