### PR TITLE
fix: sidebar navigation issues on mobile/tablet viewports

### DIFF
--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -54,6 +54,7 @@
         sideBarIsOpen: boolean;
         showAccountMenu: boolean;
         subNavigation?: ComponentType;
+        organizationId?: string;
     };
 
     export let state: $$Props['state'] = 'icons';
@@ -63,6 +64,7 @@
     export let sideBarIsOpen: boolean;
     export let showAccountMenu: boolean;
     export let subNavigation = undefined;
+    export let organizationId: string | undefined = undefined;
 
     function toggleFeedback() {
         trackEvent(Click.FeedbackSubmitClick);
@@ -128,6 +130,21 @@
             </div>
         </div>
         <div slot="middle" class="middle-container" class:icons={state === 'icons'}>
+            {#if !project && organizationId}
+                <div class="upgrade-button-container">
+                    <Button.Anchor
+                        size="s"
+                        variant="primary"
+                        on:click={() => {
+                            trackEvent(Click.OrganizationClickUpgrade, {
+                                from: 'button',
+                                source: 'side_nav'
+                            });
+                        }}
+                        href={`${base}/organization-${organizationId}/change-plan`}
+                        >Upgrade</Button.Anchor>
+                </div>
+            {/if}
             {#if progressCard}
                 <Tooltip placement="right" disabled={state !== 'icons'}>
                     <a
@@ -237,7 +254,7 @@
                             <span slot="tooltip">{projectOption.name}</span>
                         </Tooltip>
                     {/each}
-                    {#if project && $isSmallViewport}
+                    {#if project}
                         <div class="mobile-tablet-settings">
                             <Tooltip placement="right" disabled={state !== 'icons'}>
                                 <a
@@ -259,7 +276,7 @@
                         </div>
                     {/if}
                 </Layout.Stack>
-            {:else if $isSmallViewport}
+            {:else if project && $isSmallViewport}
                 <div class="action-buttons">
                     <Layout.Stack direction="column" gap="s">
                         <DropList show={$feedback.show} scrollable>
@@ -268,13 +285,13 @@
                                 size="s"
                                 on:click={() => {
                                     toggleFeedback();
-                                    trackEvent(Click.FeedbackSubmitClick, { source: 'side_nav' });
+                                    trackEvent('click_menu_feedback', { source: 'side_nav' });
                                 }}
-                                >Feedback
+                                ><span>Feedback</span>
                             </Button.Button>
-                            <svelte:fragment slot="other">
+                            <!-- <svelte:fragment slot="other">
                                 <MobileFeedbackModal />
-                            </svelte:fragment>
+                            </svelte:fragment> -->
                         </DropList>
 
                         <DropList show={$showSupportModal} scrollable>
@@ -286,10 +303,10 @@
                                     trackEvent(Click.SupportOpenClick, { source: 'side_nav' });
                                 }}>
                                 <span>Support</span>
-                                <svelte:fragment slot="other">
+                                <!-- <svelte:fragment slot="other">
                                     <MobileSupportModal bind:show={$showSupportModal}
                                     ></MobileSupportModal>
-                                </svelte:fragment>
+                                </svelte:fragment> -->
                             </Button.Button>
                         </DropList>
                     </Layout.Stack>
@@ -317,7 +334,7 @@
                 </div>
             {/if}
 
-            {#if project && $isSmallViewport}
+            {#if (project || (!project && organizationId)) && $isTabletViewport}
                 <div class="action-buttons">
                     <Layout.Stack direction="column" gap="s">
                         <DropList show={$feedback.show} scrollable>
@@ -348,6 +365,11 @@
             {/if}
         </div>
     </Sidebar.Base>
+
+    {#if $isTabletViewport}
+        <MobileFeedbackModal />
+        <MobileSupportModal bind:show={$showSupportModal} />
+    {/if}
 </div>
 
 <div style:--banner-spacing={$bannerSpacing ? $bannerSpacing : undefined}>
@@ -372,6 +394,16 @@
         flex: 1;
         overflow-y: visible;
         max-height: none;
+    }
+
+    .upgrade-button-container {
+        margin-bottom: var(--space-6, 12px);
+
+        :global(a) {
+            width: 100%;
+            display: block;
+            text-align: center;
+        }
     }
 
     .mobile-tablet-settings {

--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -276,7 +276,8 @@
                         </div>
                     {/if}
                 </Layout.Stack>
-            {:else if project && $isSmallViewport}
+            {/if}
+            {#if project && $isSmallViewport}
                 <div class="action-buttons">
                     <Layout.Stack direction="column" gap="s">
                         <DropList show={$feedback.show} scrollable>
@@ -334,7 +335,7 @@
                 </div>
             {/if}
 
-            {#if (project || (!project && organizationId)) && $isTabletViewport}
+            {#if (project || organizationId) && $isTabletViewport}
                 <div class="action-buttons">
                     <Layout.Stack direction="column" gap="s">
                         <DropList show={$feedback.show} scrollable>

--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -277,7 +277,7 @@
                     {/if}
                 </Layout.Stack>
             {/if}
-            {#if project && $isSmallViewport}
+            {#if project && $isSmallViewport && !$isTabletViewport}
                 <div class="action-buttons">
                     <Layout.Stack direction="column" gap="s">
                         <DropList show={$feedback.show} scrollable>

--- a/src/lib/layout/shell.svelte
+++ b/src/lib/layout/shell.svelte
@@ -175,6 +175,8 @@
 
     $: isProjectPage = $page.route?.id?.includes('project-');
 
+    $: isOrganizationPage = $page.route?.id?.includes('organization-');
+
     $: {
         if ($isSidebarOpen) {
             yOnMenuOpen = window.scrollY;
@@ -205,9 +207,10 @@
         <Navbar {...navbarProps} bind:sideBarIsOpen={$isSidebarOpen} bind:showAccountMenu />
     {/if}
 
-    {#if !$isNewWizardStatusOpen && isProjectPage}
+    {#if !$isNewWizardStatusOpen && (isProjectPage || isOrganizationPage)}
         <Sidebar
             project={selectedProject}
+            organizationId={$organization?.$id}
             progressCard={getProgressCard()}
             avatar={navbarProps.avatar}
             bind:subNavigation

--- a/src/routes/(console)/wizard/feedback/mobileFeedbackModal.svelte
+++ b/src/routes/(console)/wizard/feedback/mobileFeedbackModal.svelte
@@ -19,10 +19,10 @@
     :global(.mobile-feedback-dialog-modal dialog) {
         background-color: #fff;
     }
-
+    /* 
     :global(.theme-dark .mobile-feedback-dialog-modal dialog) {
         background-color: #131315;
-    }
+    } */
 
     /* pink2 modal doesn't allow removing the header divider yet, temporary fix*/
     :global(.mobile-feedback-dialog-modal dialog header) {

--- a/src/routes/(console)/wizard/support/mobileSupportModal.svelte
+++ b/src/routes/(console)/wizard/support/mobileSupportModal.svelte
@@ -21,9 +21,9 @@
         background-color: #fff;
     }
 
-    :global(.theme-dark .mobile-support-dialog-modal dialog) {
+    /* :global(.theme-dark .mobile-support-dialog-modal dialog) {
         background-color: #131315;
-    }
+    } */
 
     /* pink2 modal doesn't allow removing the header divider yet, temporary fix*/
     :global(.mobile-support-dialog-modal dialog header) {


### PR DESCRIPTION
## What does this PR do?

### Problem

**Organization Pages:**
- Clicking hamburger menu showed only blur overlay without sidebar content
- Navigation was completely broken on mobile/tablet devices

**Project Pages:**
- Sidebar missing essential navigation items (Settings, Feedback, Support) on mobile/tablet
- Incorrect responsive conditions hid important buttons

**Modal Issues:**
- Feedback and Support modals had extra background overlays
- Modals weren't opening properly due to DropList rendering conflicts

### Solution

**For Organization Pages:**
- Added `isOrganizationPage` reactive variable in shell.svelte
- Updated sidebar condition to include organization pages: `(isProjectPage || isOrganizationPage)`
- Passed `organizationId` prop to Sidebar component
- Display Upgrade button for organization navigation

**For Project Pages:**
- Fixed Settings button to always show on mobile/tablet with proper divider
- Updated Feedback/Support buttons to use `$isTabletViewport` (< 1024px)

**For Modal Functionality:**
- Moved modals outside DropList structure to sidebar root level
- Rendered modals conditionally only when `$isTabletViewport` is true
- Prevents duplicate modals and overlay conflicts

### Changes Made

**File: `src/lib/layout/shell.svelte`**
- Added `isOrganizationPage` reactive variable
- Updated sidebar condition: `(isProjectPage || isOrganizationPage)`
- Added `organizationId={$organization?.$id}` prop to Sidebar

**File: `src/lib/components/sidebar.svelte`**
- Added `organizationId` prop to component interface
- Added Upgrade button for organization pages
- Fixed Settings button visibility on mobile/tablet
- Updated Feedback/Support condition to `$isTabletViewport`
- Moved modals outside DropList to prevent overlay issues

**Files: `mobileFeedbackModal.svelte` & `mobileSupportModal.svelte`**
- Removed code causing extra background overlays

## Test Plan

### Local Testing Performed:

1. ✅ Organization pages - Sidebar opens with Upgrade, Feedback, Support on mobile/tablet
2. ✅ Project pages - All navigation items visible (Settings, Feedback, Support) on mobile/tablet
3. ✅ Modals open cleanly without extra overlays on all viewport sizes
4. ✅ Desktop viewport - No regression, all features work as before
5. ✅ Smooth transitions between viewport sizes, no layout shifts
6. ✅ Ran `pnpm lint` and `pnpm format` - all checks passed

### Screenshots

*Before Fix:*
https://github.com/user-attachments/assets/4651a4ed-2da6-4299-bf09-31027fde44c9

*After Fix:*
https://github.com/user-attachments/assets/1a72c7b9-39fa-41cd-ae4c-002ef42e82cf

## Related PRs and Issues

Fixes #2484 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and followed the contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an upgrade option in the sidebar for organizations without active projects to view/change organization plans.
  * Sidebar now recognizes organization pages and adjusts layout and tablet action buttons; mobile feedback and support modals are rendered for tablet viewports.
  * Feedback menu label and tracking event key updated for consistency.

* **Style**
  * Adjusted mobile modal theme rules and added styling for the new upgrade button area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->