### PR TITLE
fix: resolve popover z-index stacking in settings cards

### DIFF
--- a/src/lib/components/cardGrid.svelte
+++ b/src/lib/components/cardGrid.svelte
@@ -3,9 +3,11 @@
 
     export let hideFooter = false;
     export let gap: 'none' | 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl' = 'l';
+    export let style = '';
+    export let zIndex: number | undefined = undefined;
 </script>
 
-<Card.Base>
+<Card.Base style="{zIndex !== undefined ? `position: relative; z-index: ${zIndex};` : ''} {style}">
     <Layout.Stack gap="xl" justifyContent="space-around">
         <Layout.GridFraction gap="xxxl" rowGap="xl" start={1} end={2}>
             <Layout.Stack gap="xxs">

--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -77,7 +77,7 @@
     }
 </script>
 
-<CardGrid>
+<CardGrid zIndex={10}>
     <svelte:fragment slot="title">Git configuration</svelte:fragment>
     Add a Git installation to your project so you can connect repositories later through your function
     or site settings.

--- a/src/routes/(console)/project-[region]-[project]/updateVariables.svelte
+++ b/src/routes/(console)/project-[region]-[project]/updateVariables.svelte
@@ -265,7 +265,7 @@
         : false;
 </script>
 
-<CardGrid>
+<CardGrid zIndex={10}>
     <svelte:fragment slot="title"
         >{isGlobal ? 'Global variables' : 'Environment variables'}</svelte:fragment>
     {#if isGlobal}


### PR DESCRIPTION
## What does this PR do?

Fixes z-index stacking context issues where popover menus in settings cards get hidden behind subsequent cards.

### Problem
Multiple `Card.Base` components with default styling create competing stacking contexts. When a popover opens in an upper card (like Git configuration or Global variables), it gets rendered behind lower cards in the DOM, making it partially or completely hidden.

### Solution
Added an optional `zIndex` prop to the `CardGrid` component. This allows specific cards containing popover menus to establish proper stacking context without affecting all CardGrid instances.

### Changes Made
- Added optional `zIndex` prop to `CardGrid` component (`src/lib/components/cardGrid.svelte`)
- Applied `zIndex={10}` to Git configuration card in `updateInstallations.svelte`
- Applied `zIndex={10}` to Global variables card in `updateVariables.svelte`
- Maintained backward compatibility - cards without the prop work as before

## Test Plan

### Local Testing Performed:
1. ✅ Navigated to Project Settings page
2. ✅ Added a Git installation and clicked the three-dot menu - verified popover appears on top
3. ✅ Clicked three-dot menu on Global variables - verified popover appears on top
4. ✅ Tested other pages using CardGrid component - no visual regression
5. ✅ Tested in both light and dark themes
6. ✅ Verified MCP server card (without zIndex) still renders correctly
7. ✅ Ran `pnpm lint` and `pnpm format` - all checks passed

### Screenshots

#### Git Configuration

**Before Fix:**
<img width="1525" height="333" alt="git-before" src="https://github.com/user-attachments/assets/e4c64786-1300-41a6-a024-c3449e1853cd" />

**After Fix:**
<img width="1486" height="337" alt="git-after" src="https://github.com/user-attachments/assets/29c72c74-bec5-4849-9135-ba41674b8903" />

#### Global Variables

**Before Fix:**
<img width="1502" height="327" alt="global-before" src="https://github.com/user-attachments/assets/33c39054-e532-41ea-afec-a6ef0eeece69" />

**After Fix:**
<img width="1492" height="414" alt="global-after" src="https://github.com/user-attachments/assets/293f39db-3d11-4efe-a199-4a7e22537c05" />

## Related PRs and Issues

Fixes #2464

## Additional Notes

The `zIndex` prop is optional and defaults to `undefined`, ensuring backward compatibility. Only cards that explicitly need elevated stacking (those with popovers) should use this prop. This is a non-breaking change.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and followed the contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CardGrid now supports two new props: style (string) and zIndex (number) for custom inline styling and stacking control.
  - Conditional z-index styling applied when zIndex is provided, ensuring correct layering without altering behavior.
  - Updated Git configuration and project variables views to use zIndex for CardGrid, improving visual stacking in those sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->