### PR TITLE
Fix: duplicate row not copying permissions

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/create.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/create.svelte
@@ -58,7 +58,7 @@
                       },
                       {} as Record<string, unknown>
                   ),
-            permissions: [],
+            permissions: existingData.$permissions ?? [],
             columns: availableColumns
         };
     }


### PR DESCRIPTION
## What does this PR do?

Duplicate row option was missing permissions copy.

## Test Plan

Manual.

Before -

https://github.com/user-attachments/assets/9404cd4c-2a98-4e02-9aee-43c7aa61af51

After -

https://github.com/user-attachments/assets/83f575bc-b5ef-4292-9c6d-212d287d76d3

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)