### PR TITLE
Feat: resizable columns on columns and indexes page

### DIFF
--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -224,6 +224,7 @@ function createPreferences() {
             delete teamPreferences?.displayNames?.[tableId];
             delete teamPreferences?.columnOrder?.[tableId];
             delete teamPreferences?.columnWidths?.[tableId];
+            delete teamPreferences?.columnWidths?.[tableId + '#columns'];
 
             const removeTablePreferences = sdk.forConsole.teams.updatePrefs({
                 teamId: orgId,

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -225,6 +225,7 @@ function createPreferences() {
             delete teamPreferences?.columnOrder?.[tableId];
             delete teamPreferences?.columnWidths?.[tableId];
             delete teamPreferences?.columnWidths?.[tableId + '#columns'];
+            delete teamPreferences?.columnWidths?.[tableId + '#indexes'];
 
             const removeTablePreferences = sdk.forConsole.teams.updatePrefs({
                 teamId: orgId,

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/create.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/create.svelte
@@ -58,7 +58,7 @@
                       },
                       {} as Record<string, unknown>
                   ),
-            permissions: existingData.$permissions ?? [],
+            permissions: existingData?.$permissions ?? [],
             columns: availableColumns
         };
     }

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/store.ts
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/store.ts
@@ -33,9 +33,12 @@ export const tableColumns = writable<Column[]>([]);
 export const isCsvImportInProgress = writable(false);
 
 export const columnsOrder = writable<string[]>([]);
-export const columnsWidth = writable<{
+
+export type ColumnsWidth = {
     [columnId: string]: { fixed: number | { min: number }; resized: number };
-}>();
+};
+
+export const columnsWidth = writable<ColumnsWidth>();
 
 type DatabaseSheetOptions = {
     show: boolean;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Columns and Indexes views now support resizable columns.
  - Column widths persist per table and organization, loading automatically and saving on resize.
  - Improved default width handling for a more consistent spreadsheet experience.

- Bug Fixes
  - Prevents occasional errors when creating rows if no existing data is present.
  - Cleans up saved column width preferences when a table is deleted, avoiding leftover settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->