### PR TITLE
fix: correct payment method expiration notification logic

### DIFF
--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -488,6 +488,9 @@ export async function paymentExpired(org: Organization) {
     const nots = get(notifications);
     const expiredNotification = nots.some((n) => n.message === expiredMessage);
     const expiringNotification = nots.some((n) => n.message === expiringMessage);
+    const cardExpiry = new Date(payment.expiryYear, payment.expiryMonth, 1);
+    const nextMonth = new Date(year, month + 1, 1);
+    const isExpiringNextMonth = cardExpiry.getTime() === nextMonth.getTime();
     if (payment.expired && !expiredNotification) {
         addNotification({
             type: 'error',
@@ -503,15 +506,7 @@ export async function paymentExpired(org: Organization) {
                 }
             ]
         });
-    } else if (
-        !expiringNotification &&
-        !payment.expired &&
-        (() => {
-            const cardExpiry = new Date(payment.expiryYear, payment.expiryMonth, 1);
-            const nextMonth = new Date(year, month + 1, 1);
-            return cardExpiry.getTime() === nextMonth.getTime();
-        })()
-    ) {
+    } else if (!expiringNotification && !payment.expired && isExpiringNextMonth) {
         addNotification({
             type: 'warning',
             isHtml: true,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment expiration warning now triggers precisely one month before a card’s expiry, avoiding premature or duplicate alerts.
  * Existing expired-card notification behavior remains unchanged and is still shown only when a card is actually expired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->