### PR TITLE
fix: use page currentPlan for limits to refresh button state on org switch

### DIFF
--- a/src/routes/(console)/organization-[organization]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/+page.svelte
@@ -83,12 +83,13 @@
     }
 
     $: projectCreationDisabled =
-        (isCloud && getServiceLimit('projects') <= data.projects.total) ||
+        (isCloud && getServiceLimit('projects', null, data.currentPlan) <= data.projects.total) ||
         (isCloud && $readOnly && !GRACE_PERIOD_OVERRIDE) ||
         !$canWriteProjects;
 
-    $: reachedProjectLimit = isCloud && getServiceLimit('projects') <= data.projects.total;
-    $: projectsLimit = getServiceLimit('projects');
+    $: reachedProjectLimit =
+        isCloud && getServiceLimit('projects', null, data.currentPlan) <= data.projects.total;
+    $: projectsLimit = getServiceLimit('projects', null, data.currentPlan);
 
     $: $registerCommands([
         {

--- a/src/routes/(console)/organization-[organization]/header.svelte
+++ b/src/routes/(console)/organization-[organization]/header.svelte
@@ -29,7 +29,7 @@
     let areMembersLimited: boolean = $state(false);
 
     $effect(() => {
-        const limit = getServiceLimit('members') || Infinity;
+        const limit = getServiceLimit('members', null, page.data.currentPlan) || Infinity;
         const isLimited = limit !== 0 && limit < Infinity;
         areMembersLimited =
             isCloud &&


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project creation availability and project limit indicators now correctly reflect your current plan.
  - Organization member limits in the header now accurately respect your current plan.
  - UI hints and messages related to limits update reliably, preventing incorrect blocking or misleading guidance.
  - Limit calculations are now consistent across the app, ensuring clearer expectations when creating projects or managing members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->