### PR TITLE
Set specifications only for cloud

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/deploy/+page.svelte
@@ -20,6 +20,7 @@
     import { getLatestTag } from '$lib/helpers/github';
     import { writable } from 'svelte/store';
     import Link from '$lib/elements/link.svelte';
+    import { isCloud } from '$lib/system';
 
     let {
         data
@@ -105,7 +106,7 @@
                     commands: installCommand || undefined,
                     scopes: selectedScopes?.length ? selectedScopes : undefined,
                     providerSilentMode: false,
-                    specification: specification || undefined
+                    specification: isCloud ? specification || undefined : undefined
                 });
 
             // Add domain

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
@@ -72,7 +72,7 @@
                     enabled: true,
                     entrypoint,
                     commands: buildCommand,
-                    specification: specification || undefined
+                    specification: isCloud ? specification || undefined : undefined
                 });
 
             // Add domain

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/+page.svelte
@@ -22,6 +22,7 @@
     import RepoCard from './repoCard.svelte';
     import { getIconFromRuntime } from '$lib/stores/runtimes';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
+    import { isCloud } from '$lib/system';
 
     export let data;
 
@@ -108,7 +109,7 @@
                     providerBranch: branch,
                     providerSilentMode: silentMode,
                     providerRootDirectory: rootDir,
-                    specification: specification || undefined
+                    specification: isCloud ? specification || undefined : undefined
                 });
 
             // Add domain

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
@@ -31,6 +31,7 @@
     import { Dependencies } from '$lib/constants';
     import { getIconFromRuntime } from '$lib/stores/runtimes';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
+    import { isCloud } from '$lib/system';
 
     export let data;
 
@@ -148,7 +149,7 @@
                         providerBranch: branch,
                         providerSilentMode: silentMode,
                         providerRootDirectory: rootDir,
-                        specification: specification || undefined
+                        specification: isCloud ? specification || undefined : undefined
                     });
 
                 // Add domain

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildCommand.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildCommand.svelte
@@ -8,6 +8,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { page } from '$app/state';
 
     export let func: Models.Function;
@@ -36,7 +37,7 @@
                 providerBranch: func.providerBranch || undefined,
                 providerSilentMode: func.providerSilentMode || undefined,
                 providerRootDirectory: func.providerRootDirectory || undefined,
-                specification: func.specification || undefined
+                specification: isCloud ? func.specification || undefined : undefined
             });
 
             await invalidate(Dependencies.FUNCTION);

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateEvents.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateEvents.svelte
@@ -15,6 +15,7 @@
     import { Button } from '$lib/elements/forms';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { IconPlus, IconX } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Link, Table, Typography } from '@appwrite.io/pink-svelte';
 
@@ -47,7 +48,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateLogging.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateLogging.svelte
@@ -8,6 +8,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { Typography } from '@appwrite.io/pink-svelte';
     import { page } from '$app/state';
 
@@ -37,7 +38,7 @@
                 providerBranch: func.providerBranch || undefined,
                 providerSilentMode: func.providerSilentMode || undefined,
                 providerRootDirectory: func.providerRootDirectory || undefined,
-                specification: func.specification || undefined
+                specification: isCloud ? func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateName.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateName.svelte
@@ -11,6 +11,7 @@
     import { func } from '../store';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
 
     const functionId = page.params.function;
     let functionName: string = null;
@@ -42,7 +43,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updatePermissions.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updatePermissions.svelte
@@ -13,6 +13,7 @@
     import { symmetricDifference } from '$lib/helpers/array';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { Link } from '$lib/elements';
 
     const functionId = page.params.function;
@@ -47,7 +48,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
@@ -44,7 +44,7 @@
                 providerBranch: func.providerBranch || undefined,
                 providerSilentMode: func.providerSilentMode || undefined,
                 providerRootDirectory: func.providerRootDirectory || undefined,
-                specification: specification || undefined
+                specification: isCloud ? specification || undefined : undefined
             });
 
             await invalidate(Dependencies.FUNCTION);

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRuntime.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRuntime.svelte
@@ -11,6 +11,7 @@
     import InputSelect from '$lib/elements/forms/inputSelect.svelte';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { Layout, Typography } from '@appwrite.io/pink-svelte';
     import Link from '$lib/elements/link.svelte';
 
@@ -46,7 +47,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateSchedule.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateSchedule.svelte
@@ -11,6 +11,7 @@
     import { func } from '../store';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { Link } from '$lib/elements';
     import { parseExpression } from 'cron-parser';
 
@@ -47,7 +48,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateScopes.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateScopes.svelte
@@ -11,6 +11,7 @@
     import { func } from '../store';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import Scopes from '$routes/(console)/project-[region]-[project]/overview/api-keys/scopes.svelte';
     import { symmetricDifference } from '$lib/helpers/array';
     import { Link } from '$lib/elements';
@@ -45,7 +46,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateTimeout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateTimeout.svelte
@@ -11,6 +11,7 @@
     import { func } from '../store';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { Runtime } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
 
     const functionId = page.params.function;
     let timeout: number = null;
@@ -42,7 +43,7 @@
                 providerBranch: $func.providerBranch || undefined,
                 providerSilentMode: $func.providerSilentMode || undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                specification: $func.specification || undefined
+                specification: isCloud ? $func.specification || undefined : undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -7,6 +7,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { Card, Fieldset, Icon, InlineCode, Layout, Tooltip } from '@appwrite.io/pink-svelte';
     import { iconPath } from '$lib/stores/app';
     import { Link } from '$lib/elements';
@@ -136,7 +137,7 @@
                 providerBranch: site.providerBranch || undefined,
                 providerSilentMode: site.providerSilentMode || undefined,
                 providerRootDirectory: site.providerRootDirectory || undefined,
-                specification: specToSend || undefined
+                specification: isCloud ? specToSend || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateLogging.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateLogging.svelte
@@ -8,6 +8,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { Typography } from '@appwrite.io/pink-svelte';
 
     export let site: Models.Site;
@@ -33,7 +34,7 @@
                 providerBranch: site?.providerBranch || undefined,
                 providerSilentMode: site?.providerSilentMode || undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                specification: site?.specification || undefined
+                specification: isCloud ? site?.specification || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateName.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateName.svelte
@@ -8,6 +8,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { onMount } from 'svelte';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { page } from '$app/state';
 
     export let site: Models.Site;
@@ -37,7 +38,7 @@
                 providerBranch: site?.providerBranch || undefined,
                 providerSilentMode: site?.providerSilentMode || undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                specification: site?.specification || undefined
+                specification: isCloud ? site?.specification || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRepository.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRepository.svelte
@@ -7,6 +7,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { onMount } from 'svelte';
     import DisconnectRepo from './disconnectRepo.svelte';
     import { installation, repository as repositoryStore, sortBranches } from '$lib/stores/vcs';
@@ -86,7 +87,7 @@
                 providerBranch: selectedBranch || undefined,
                 providerSilentMode: silentMode || undefined,
                 providerRootDirectory: selectedDir || undefined,
-                specification: site?.specification || undefined
+                specification: isCloud ? site?.specification || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({
@@ -133,7 +134,7 @@
                 installationId: selectedInstallationId,
                 providerRepositoryId: selectedRepository,
                 providerBranch: 'main',
-                specification: site?.specification || undefined
+                specification: isCloud ? site?.specification || undefined : undefined
             });
 
             invalidate(Dependencies.SITE);

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -39,7 +39,7 @@
                 providerBranch: site?.providerBranch || undefined,
                 providerSilentMode: site?.providerSilentMode || undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                specification: specification || undefined
+                specification: isCloud ? specification || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             originalSpecification = specification;

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRuntimeSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRuntimeSettings.svelte
@@ -11,6 +11,7 @@
     import { getIconFromRuntime } from '$lib/stores/runtimes';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
 
     export let site: Models.Site;
     export let frameworks: Models.Framework[];
@@ -43,7 +44,7 @@
                 providerBranch: site?.providerBranch || undefined,
                 providerSilentMode: site?.providerSilentMode || undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                specification: site?.specification || undefined
+                specification: isCloud ? site?.specification || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateTimeout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateTimeout.svelte
@@ -8,6 +8,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { onMount } from 'svelte';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
+    import { isCloud } from '$lib/system';
     import { page } from '$app/state';
 
     export let site: Models.Site;
@@ -36,7 +37,7 @@
                 providerBranch: site?.providerBranch || undefined,
                 providerSilentMode: site?.providerSilentMode || undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                specification: site?.specification || undefined
+                specification: isCloud ? site?.specification || undefined : undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Only pass specifications if on cloud

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved compatibility for self-hosted/non-cloud environments by omitting unsupported “specification” data during Function and Site creation/updates. Applies to create flows (deploy, manual, repo, template) and settings updates (build, runtime, events, logging, name, permissions, scopes, schedule, resource limits, timeout, repository). Reduces errors and unexpected behavior outside cloud deployments.
- Chores
  - Standardized payload handling across Function and Site settings to respect cloud vs. non-cloud contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->