### PR TITLE
chore: change image output format from Webp to Avif

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/siteCard.svelte
@@ -51,7 +51,7 @@
             fileId,
             width: 1024,
             height: 576,
-            output: ImageFormat.Webp
+            output: ImageFormat.Avif
         });
     }
 </script>

--- a/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/grid.svelte
@@ -38,7 +38,7 @@
             fileId,
             width: 1024,
             height: 576,
-            output: ImageFormat.Webp
+            output: ImageFormat.Avif
         });
     }
 </script>

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
@@ -9,7 +9,7 @@
     import { Button } from '$lib/elements/forms';
     import { calculateSize } from '$lib/helpers/sizeConvertion';
     import { Container } from '$lib/layout';
-    import type { Models } from '@appwrite.io/console';
+    import { ImageFormat, type Models } from '@appwrite.io/console';
     import { addNotification } from '$lib/stores/notifications';
     import { uploader } from '$lib/stores/uploader';
     import { sdk } from '$lib/stores/sdk.js';
@@ -53,7 +53,8 @@
                     bucketId,
                     fileId,
                     height: 128,
-                    width: 128
+                    width: 128,
+                    output: ImageFormat.Avif
                 })
                 .toString() + '&mode=admin'
         );

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/file-[file]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/file-[file]/+page.svelte
@@ -35,7 +35,7 @@
     } from '@appwrite.io/pink-icons-svelte';
     import FileTokensCopyUrl from './fileTokensCopyUrl.svelte';
     import ManageFileTokenModal, { cleanFormattedDate } from './manageFileToken.svelte';
-    import { type Models } from '@appwrite.io/console';
+    import { ImageFormat, type Models } from '@appwrite.io/console';
     import { isSmallViewport } from '$lib/stores/viewport';
     import { Menu } from '$lib/components/menu';
 
@@ -57,7 +57,8 @@
                 bucketId: $file.bucketId,
                 fileId,
                 width: 640,
-                height: 300
+                height: 300,
+                output: ImageFormat.Avif
             })
             .toString() + '&mode=admin';
     const getView = (fileId: string) =>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Use AVIF over WebP because it results in a smaller file

## Test Plan

Manual:

<img width="801" height="596" alt="image" src="https://github.com/user-attachments/assets/fa9761be-3573-4afe-9762-b804dd89272e" />

<img width="751" height="571" alt="image" src="https://github.com/user-attachments/assets/97059b59-eb07-42dd-8b2f-9bc454d77ed8" />

<img width="697" height="429" alt="image" src="https://github.com/user-attachments/assets/7faea6f9-1be1-4eeb-9ab1-92074ea700ee" />

<img width="499" height="535" alt="image" src="https://github.com/user-attachments/assets/e124bbc9-5f3d-4040-86f4-047e90adb1ea" />


## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/10699

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced screenshot preview quality and performance in the sites grid view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->