### PR TITLE
Fixes for Editor switching to next field on pressing Enter

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/execute-function/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/execute-function/+page.svelte
@@ -307,7 +307,7 @@
                                             }
                                         }}>
                                         <InputTextarea
-                                            placeholder="Enter request body heresssss..."
+                                            placeholder="Enter request body here..."
                                             id="body"
                                             bind:value={body} />
                                     </div>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/execute-function/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/execute-function/+page.svelte
@@ -176,10 +176,19 @@
                                 Provide the request body to include the main data you want to send
                                 to the server.
                             </Typography.Text>
-                            <InputTextarea
-                                placeholder="Enter request body here..."
-                                id="body"
-                                bind:value={body} />
+                            <div
+                                role="textbox"
+                                tabindex="-1"
+                                on:keyup={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.stopPropagation();
+                                    }
+                                }}>
+                                <InputTextarea
+                                    placeholder="Enter request body here..."
+                                    id="body"
+                                    bind:value={body} />
+                            </div>
                         </Layout.Stack>
                     </Accordion>
                 </Fieldset>
@@ -289,10 +298,19 @@
                                         Provide the request body to include the main data you want
                                         to send to the server.
                                     </Typography.Text>
-                                    <InputTextarea
-                                        placeholder="Enter request body here..."
-                                        id="body"
-                                        bind:value={body} />
+                                    <div
+                                        role="textbox"
+                                        tabindex="-1"
+                                        on:keyup={(e) => {
+                                            if (e.key === 'Enter') {
+                                                e.stopPropagation();
+                                            }
+                                        }}>
+                                        <InputTextarea
+                                            placeholder="Enter request body heresssss..."
+                                            id="body"
+                                            bind:value={body} />
+                                    </div>
                                 </Layout.Stack>
                             </Accordion>
                         </Layout.Stack>


### PR DESCRIPTION
## What does this PR do?

Fixes for Editor switching to next field on pressing Enter inside text area specific to Body component in Execution Create

Fixes https://github.com/appwrite/appwrite/issues/10607

## Test Plan

Reproduction Steps:

1. Go to the website and navigate to the Create Execution page in Appwrite.
2. In the Body section, open the text editor to enter request content.
3. Start typing some text.
4. Press Enter or Shift+Enter inside the editor.

The cursor goes to the next line but the Accordion closes when user presses Enter key.

Check the attached recording for reference

https://github.com/user-attachments/assets/673b0f03-f0f3-4f99-ac96-1dbd98819a0a


## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/10607

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents Enter in request body textareas from triggering parent actions, improving multiline editing.
- Accessibility
  - Improved keyboard/interaction handling and semantic role for request body inputs to enhance usability for keyboard and assistive technology users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->