### PR TITLE
 feat: make deployment screenshots clickable

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
@@ -39,16 +39,16 @@
 
     let show = $state(false);
 
-    let totalSize = $derived(humanFileSize(deployment?.totalSize ?? 0));
+    const totalSize = $derived(humanFileSize(deployment?.totalSize ?? 0));
 
-    let sortedDomains = $derived(
+    const sortedDomains = $derived(
         proxyRuleList?.rules?.slice()?.sort((a, b) => {
             if (a?.trigger === 'manual' && b?.trigger !== 'manual') return -1;
             if (a?.trigger !== 'manual' && b?.trigger === 'manual') return 1;
             return 0;
         })
     );
-    let primaryDomain = $derived(sortedDomains?.[0]?.domain);
+    const primaryDomain = $derived(sortedDomains?.[0]?.domain);
 
     function getScreenshot(theme: string, deployment: Models.Deployment) {
         if (theme === 'dark') {
@@ -77,11 +77,7 @@
     <Layout.Stack gap="l">
         <div class="card-grid">
             {#if primaryDomain}
-                <a
-                    href={`${$regionalProtocol}${primaryDomain}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Open site">
+                <Card href={`${$regionalProtocol}${primaryDomain}`} padding="none" radius="s">
                     <Image
                         border
                         radius="s"
@@ -89,7 +85,7 @@
                         style="width: 100%; align-self: start"
                         src={getScreenshot($app.themeInUse, deployment)}
                         alt="Screenshot" />
-                </a>
+                </Card>
             {:else}
                 <Image
                     border


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?


<img width="1809" height="909" alt="image" src="https://github.com/user-attachments/assets/4c365ea0-89fd-45fe-98c9-ffee000a6c29" />


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site card screenshots are now clickable links to the primary domain when proxy rules exist.
  * Domain links respect regional protocol settings for more reliable navigation.
  * Domains on site cards are sorted to prioritize manually configured entries for clearer presentation.
  * Deployment size is now shown in a human-readable format on site cards for easier inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->