### PR TITLE
Fix: UX of site settings

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/store.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/store.ts
@@ -69,12 +69,12 @@ export const adapterDataList = [
     {
         framework: 'nextjs',
         ssr: {
-            desc: "Ensure you don't set $ in $ file.",
-            code: ['output', 'next.config.js'],
+            desc: 'Set $ in $ file.',
+            code: ["output: 'standalone'", 'next.config.js'],
             url: 'https://nextjs.org/docs/pages/building-your-application/deploying'
         },
         static: {
-            desc: 'Set $ in $ file',
+            desc: 'Set $ in $ file.',
             code: ["output: 'export'", 'next.config.js'],
             url: 'https://nextjs.org/docs/pages/building-your-application/deploying/static-exports'
         }
@@ -82,12 +82,12 @@ export const adapterDataList = [
     {
         framework: 'analog',
         ssr: {
-            desc: 'Set $ in $ plugin in $',
+            desc: 'Set $ in $ plugin in $.',
             code: ['ssr: true', 'analog', 'vite.config.ts'],
             url: 'https://analogjs.org/docs/features/server/server-side-rendering'
         },
         static: {
-            desc: 'Set $ in $ plugin in $',
+            desc: 'Set $ in $ plugin in $.',
             code: ['static: true', 'analog', 'vite.config.ts'],
             url: 'https://analogjs.org/docs/features/server/static-site-generation'
         }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

All changes to build command card in site settings:

- Suggests standalone build for next.js
- adds missing dots in copy
- mutes learn-more to prevent visual unbalance
- Fixes "Update" of build settings being never disabled
- Auto-populates recommened build settings after adapter change
- Fixes switching adapter after switching framework (before it was always stuck on ssr)
- Fixes reset button behaviour to show recommended value without override
- Makes reset button disabled if value already matches

## Test Plan

Manual QA ✅
Design review ✅
Code review ✅

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework configuration descriptions and examples for Next.js and Analog setup.

* **Bug Fixes**
  * Improved build settings synchronization when selecting a framework adapter.
  * Enhanced change detection for build configuration updates to prevent unnecessary submissions.

* **Style**
  * Applied muted styling refinements to UI elements in the settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->