### PR TITLE
Fix: nullable not shown in datetime column type

### DIFF
--- a/src/lib/elements/forms/inputDateTime.svelte
+++ b/src/lib/elements/forms/inputDateTime.svelte
@@ -4,7 +4,7 @@
 
     export let id: string;
     export let label: string = '';
-    export let value: string;
+    export let value: string | null;
     export let required = false;
     export let nullable = false;
     export let disabled = false;
@@ -17,6 +17,7 @@
 
     let error: string;
     let element: HTMLInputElement;
+    let previousValue: string | null = null;
 
     onMount(() => {
         if (element && autofocus) {
@@ -24,14 +25,16 @@
         }
     });
 
-    let prevValue = '';
     function handleNullChange(e: CustomEvent<boolean>) {
         const isNull = e.detail;
+
         if (isNull) {
-            prevValue = value;
+            if (value) {
+                previousValue = value;
+            }
             value = null;
         } else {
-            value = prevValue;
+            value = previousValue;
         }
     }
 
@@ -39,9 +42,7 @@
         error = null;
     }
 
-    function onChange(event: CustomEvent) {
-        value = (event.target as HTMLInputElement).value;
-    }
+    $: isValueNull = value === null;
 </script>
 
 <Layout.Stack gap="s" direction="row">
@@ -51,20 +52,20 @@
         {disabled}
         {readonly}
         {required}
-        {value}
+        bind:value
         {step}
         {type}
         helper={error}
         {leadingIcon}
-        on:change={onChange}
         autocomplete={autocomplete ? 'on' : 'off'}>
-        {#if nullable}
-            <Selector.Checkbox
-                size="s"
-                slot="end"
-                label="NULL"
-                checked={value === null}
-                on:change={handleNullChange} />
-        {/if}
+        <svelte:fragment slot="end">
+            {#if nullable}
+                <Selector.Checkbox
+                    size="s"
+                    label="NULL"
+                    checked={isValueNull}
+                    on:change={handleNullChange} />
+            {/if}
+        </svelte:fragment>
     </Input.DateTime>
 </Layout.Stack>

--- a/src/lib/elements/forms/inputDateTime.svelte
+++ b/src/lib/elements/forms/inputDateTime.svelte
@@ -29,7 +29,7 @@
         const isNull = e.detail;
 
         if (isNull) {
-            if (value) {
+            if (value !== null) {
                 previousValue = value;
             }
             value = null;

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/datetime.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/datetime.svelte
@@ -68,6 +68,7 @@
         array: false,
         ...data
     });
+
     $: listen(data);
 
     $: handleDefaultState($required || $array);

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
@@ -1217,6 +1217,10 @@
             padding-inline: 8px !important;
         }
 
+        & :global(.input:has([type^='date'])) {
+            padding: 12px !important;
+        }
+
         & :global(.input:focus-within) {
             top: 0 !important;
         }


### PR DESCRIPTION
## What does this PR do?

Fix nullable not shown on UI for datettime.
Context: Slot rendering isn't conditional. The content inside it can be optional though.

## Test Plan

Manual.

Before -

<img width="665" height="420" alt="Screenshot 2025-10-04 at 12 03 23 PM" src="https://github.com/user-attachments/assets/c7810b03-0ef5-4767-8056-1a34c94a9bff" />

After -

<img width="665" height="441" alt="Screenshot 2025-10-04 at 12 03 38 PM" src="https://github.com/user-attachments/assets/91697118-f32c-4221-9c74-7fe45771e7fe" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Date/time input now supports nullable values with a NULL toggle that preserves and restores the previous value.
- Bug Fixes
  - Database column datetime page now establishes its data listener after initialization so the UI reliably stays in sync with data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->