### PR TITLE
fix: allow custom project id on self-hosted

### DIFF
--- a/src/routes/(console)/organization-[organization]/createProject.svelte
+++ b/src/routes/(console)/organization-[organization]/createProject.svelte
@@ -16,7 +16,7 @@
 
     const dispatch = createEventDispatcher();
 
-    let id: string;
+    let id: string = '';
     let error: string;
     let showCustomId = false;
     let disabled: boolean = false;
@@ -28,7 +28,7 @@
             disabled = true;
             showSubmissionLoader = true;
             const project = await sdk.forConsole.projects.create({
-                projectId: id ?? ID.unique(),
+                projectId: id || ID.unique(),
                 name,
                 teamId
             });


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Becuase the id was undefined, svelte threw a props_invalid_value error

Cannot do `bind:id={undefined}` when `id` has a fallback value

This PR updates the id to be an empty string to match other areas where we do something similar.

## Test Plan

Manually tested locally:

<img width="716" height="528" alt="image" src="https://github.com/user-attachments/assets/918f41ed-4d6d-45d5-a227-774681b3fa3d" />

Successfully created a project w/ custom ID:
<img width="628" height="235" alt="image" src="https://github.com/user-attachments/assets/6236614f-ef23-4977-b704-d173863f4ac2" />

And w/o custom ID:

<img width="683" height="218" alt="image" src="https://github.com/user-attachments/assets/0888c322-f483-4a76-92a8-6c82dc6f95dc" />


## Related PRs and Issues

* https://github.com/appwrite/console/pull/2402

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where projects could be created with empty identifiers. Projects now always receive unique IDs upon creation, ensuring proper identification and preventing conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->