### PR TITLE
Update placeholder text for input tags

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte
@@ -378,7 +378,7 @@
                         <InputTags
                             id="user-labels"
                             label="Labels"
-                            placeholder="Select or type user labels"
+                            placeholder="Select or type file extensions"
                             bind:tags={extensions} />
                     {/key}
                     <Layout.Stack direction="row">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes #2443. The "Allowed File Extensions" field in the bucket settings page showed the placeholder "Select or type **user labels**", which is incorrect as the field accepts **file extensions**, not **user labels**.

## Test Plan

(N/A)

## Related PRs and Issues

#2443

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated placeholder text in the file extensions input field on the storage bucket settings page for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->