### PR TITLE
Fix: region awareness (templates env vars)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/configuration.svelte
@@ -41,8 +41,8 @@
 
     variables.map((variable) => {
         if (variable.value === '{apiEndpoint}') {
-            variable.value = getApiEndpoint();
-            variable.placeholder = getApiEndpoint();
+            variable.value = getApiEndpoint(page.params.region);
+            variable.placeholder = getApiEndpoint(page.params.region);
         } else if (variable.value === '{projectId}') {
             variable.value = page.params.project;
             variable.placeholder = page.params.project;

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/configuration.svelte
@@ -41,8 +41,8 @@
 
     variables.map((variable) => {
         if (variable.value === '{apiEndpoint}') {
-            variable.value = getApiEndpoint();
-            variable.placeholder = getApiEndpoint();
+            variable.value = getApiEndpoint(page.params.region);
+            variable.placeholder = getApiEndpoint(page.params.region);
         } else if (variable.value === '{projectId}') {
             variable.value = page.params.project;
             variable.placeholder = page.params.project;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When site starter template is made on non-fra region, this prevents CORS issues (and unauthorized due to project ID issues)

> `Project is not accessible in this region. Please make sure you are using the correct endpoint`

## Test Plan

Confidence

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API endpoint resolution to correctly use the current region when creating functions and sites, ensuring proper regional endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->