### PR TITLE
fix: show scroll-to-top/bottom controls in deployment logs

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/deployment-[deployment]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/deployment-[deployment]/+page.svelte
@@ -83,7 +83,7 @@
             open
             badgeType={badgeTypeDeployment(deployment.status)}
             hideDivider>
-            <Logs {deployment} hideTitle hideScrollButtons fullHeight />
+            <Logs {deployment} hideTitle fullHeight />
             <svelte:fragment slot="end">
                 <LogsTimer status={deployment.status} {deployment} />
             </svelte:fragment>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scroll buttons are now visible in the deployment logs section, enabling easier navigation through log entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->