### PR TITLE
Add charts for sites/functions usage

### DIFF
--- a/src/lib/layout/usage.svelte
+++ b/src/lib/layout/usage.svelte
@@ -76,7 +76,8 @@
     import { Card } from '$lib/components';
     import { InputSelect } from '$lib/elements/forms';
     import { formatNumberWithCommas } from '$lib/helpers/numbers';
-    import { Layout, Typography } from '@appwrite.io/pink-svelte';
+    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
+    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
 
     type MetricMetadata = {
         title: string;
@@ -117,11 +118,11 @@
         </div>
     {/if}
     <Card>
-        {#if count}
-            <Layout.Stack gap="xs">
-                <Typography.Title>{formatNumberWithCommas(total)}</Typography.Title>
-                <Typography.Text>{countMetadata.title}</Typography.Text>
-            </Layout.Stack>
+        <Layout.Stack gap="xs" direction="row" alignItems="baseline">
+            <Typography.Title>{formatNumberWithCommas(total)}</Typography.Title>
+            <Typography.Text>{countMetadata.title}</Typography.Text>
+        </Layout.Stack>
+        {#if count?.length > 0}
             <div class="chart-container">
                 <BarChart
                     formatted={page.params.period === '24h' ? 'hours' : 'days'}
@@ -134,6 +135,11 @@
                         }
                     ]} />
             </div>
+        {:else}
+            <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
+                <Icon icon={IconChartSquareBar} size="l" />
+                <Typography.Text variant="m-600">No data to show</Typography.Text>
+            </Layout.Stack>
         {/if}
     </Card>
 </Layout.Stack>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
@@ -2,12 +2,7 @@
     import { Container, Usage } from '$lib/layout';
     import { page } from '$app/state';
     import { base } from '$app/paths';
-    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
-    import Card from '$lib/components/card.svelte';
-    import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
-    import { BarChart } from '$lib/charts/index.js';
-    import { total as totalMetrics } from '$lib/layout/usage.svelte';
-    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
+    import { Layout } from '@appwrite.io/pink-svelte';
 
     let { data } = $props();
     let total = $derived(data.executionsTotal);
@@ -19,7 +14,6 @@
             value: metric.value / 1000 / 3600
         }))
         .filter(({ value }) => value));
-    let bandwidth = $state([]);
 </script>
 
 <Container>
@@ -42,47 +36,5 @@
             }}
             total={gbHoursTotal}
             count={gbHoursCount} />
-
-        <Card>
-            {@const humanized = humanFileSize(totalMetrics(bandwidth))}
-            <Layout.Stack gap="s" direction="column" alignItems="baseline">
-                <Layout.Stack gap="s" direction="row" alignItems="baseline">
-                    <Typography.Title>
-                        {humanized.value}
-                    </Typography.Title>
-                    <Typography.Text>{humanized.unit} bandwidth</Typography.Text>
-                </Layout.Stack>
-            </Layout.Stack>
-            {#if bandwidth?.length > 0}
-                <BarChart
-                    options={{
-                        yAxis: {
-                            axisLabel: {
-                                formatter: (value) =>
-                                    value
-                                        ? `${humanFileSize(+value).value} ${
-                                            humanFileSize(+value).unit
-                                        }`
-                                        : '0'
-                            }
-                        }
-                    }}
-                    series={[
-                        {
-                            name: 'Bandwidth',
-                            data: [...bandwidth.map((e) => [e.date, e.value])],
-                            tooltip: {
-                                valueFormatter: (value) =>
-                                    `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
-                            }
-                        }
-                    ]} />
-            {:else}
-                <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
-                    <Icon icon={IconChartSquareBar} size="l" />
-                    <Typography.Text variant="m-600">No data to show</Typography.Text>
-                </Layout.Stack>
-            {/if}
-        </Card>
     </Layout.Stack>
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
@@ -7,25 +7,31 @@
     let { data } = $props();
     let total = $derived(data.executionsTotal);
     let count = $derived(data.executions);
-    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
-    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
-        ?.map((metric) => ({
-            ...metric,
-            value: metric.value / 1000 / 3600
-        }))
-        .filter(({ value }) => value));
+    let gbHoursTotal = $derived(
+        (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600
+    );
+    let gbHoursCount = $derived(
+        [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+            ?.map((metric) => ({
+                ...metric,
+                value: metric.value / 1000 / 3600
+            }))
+            .filter(({ value }) => value)
+    );
 
-    const path = $derived(resolve('/(console)/project-[region]-[project]/functions/function-[function]/usage', {
-        region: page.params.region,
-        project: page.params.project,
-        function: page.params.function
-    }));
+    const path = $derived(
+        resolve('/(console)/project-[region]-[project]/functions/function-[function]/usage', {
+            region: page.params.region,
+            project: page.params.project,
+            function: page.params.function
+        })
+    );
 </script>
 
 <Container>
     <Layout.Stack gap="l">
         <Usage
-            path={path}
+            {path}
             countMetadata={{
                 legend: 'Executions',
                 title: 'executions'
@@ -35,7 +41,7 @@
 
         <Usage
             hidePeriodSelect
-            path={path}
+            {path}
             countMetadata={{
                 legend: 'GB hours',
                 title: 'GB hours'

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
@@ -2,44 +2,86 @@
     import { Container, Usage } from '$lib/layout';
     import { page } from '$app/state';
     import { base } from '$app/paths';
-    import { Layout } from '@appwrite.io/pink-svelte';
+    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
+    import Card from '$lib/components/card.svelte';
+    import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
+    import { BarChart } from '$lib/charts/index.js';
+    import { total as totalMetrics } from '$lib/layout/usage.svelte';
+    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
 
     export let data;
     $: total = data.executionsTotal;
     $: count = data.executions;
-    $: gbHoursTotal = data.executionsMbSecondsTotal / 1000 / 3600;
-    $: mbSecondsCount = data.executionsMbSeconds;
-    $: gbHoursCount = data.executionsMbSeconds
+    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
+    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
         ?.map((metric) => ({
             ...metric,
             value: metric.value / 1000 / 3600
         }))
-        .filter(({ value }) => value);
+    $: bandwidth = [];
 </script>
 
 <Container>
     <Layout.Stack gap="l">
-        {#if count}
-            <Usage
-                path={`${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/usage`}
-                countMetadata={{
-                    legend: 'Executions',
-                    title: 'Total executions'
-                }}
-                {total}
-                {count} />
-        {/if}
+        <Usage
+            path={`${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/usage`}
+            countMetadata={{
+                legend: 'Executions',
+                title: 'executions'
+            }}
+            {total}
+            {count} />
 
-        {#if mbSecondsCount}
-            <Usage
-                hidePeriodSelect
-                path={`${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/usage`}
-                countMetadata={{
-                    legend: 'GB hours',
-                    title: 'Total GB hours'
-                }}
-                total={gbHoursTotal}
-                count={gbHoursCount} />
-        {/if}
+        <Usage
+            hidePeriodSelect
+            path={`${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/usage`}
+            countMetadata={{
+                legend: 'GB hours',
+                title: 'GB hours'
+            }}
+            total={gbHoursTotal}
+            count={gbHoursCount} />
+
+        <Card>
+            {@const humanized = humanFileSize(totalMetrics(bandwidth))}
+            <Layout.Stack gap="s" direction="column" alignItems="baseline">
+                <Layout.Stack gap="s" direction="row" alignItems="baseline">
+                    <Typography.Title>
+                        {humanized.value}
+                    </Typography.Title>
+                    <Typography.Text>{humanized.unit} bandwidth</Typography.Text>
+                </Layout.Stack>
+            </Layout.Stack>
+            {#if bandwidth?.length > 0}
+                <BarChart
+                    options={{
+                        yAxis: {
+                            axisLabel: {
+                                formatter: (value) =>
+                                    value
+                                        ? `${humanFileSize(+value).value} ${
+                                            humanFileSize(+value).unit
+                                        }`
+                                        : '0'
+                            }
+                        }
+                    }}
+                    series={[
+                        {
+                            name: 'Bandwidth',
+                            data: [...bandwidth.map((e) => [e.date, e.value])],
+                            tooltip: {
+                                valueFormatter: (value) =>
+                                    `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
+                            }
+                        }
+                    ]} />
+            {:else}
+                <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
+                    <Icon icon={IconChartSquareBar} size="l" />
+                    <Typography.Text variant="m-600">No data to show</Typography.Text>
+                </Layout.Stack>
+            {/if}
+        </Card>
     </Layout.Stack>
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { Container, Usage } from '$lib/layout';
     import { page } from '$app/state';
-    import { base } from '$app/paths';
+    import { resolve } from '$app/paths';
     import { Layout } from '@appwrite.io/pink-svelte';
 
     let { data } = $props();
@@ -14,12 +14,18 @@
             value: metric.value / 1000 / 3600
         }))
         .filter(({ value }) => value));
+
+    const path = $derived(resolve('/(console)/project-[region]-[project]/functions/function-[function]/usage', {
+        region: page.params.region,
+        project: page.params.project,
+        function: page.params.function
+    }));
 </script>
 
 <Container>
     <Layout.Stack gap="l">
         <Usage
-            path={`${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/usage`}
+            path={path}
             countMetadata={{
                 legend: 'Executions',
                 title: 'executions'
@@ -29,7 +35,7 @@
 
         <Usage
             hidePeriodSelect
-            path={`${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/usage`}
+            path={path}
             countMetadata={{
                 legend: 'GB hours',
                 title: 'GB hours'

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/usage/[[period]]/+page.svelte
@@ -9,16 +9,17 @@
     import { total as totalMetrics } from '$lib/layout/usage.svelte';
     import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
 
-    export let data;
-    $: total = data.executionsTotal;
-    $: count = data.executions;
-    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
-    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+    let { data } = $props();
+    let total = $derived(data.executionsTotal);
+    let count = $derived(data.executions);
+    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
+    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
         ?.map((metric) => ({
             ...metric,
             value: metric.value / 1000 / 3600
         }))
-    $: bandwidth = [];
+        .filter(({ value }) => value));
+    let bandwidth = $state([]);
 </script>
 
 <Container>

--- a/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
@@ -1,20 +1,86 @@
 <script lang="ts">
     import { base } from '$app/paths';
     import { page } from '$app/state';
+    import { BarChart } from '$lib/charts/index.js';
+    import Card from '$lib/components/card.svelte';
+    import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
     import { Container, Usage } from '$lib/layout';
+    import { total as totalMetrics } from '$lib/layout/usage.svelte';
+    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
+    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
     export let data;
-    $: total = data.deploymentsTotal;
-    $: count = data.deployments;
+    $: total = data.executionsTotal;
+    $: count = data.executions;
+    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
+    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+        ?.map((metric) => ({
+            ...metric,
+            value: metric.value / 1000 / 3600
+        }))
+        .filter(({ value }) => value);
+    $: bandwidth = [];
 </script>
 
 <Container>
     <Usage
         path={`${base}/project-${page.params.region}-${page.params.project}/functions/usage`}
         countMetadata={{
-            legend: 'Functions',
-            title: 'Total functions'
+            legend: 'Executions',
+            title: 'executions'
         }}
         {total}
         {count} />
+    
+    <Usage
+        hidePeriodSelect
+        path={`${base}/project-${page.params.region}-${page.params.project}/functions/usage`}
+        countMetadata={{
+            legend: 'GB hours',
+            title: 'GB hours'
+        }}
+        total={gbHoursTotal}
+        count={gbHoursCount} />
+
+    <Card>
+        {@const humanized = humanFileSize(totalMetrics(bandwidth))}
+        <Layout.Stack gap="s" direction="column" alignItems="baseline">
+            <Layout.Stack gap="s" direction="row" alignItems="baseline">
+                <Typography.Title>
+                    {humanized.value}
+                </Typography.Title>
+                <Typography.Text>{humanized.unit} bandwidth</Typography.Text>
+            </Layout.Stack>
+        </Layout.Stack>
+        {#if bandwidth?.length > 0}
+            <BarChart
+                options={{
+                    yAxis: {
+                        axisLabel: {
+                            formatter: (value) =>
+                                value
+                                    ? `${humanFileSize(+value).value} ${
+                                        humanFileSize(+value).unit
+                                    }`
+                                    : '0'
+                        }
+                    }
+                }}
+                series={[
+                    {
+                        name: 'Bandwidth',
+                        data: [...bandwidth.map((e) => [e.date, e.value])],
+                        tooltip: {
+                            valueFormatter: (value) =>
+                                `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
+                        }
+                    }
+                ]} />
+        {:else}
+            <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
+                <Icon icon={IconChartSquareBar} size="l" />
+                <Typography.Text variant="m-600">No data to show</Typography.Text>
+            </Layout.Stack>
+        {/if}
+    </Card>
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { base } from '$app/paths';
+    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import { Container, Usage } from '$lib/layout';
 
@@ -13,11 +13,16 @@
             value: metric.value / 1000 / 3600
         }))
         .filter(({ value }) => value));
+
+    const path = $derived(resolve('/(console)/project-[region]-[project]/functions/usage', {
+        region: page.params.region,
+        project: page.params.project
+    }));
 </script>
 
 <Container>
     <Usage
-        path={`${base}/project-${page.params.region}-${page.params.project}/functions/usage`}
+        path={path}
         countMetadata={{
             legend: 'Executions',
             title: 'executions'
@@ -27,7 +32,7 @@
     
     <Usage
         hidePeriodSelect
-        path={`${base}/project-${page.params.region}-${page.params.project}/functions/usage`}
+        path={path}
         countMetadata={{
             legend: 'GB hours',
             title: 'GB hours'

--- a/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
@@ -6,33 +6,39 @@
     let { data } = $props();
     let total = $derived(data.executionsTotal);
     let count = $derived(data.executions);
-    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
-    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
-        ?.map((metric) => ({
-            ...metric,
-            value: metric.value / 1000 / 3600
-        }))
-        .filter(({ value }) => value));
+    let gbHoursTotal = $derived(
+        (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600
+    );
+    let gbHoursCount = $derived(
+        [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+            ?.map((metric) => ({
+                ...metric,
+                value: metric.value / 1000 / 3600
+            }))
+            .filter(({ value }) => value)
+    );
 
-    const path = $derived(resolve('/(console)/project-[region]-[project]/functions/usage', {
-        region: page.params.region,
-        project: page.params.project
-    }));
+    const path = $derived(
+        resolve('/(console)/project-[region]-[project]/functions/usage', {
+            region: page.params.region,
+            project: page.params.project
+        })
+    );
 </script>
 
 <Container>
     <Usage
-        path={path}
+        {path}
         countMetadata={{
             legend: 'Executions',
             title: 'executions'
         }}
         {total}
         {count} />
-    
+
     <Usage
         hidePeriodSelect
-        path={path}
+        {path}
         countMetadata={{
             legend: 'GB hours',
             title: 'GB hours'

--- a/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
@@ -9,17 +9,17 @@
     import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
-    export let data;
-    $: total = data.executionsTotal;
-    $: count = data.executions;
-    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
-    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+    let { data } = $props();
+    let total = $derived(data.executionsTotal);
+    let count = $derived(data.executions);
+    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
+    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
         ?.map((metric) => ({
             ...metric,
             value: metric.value / 1000 / 3600
         }))
-        .filter(({ value }) => value);
-    $: bandwidth = [];
+        .filter(({ value }) => value));
+    let bandwidth = $state([]);
 </script>
 
 <Container>

--- a/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
     import { base } from '$app/paths';
     import { page } from '$app/state';
-    import { BarChart } from '$lib/charts/index.js';
-    import Card from '$lib/components/card.svelte';
-    import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
     import { Container, Usage } from '$lib/layout';
-    import { total as totalMetrics } from '$lib/layout/usage.svelte';
-    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
-    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
     let { data } = $props();
     let total = $derived(data.executionsTotal);
@@ -19,7 +13,6 @@
             value: metric.value / 1000 / 3600
         }))
         .filter(({ value }) => value));
-    let bandwidth = $state([]);
 </script>
 
 <Container>
@@ -41,46 +34,4 @@
         }}
         total={gbHoursTotal}
         count={gbHoursCount} />
-
-    <Card>
-        {@const humanized = humanFileSize(totalMetrics(bandwidth))}
-        <Layout.Stack gap="s" direction="column" alignItems="baseline">
-            <Layout.Stack gap="s" direction="row" alignItems="baseline">
-                <Typography.Title>
-                    {humanized.value}
-                </Typography.Title>
-                <Typography.Text>{humanized.unit} bandwidth</Typography.Text>
-            </Layout.Stack>
-        </Layout.Stack>
-        {#if bandwidth?.length > 0}
-            <BarChart
-                options={{
-                    yAxis: {
-                        axisLabel: {
-                            formatter: (value) =>
-                                value
-                                    ? `${humanFileSize(+value).value} ${
-                                        humanFileSize(+value).unit
-                                    }`
-                                    : '0'
-                        }
-                    }
-                }}
-                series={[
-                    {
-                        name: 'Bandwidth',
-                        data: [...bandwidth.map((e) => [e.date, e.value])],
-                        tooltip: {
-                            valueFormatter: (value) =>
-                                `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
-                        }
-                    }
-                ]} />
-        {:else}
-            <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
-                <Icon icon={IconChartSquareBar} size="l" />
-                <Typography.Text variant="m-600">No data to show</Typography.Text>
-            </Layout.Stack>
-        {/if}
-    </Card>
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
@@ -1,33 +1,86 @@
 <script lang="ts">
     import { base } from '$app/paths';
     import { page } from '$app/state';
+    import { BarChart } from '$lib/charts/index.js';
+    import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
     import { Container, Usage } from '$lib/layout';
+    import { total as totalMetrics } from '$lib/layout/usage.svelte';
+    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
+    import Card from '$lib/components/card.svelte';
+    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
     export let data;
-    $: total = data.deploymentsTotal;
-    $: count = data.deployments;
-
-    // $: totalBuilds = data.buildsTotal;
-    // $: countBuilds = data.builds;
+    $: total = data.executionsTotal;
+    $: count = data.executions;
+    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
+    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+        ?.map((metric) => ({
+            ...metric,
+            value: metric.value / 1000 / 3600
+        }))
+        .filter(({ value }) => value);
+    $: bandwidth = [...data.inbound, ...data.outbound];
 </script>
 
 <Container>
     <Usage
         path={`${base}/project-${page.params.region}-${page.params.project}/sites/site-${page.params.site}/usage`}
         countMetadata={{
-            legend: 'Deployments',
-            title: 'Total deployments'
+            legend: 'Executions',
+            title: 'executions'
         }}
         {total}
         {count} />
 
-    <!-- <Usage
-    title="Builds"
-    path={`${base}/project-${page.params.region}-${page.params.project}/sites/site-${page.params.site}/usage`}
-    countMetadata={{
-        legend: 'Builds',
-        title: 'Total builds'
+    <Usage
+        hidePeriodSelect
+        path={`${base}/project-${page.params.region}-${page.params.project}/sites/site-${page.params.site}/usage`}
+        countMetadata={{
+            legend: 'GB hours',
+            title: 'GB hours'
         }}
-        total={totalBuilds}
-        count={countBuilds} /> -->
+        total={gbHoursTotal}
+        count={gbHoursCount} />
+
+    <Card>
+        {@const humanized = humanFileSize(totalMetrics(bandwidth))}
+        <Layout.Stack gap="s" direction="column" alignItems="baseline">
+            <Layout.Stack gap="s" direction="row" alignItems="baseline">
+                <Typography.Title>
+                    {humanized.value}
+                </Typography.Title>
+                <Typography.Text>{humanized.unit} bandwidth</Typography.Text>
+            </Layout.Stack>
+        </Layout.Stack>
+        {#if bandwidth?.length > 0}
+            <BarChart
+                options={{
+                    yAxis: {
+                        axisLabel: {
+                            formatter: (value) =>
+                                value
+                                    ? `${humanFileSize(+value).value} ${
+                                        humanFileSize(+value).unit
+                                    }`
+                                    : '0'
+                        }
+                    }
+                }}
+                series={[
+                    {
+                        name: 'Bandwidth',
+                        data: [...bandwidth.map((e) => [e.date, e.value])],
+                        tooltip: {
+                            valueFormatter: (value) =>
+                                `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
+                        }
+                    }
+                ]} />
+        {:else}
+            <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
+                <Icon icon={IconChartSquareBar} size="l" />
+                <Typography.Text variant="m-600">No data to show</Typography.Text>
+            </Layout.Stack>
+        {/if}
+    </Card>
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { base } from '$app/paths';
+    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import { BarChart } from '$lib/charts/index.js';
     import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
@@ -20,11 +20,17 @@
         }))
         .filter(({ value }) => value));
     let bandwidth = $derived([...data.inbound, ...data.outbound]);
+
+    const path = $derived(resolve('/(console)/project-[region]-[project]/sites/site-[site]/usage', {
+        region: page.params.region,
+        project: page.params.project,
+        site: page.params.site
+    }));
 </script>
 
 <Container>
     <Usage
-        path={`${base}/project-${page.params.region}-${page.params.project}/sites/site-${page.params.site}/usage`}
+        path={path}
         countMetadata={{
             legend: 'Executions',
             title: 'executions'
@@ -34,7 +40,7 @@
 
     <Usage
         hidePeriodSelect
-        path={`${base}/project-${page.params.region}-${page.params.project}/sites/site-${page.params.site}/usage`}
+        path={path}
         countMetadata={{
             legend: 'GB hours',
             title: 'GB hours'

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
@@ -9,17 +9,17 @@
     import Card from '$lib/components/card.svelte';
     import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
-    export let data;
-    $: total = data.executionsTotal;
-    $: count = data.executions;
-    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
-    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+    let { data } = $props();
+    let total = $derived(data.executionsTotal);
+    let count = $derived(data.executions);
+    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
+    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
         ?.map((metric) => ({
             ...metric,
             value: metric.value / 1000 / 3600
         }))
-        .filter(({ value }) => value);
-    $: bandwidth = [...data.inbound, ...data.outbound];
+        .filter(({ value }) => value));
+    let bandwidth = $derived([...data.inbound, ...data.outbound]);
 </script>
 
 <Container>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/usage/[[period]]/+page.svelte
@@ -12,25 +12,31 @@
     let { data } = $props();
     let total = $derived(data.executionsTotal);
     let count = $derived(data.executions);
-    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
-    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
-        ?.map((metric) => ({
-            ...metric,
-            value: metric.value / 1000 / 3600
-        }))
-        .filter(({ value }) => value));
+    let gbHoursTotal = $derived(
+        (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600
+    );
+    let gbHoursCount = $derived(
+        [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+            ?.map((metric) => ({
+                ...metric,
+                value: metric.value / 1000 / 3600
+            }))
+            .filter(({ value }) => value)
+    );
     let bandwidth = $derived([...data.inbound, ...data.outbound]);
 
-    const path = $derived(resolve('/(console)/project-[region]-[project]/sites/site-[site]/usage', {
-        region: page.params.region,
-        project: page.params.project,
-        site: page.params.site
-    }));
+    const path = $derived(
+        resolve('/(console)/project-[region]-[project]/sites/site-[site]/usage', {
+            region: page.params.region,
+            project: page.params.project,
+            site: page.params.site
+        })
+    );
 </script>
 
 <Container>
     <Usage
-        path={path}
+        {path}
         countMetadata={{
             legend: 'Executions',
             title: 'executions'
@@ -40,7 +46,7 @@
 
     <Usage
         hidePeriodSelect
-        path={path}
+        {path}
         countMetadata={{
             legend: 'GB hours',
             title: 'GB hours'
@@ -65,9 +71,7 @@
                         axisLabel: {
                             formatter: (value) =>
                                 value
-                                    ? `${humanFileSize(+value).value} ${
-                                        humanFileSize(+value).unit
-                                    }`
+                                    ? `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
                                     : '0'
                         }
                     }

--- a/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
@@ -12,24 +12,30 @@
     let { data } = $props();
     let total = $derived(data.executionsTotal);
     let count = $derived(data.executions);
-    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
-    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
-        ?.map((metric) => ({
-            ...metric,
-            value: metric.value / 1000 / 3600
-        }))
-        .filter(({ value }) => value));
+    let gbHoursTotal = $derived(
+        (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600
+    );
+    let gbHoursCount = $derived(
+        [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+            ?.map((metric) => ({
+                ...metric,
+                value: metric.value / 1000 / 3600
+            }))
+            .filter(({ value }) => value)
+    );
     let bandwidth = $derived([...data.inbound, ...data.outbound]);
 
-    const path = $derived(resolve('/(console)/project-[region]-[project]/sites/usage', {
-        region: page.params.region,
-        project: page.params.project
-    }));
+    const path = $derived(
+        resolve('/(console)/project-[region]-[project]/sites/usage', {
+            region: page.params.region,
+            project: page.params.project
+        })
+    );
 </script>
 
 <Container>
     <Usage
-        path={path}
+        {path}
         countMetadata={{
             legend: 'Executions',
             title: 'executions'
@@ -39,7 +45,7 @@
 
     <Usage
         hidePeriodSelect
-        path={path}
+        {path}
         countMetadata={{
             legend: 'GB hours',
             title: 'GB hours'
@@ -64,9 +70,7 @@
                         axisLabel: {
                             formatter: (value) =>
                                 value
-                                    ? `${humanFileSize(+value).value} ${
-                                        humanFileSize(+value).unit
-                                    }`
+                                    ? `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
                                     : '0'
                         }
                     }

--- a/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { base } from '$app/paths';
+    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import { BarChart } from '$lib/charts/index.js';
     import Card from '$lib/components/card.svelte';
@@ -20,11 +20,16 @@
         }))
         .filter(({ value }) => value));
     let bandwidth = $derived([...data.inbound, ...data.outbound]);
+
+    const path = $derived(resolve('/(console)/project-[region]-[project]/sites/usage', {
+        region: page.params.region,
+        project: page.params.project
+    }));
 </script>
 
 <Container>
     <Usage
-        path={`${base}/project-${page.params.region}-${page.params.project}/sites/usage`}
+        path={path}
         countMetadata={{
             legend: 'Executions',
             title: 'executions'
@@ -34,7 +39,7 @@
 
     <Usage
         hidePeriodSelect
-        path={`${base}/project-${page.params.region}-${page.params.project}/sites/usage`}
+        path={path}
         countMetadata={{
             legend: 'GB hours',
             title: 'GB hours'

--- a/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
@@ -1,20 +1,86 @@
 <script lang="ts">
     import { base } from '$app/paths';
     import { page } from '$app/state';
+    import { BarChart } from '$lib/charts/index.js';
+    import Card from '$lib/components/card.svelte';
+    import { humanFileSize } from '$lib/helpers/sizeConvertion.js';
     import { Container, Usage } from '$lib/layout';
+    import { total as totalMetrics } from '$lib/layout/usage.svelte';
+    import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
+    import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
     export let data;
-    $: total = data.deploymentsTotal;
-    $: count = data.deployments;
+    $: total = data.executionsTotal;
+    $: count = data.executions;
+    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
+    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+        ?.map((metric) => ({
+            ...metric,
+            value: metric.value / 1000 / 3600
+        }))
+        .filter(({ value }) => value);
+    $: bandwidth = [...data.inbound, ...data.outbound];
 </script>
 
 <Container>
     <Usage
         path={`${base}/project-${page.params.region}-${page.params.project}/sites/usage`}
         countMetadata={{
-            legend: 'Sites',
-            title: 'Total sites'
+            legend: 'Executions',
+            title: 'executions'
         }}
         {total}
         {count} />
+
+    <Usage
+        hidePeriodSelect
+        path={`${base}/project-${page.params.region}-${page.params.project}/sites/usage`}
+        countMetadata={{
+            legend: 'GB hours',
+            title: 'GB hours'
+        }}
+        total={gbHoursTotal}
+        count={gbHoursCount} />
+
+    <Card>
+        {@const humanized = humanFileSize(totalMetrics(bandwidth))}
+        <Layout.Stack gap="s" direction="column" alignItems="baseline">
+            <Layout.Stack gap="s" direction="row" alignItems="baseline">
+                <Typography.Title>
+                    {humanized.value}
+                </Typography.Title>
+                <Typography.Text>{humanized.unit} bandwidth</Typography.Text>
+            </Layout.Stack>
+        </Layout.Stack>
+        {#if bandwidth?.length > 0}
+            <BarChart
+                options={{
+                    yAxis: {
+                        axisLabel: {
+                            formatter: (value) =>
+                                value
+                                    ? `${humanFileSize(+value).value} ${
+                                        humanFileSize(+value).unit
+                                    }`
+                                    : '0'
+                        }
+                    }
+                }}
+                series={[
+                    {
+                        name: 'Bandwidth',
+                        data: [...bandwidth.map((e) => [e.date, e.value])],
+                        tooltip: {
+                            valueFormatter: (value) =>
+                                `${humanFileSize(+value).value} ${humanFileSize(+value).unit}`
+                        }
+                    }
+                ]} />
+        {:else}
+            <Layout.Stack gap="xs" alignItems="center" justifyContent="center">
+                <Icon icon={IconChartSquareBar} size="l" />
+                <Typography.Text variant="m-600">No data to show</Typography.Text>
+            </Layout.Stack>
+        {/if}
+    </Card>
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
@@ -9,17 +9,17 @@
     import { IconChartSquareBar } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
-    export let data;
-    $: total = data.executionsTotal;
-    $: count = data.executions;
-    $: gbHoursTotal = (data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600;
-    $: gbHoursCount = [...data.buildsMbSeconds, ...data.executionsMbSeconds]
+    let { data } = $props();
+    let total = $derived(data.executionsTotal);
+    let count = $derived(data.executions);
+    let gbHoursTotal = $derived((data.buildsMbSecondsTotal + data.executionsMbSecondsTotal) / 1000 / 3600);
+    let gbHoursCount = $derived([...data.buildsMbSeconds, ...data.executionsMbSeconds]
         ?.map((metric) => ({
             ...metric,
             value: metric.value / 1000 / 3600
         }))
-        .filter(({ value }) => value);
-    $: bandwidth = [...data.inbound, ...data.outbound];
+        .filter(({ value }) => value));
+    let bandwidth = $derived([...data.inbound, ...data.outbound]);
 </script>
 
 <Container>


### PR DESCRIPTION
Task: https://linear.app/appwrite/issue/SER-476/add-charts-for-sitesfunctions-usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bandwidth visualization with bar charts added to usage pages
  * GB-hours consumption tracking added alongside execution metrics
  * Empty-state UI with icon and “No data to show” message when no data

* **Improvements**
  * Consistent executions-focused metrics across usage views (titles/legends updated)
  * Human-readable formatting for bandwidth totals and chart labels
  * GB-hours shown as a secondary Usage block (period selector hidden)
  * Total value and its label now aligned horizontally for clearer display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->