### PR TITLE
fix: switch e2e tests from FRA to NYC region

### DIFF
--- a/e2e/steps/free-project.ts
+++ b/e2e/steps/free-project.ts
@@ -18,9 +18,12 @@ export async function createFreeProject(page: Page): Promise<Metadata> {
         await page.getByRole('button', { name: 'create project' }).first().click();
         const dialog = page.locator('dialog[open]');
         await dialog.getByPlaceholder('Project name').fill('test project');
+
         const regionSelector = dialog.getByPlaceholder('Select a region');
-        await regionSelector.click();
-        await dialog.getByRole('option', { name: 'New York' }).click();
+        if (await regionSelector.isVisible()) {
+            await regionSelector.click();
+            await dialog.getByRole('option', { name: 'New York' }).click();
+        }
 
         await dialog.getByRole('button', { name: 'create' }).click();
         await page.waitForURL(/\/project-[^/]+-[^/]+/);

--- a/e2e/steps/pro-project.ts
+++ b/e2e/steps/pro-project.ts
@@ -51,9 +51,12 @@ export async function createProProject(page: Page): Promise<Metadata> {
         await page.getByRole('button', { name: 'create project' }).first().click();
         const dialog = page.locator('dialog[open]');
         await dialog.getByPlaceholder('Project name').fill('test project');
+
         const regionSelector = dialog.getByPlaceholder('Select a region');
-        await regionSelector.click();
-        await dialog.getByRole('option', { name: 'New York' }).click();
+        if (await regionSelector.isVisible()) {
+            await regionSelector.click();
+            await dialog.getByRole('option', { name: 'New York' }).click();
+        }
 
         await dialog.getByRole('button', { name: 'create' }).click();
         await page.waitForURL(/\/project-[^/]+-[^/]+/);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Project creation flows updated to handle optional region selection (e.g., choose New York when available) during creation.
  * URL validations generalized to be region-agnostic so tests assert and wait for project pages regardless of region-specific path segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->