### PR TITLE
Fix: bottom nav

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
@@ -167,7 +167,7 @@
                         {@const href = `${base}/project-${region}-${project}/databases/database-${databaseId}/${action.href}`}
 
                         <Layout.Stack gap="s" direction="row" alignItems="center">
-                            <li>
+                            <li class="bottom-nav-item">
                                 <a
                                     {href}
                                     class="u-padding-block-8 u-padding-inline-end-4 u-padding-inline-start-8 u-flex u-cross-center u-gap-8">
@@ -267,8 +267,8 @@
         scrollbar-width: none;
         -ms-overflow-style: none;
 
-        //scrollbar-width: thin;
-        //scrollbar-color: var(--border-neutral, #ededf0) transparent;
+        // scrollbar-width: thin;
+        // scrollbar-color: var(--border-neutral, #ededf0) transparent;
 
         &::-webkit-scrollbar {
             width: 4px;
@@ -333,12 +333,16 @@
             position: relative;
             padding-inline-end: 0.5rem;
             margin-inline-start: 0.5rem;
-        }
 
-        li:hover {
-            color: var(--fgcolor-neutral-primary);
-            border-radius: var(--border-radius-s, 6px);
-            background: var(--bgcolor-neutral-secondary);
+            &:hover {
+                color: var(--fgcolor-neutral-primary);
+                border-radius: var(--border-radius-s, 6px);
+                background: var(--bgcolor-neutral-secondary);
+            }
+
+            &.bottom-nav-item:hover {
+                margin-inline-end: 1.25rem;
+            }
         }
 
         .table-name {
@@ -386,7 +390,6 @@
         left: 1.25rem;
         position: absolute;
         padding-block-end: 1rem;
-        background: var(--bgcolor-neutral-primary, #ffffff);
     }
 
     .action-menu-divider {

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
@@ -55,10 +55,11 @@
 
     const isMainDatabaseScreen = $derived(page.route.id.endsWith('database-[database]'));
 
-    // If banner open, `-1rem` to adjust banner size, else `-70.5px`.
+    // If banner open, adjust bottom position to account for banner container.
     // 70.5px is the size of the container of the banner holder and not just the banner!
     // Needed because things vary a bit much on how different browsers treat bottom layouts.
-    const bottomNavHeight = $derived(`calc(20% ${$bannerSpacing ? '- 1rem' : '- 70.5px'})`);
+    const bottomNavOffset = $derived($bannerSpacing ? '70.5px' : '0px');
+    const tableContentPadding = $derived($bannerSpacing ? '210px' : '140px');
 
     async function loadTables() {
         tables = await sdk.forProject(region, project).tablesDB.listTables({
@@ -92,7 +93,10 @@
 
                 {data.database?.name}
             </a>
-            <div class="table-content">
+            <div
+                class="table-content"
+                style:padding-bottom={tableContentPadding}
+            >
                 {#if tables?.total}
                     <ul class="drop-list u-margin-inline-start-8 u-margin-block-start-4">
                         {#each sortedTables as table, index}
@@ -154,10 +158,10 @@
                 </Layout.Stack>
             </div>
 
-            <Layout.Stack
-                gap="xxs"
-                direction="column"
-                style="bottom: 1rem; position: relative; height: {bottomNavHeight}">
+            <div
+                class="bottom-nav-container"
+                style:bottom={bottomNavOffset}
+            >
                 <div class="action-menu-divider">
                     <Divider />
                 </div>
@@ -183,7 +187,7 @@
                         </Layout.Stack>
                     {/each}
                 </ul>
-            </Layout.Stack>
+            </div>
         </section>
     </Sidebar.Base>
 {:else if data?.database?.name && !isMainDatabaseScreen}
@@ -263,10 +267,14 @@
         overflow-x: hidden;
         min-height: 0;
         margin-bottom: auto;
-        padding-bottom: 16px;
-        scrollbar-width: thin;
-        scrollbar-color: var(--border-neutral, #ededf0) transparent;
         color: var(--fgcolor-neutral-secondary, #56565c);
+
+        /* hide scrollbars */
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+
+        //scrollbar-width: thin;
+        //scrollbar-color: var(--border-neutral, #ededf0) transparent;
 
         &::-webkit-scrollbar {
             width: 4px;
@@ -295,6 +303,10 @@
         position: relative;
         font-size: var(--font-size-sm);
         color: var(--fgcolor-neutral-secondary);
+
+        &::-webkit-scrollbar {
+          display: none;
+        }
 
         &:not(.bottom-nav)::before {
             content: '';
@@ -374,8 +386,17 @@
         line-height: 150%; /* 21px */
     }
 
+    .bottom-nav-container {
+        right: 0;
+        bottom: 0;
+        left: 1.25rem;
+        position: absolute;
+        padding-block-end: 1rem;
+        background: var(--bgcolor-neutral-primary, #ffffff);
+    }
+
     .action-menu-divider {
-        margin-inline: -1.2rem;
         padding-block-end: 0.25rem;
+        margin-inline-start: -1.25rem;
     }
 </style>

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
@@ -93,10 +93,7 @@
 
                 {data.database?.name}
             </a>
-            <div
-                class="table-content"
-                style:padding-bottom={tableContentPadding}
-            >
+            <div class="table-content" style:padding-bottom={tableContentPadding}>
                 {#if tables?.total}
                     <ul class="drop-list u-margin-inline-start-8 u-margin-block-start-4">
                         {#each sortedTables as table, index}
@@ -158,10 +155,7 @@
                 </Layout.Stack>
             </div>
 
-            <div
-                class="bottom-nav-container"
-                style:bottom={bottomNavOffset}
-            >
+            <div class="bottom-nav-container" style:bottom={bottomNavOffset}>
                 <div class="action-menu-divider">
                     <Divider />
                 </div>
@@ -305,7 +299,7 @@
         color: var(--fgcolor-neutral-secondary);
 
         &::-webkit-scrollbar {
-          display: none;
+            display: none;
         }
 
         &:not(.bottom-nav)::before {


### PR DESCRIPTION
## What does this PR do?

Fix the bottom nav positioning.

## Test Plan

Manual.

Before -

<img width="1238" height="750" alt="Screenshot 2025-10-06 at 6 06 25 PM" src="https://github.com/user-attachments/assets/9e3434a5-9c3c-4325-a8a0-b99368c3fce7" />

After -
<img width="1238" height="750" alt="Screenshot 2025-10-06 at 6 07 16 PM" src="https://github.com/user-attachments/assets/472951df-127f-4560-815a-60d5c6fd468d" />

## Related PRs and Issues

#DAT-782

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Refined bottom navigation layout with adaptive offsets and padding to prevent overlap with the banner.
  - Added a dedicated bottom navigation container for consistent positioning and alignment.
  - Hid scrollbars across relevant areas for a cleaner appearance while preserving scroll behavior.
  - Adjusted margins, paddings, and hover styles for improved visual consistency.

- Bug Fixes
  - Fixed cases where table content could be obscured by the bottom navigation, ensuring content remains fully visible across banner states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->