### PR TITLE
fix:  replace Link with Link.Anchor to prevent focus ring on switch account button

### DIFF
--- a/src/lib/components/account/sendVerificationEmailModal.svelte
+++ b/src/lib/components/account/sendVerificationEmailModal.svelte
@@ -6,8 +6,7 @@
     import { user } from '$lib/stores/user';
     import { get } from 'svelte/store';
     import { page } from '$app/state';
-    import Link from '$lib/elements/link.svelte';
-    import { Card, Layout, Typography } from '@appwrite.io/pink-svelte';
+    import { Card, Layout, Typography, Link } from '@appwrite.io/pink-svelte';
     import { Dependencies } from '$lib/constants';
     import { onMount, onDestroy } from 'svelte';
     import { resolve } from '$app/paths';
@@ -146,7 +145,8 @@
                         style="display: inline;">{email || get(user)?.email}</Typography.Text>
                 </Typography.Text>
 
-                <Link variant="default" on:click={() => logout()}>Switch account</Link>
+                <Link.Anchor variant="default" on:click={() => logout()}
+                    >Switch account</Link.Anchor>
 
                 {#if emailSent && resendTimer > 0}
                     <div transition:slide={{ duration: 150 }}>


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the “Switch account” link in the verification email modal by using the shared design-system component, improving consistency and maintainability without changing behavior.

- **Style**
  - Minor visual and interaction consistency improvements in the modal’s “Switch account” action due to using the unified link component; no expected impact on user flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->