### PR TITLE
fix: enable scrolling in execution sheet for small page limit sizes

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/+page.svelte
@@ -45,7 +45,7 @@
     </ResponsiveContainerHeader>
 
     {#if data?.executions?.total}
-        <Table columns={$columns} executions={data.executions} />
+        <Table columns={$columns} executions={data.executions} limit={data.limit} />
 
         <PaginationWithLimit
             name="Executions"

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/sheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/sheet.svelte
@@ -28,6 +28,7 @@
     export let logs: Models.Execution[];
     export let logging: boolean;
     export let open = false;
+    export let limit: number;
 
     function nextLog() {
         const currentIndex = logs.findIndex((log) => log.$id === selectedLogId);
@@ -60,7 +61,7 @@
 
 <svelte:window onclick={handleClickOutside} />
 
-<div style="position: absolute; top: 0; " bind:this={sheet}>
+<div style="position: absolute; top: 0;" bind:this={sheet}>
     <Sheet bind:open closeOnBlur={false}>
         <div slot="header" style:width="100%">
             <Layout.Stack direction="row" justifyContent="space-between" alignItems="center">
@@ -81,103 +82,125 @@
             </Layout.Stack>
         </div>
         {#if selectedLog}
-            <Layout.Stack gap="xl">
-                <Accordion title="Details" open>
-                    <Layout.Stack gap="xxxl">
-                        <Layout.Stack gap="xxxl" direction="row" wrap="wrap">
-                            <Layout.Stack gap="xs" inline>
-                                <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                    Method
-                                </Typography.Text>
-                                <Typography.Text variant="m-400">
-                                    {selectedLog.requestMethod}
-                                </Typography.Text>
-                            </Layout.Stack>
-                            <Layout.Stack gap="xs" inline>
-                                <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                    Status code
-                                </Typography.Text>
-                                <span>
-                                    <Badge
-                                        content={selectedLog.responseStatusCode.toString()}
-                                        variant="secondary"
-                                        type={getBadgeTypeFromStatusCode(
-                                            selectedLog.responseStatusCode
-                                        )} />
-                                </span>
-                            </Layout.Stack>
-                            <Layout.Stack gap="xs" inline>
-                                <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                    Status
-                                </Typography.Text>
-
-                                <Tooltip
-                                    disabled={!selectedLog?.scheduledAt ||
-                                        selectedLog.status !== ExecutionStatus.Scheduled}
-                                    maxWidth="400px">
-                                    <div>
-                                        <Status
-                                            status={logStatusConverter(selectedLog.status)}
-                                            label={capitalize(selectedLog.status)}>
-                                        </Status>
-                                    </div>
-                                    <span slot="tooltip">
-                                        {`Scheduled to execute on ${toLocaleDateTime(selectedLog.scheduledAt)}`}
+            <div class={limit === 6 ? 'log-content-scroll' : ''}>
+                <Layout.Stack gap="xl">
+                    <Accordion title="Details" open>
+                        <Layout.Stack gap="xxxl">
+                            <Layout.Stack gap="xxxl" direction="row" wrap="wrap">
+                                <Layout.Stack gap="xs" inline>
+                                    <Typography.Text
+                                        variant="m-400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        Method
+                                    </Typography.Text>
+                                    <Typography.Text variant="m-400">
+                                        {selectedLog.requestMethod}
+                                    </Typography.Text>
+                                </Layout.Stack>
+                                <Layout.Stack gap="xs" inline>
+                                    <Typography.Text
+                                        variant="m-400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        Status code
+                                    </Typography.Text>
+                                    <span>
+                                        <Badge
+                                            content={selectedLog.responseStatusCode.toString()}
+                                            variant="secondary"
+                                            type={getBadgeTypeFromStatusCode(
+                                                selectedLog.responseStatusCode
+                                            )} />
                                     </span>
-                                </Tooltip>
-                            </Layout.Stack>
+                                </Layout.Stack>
+                                <Layout.Stack gap="xs" inline>
+                                    <Typography.Text
+                                        variant="m-400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        Status
+                                    </Typography.Text>
 
-                            <Layout.Stack gap="xs" inline>
-                                <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                    Triggered by
-                                </Typography.Text>
-                                <Typography.Text variant="m-400">
-                                    {capitalize(selectedLog.trigger)}
-                                </Typography.Text>
-                            </Layout.Stack>
+                                    <Tooltip
+                                        disabled={!selectedLog?.scheduledAt ||
+                                            selectedLog.status !== ExecutionStatus.Scheduled}
+                                        maxWidth="400px">
+                                        <div>
+                                            <Status
+                                                status={logStatusConverter(selectedLog.status)}
+                                                label={capitalize(selectedLog.status)}>
+                                            </Status>
+                                        </div>
+                                        <span slot="tooltip">
+                                            {`Scheduled to execute on ${toLocaleDateTime(selectedLog.scheduledAt)}`}
+                                        </span>
+                                    </Tooltip>
+                                </Layout.Stack>
 
-                            <Layout.Stack gap="xs" inline>
-                                <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                    Duration
-                                </Typography.Text>
-                                <Typography.Text variant="m-400">
-                                    {#if ['processing', 'waiting'].includes(selectedLog.status)}
-                                        <span use:timer={{ start: selectedLog.$createdAt }}></span>
-                                    {:else}
-                                        {calculateTime(selectedLog.duration)}
-                                    {/if}
-                                </Typography.Text>
-                            </Layout.Stack>
+                                <Layout.Stack gap="xs" inline>
+                                    <Typography.Text
+                                        variant="m-400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        Triggered by
+                                    </Typography.Text>
+                                    <Typography.Text variant="m-400">
+                                        {capitalize(selectedLog.trigger)}
+                                    </Typography.Text>
+                                </Layout.Stack>
 
-                            <Layout.Stack gap="xs" inline>
+                                <Layout.Stack gap="xs" inline>
+                                    <Typography.Text
+                                        variant="m-400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        Duration
+                                    </Typography.Text>
+                                    <Typography.Text variant="m-400">
+                                        {#if ['processing', 'waiting'].includes(selectedLog.status)}
+                                            <span use:timer={{ start: selectedLog.$createdAt }}
+                                            ></span>
+                                        {:else}
+                                            {calculateTime(selectedLog.duration)}
+                                        {/if}
+                                    </Typography.Text>
+                                </Layout.Stack>
+
+                                <Layout.Stack gap="xs" inline>
+                                    <Typography.Text
+                                        variant="m-400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        Created
+                                    </Typography.Text>
+                                    <Typography.Text variant="m-400">
+                                        {capitalize(timeFromNow(selectedLog.$createdAt))}
+                                    </Typography.Text>
+                                </Layout.Stack>
+                            </Layout.Stack>
+                            <Layout.Stack gap="xs" inline alignItems="flex-start">
                                 <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                    Created
+                                    Path
                                 </Typography.Text>
-                                <Typography.Text variant="m-400">
-                                    {capitalize(timeFromNow(selectedLog.$createdAt))}
-                                </Typography.Text>
+                                <div>
+                                    <InteractiveText
+                                        text={selectedLog.requestPath}
+                                        variant="copy-code"
+                                        isVisible />
+                                </div>
                             </Layout.Stack>
                         </Layout.Stack>
-                        <Layout.Stack gap="xs" inline alignItems="flex-start">
-                            <Typography.Text variant="m-400" color="--fgcolor-neutral-tertiary">
-                                Path
-                            </Typography.Text>
-                            <div>
-                                <InteractiveText
-                                    text={selectedLog.requestPath}
-                                    variant="copy-code"
-                                    isVisible />
-                            </div>
-                        </Layout.Stack>
-                    </Layout.Stack>
-                </Accordion>
-                <Accordion title="Request" open>
-                    <LogsRequest {selectedLog} product="function" />
-                </Accordion>
-                <Accordion title="Response" open hideDivider>
-                    <LogsResponse {selectedLog} product="function" {logging} />
-                </Accordion>
-            </Layout.Stack>
+                    </Accordion>
+                    <Accordion title="Request" open>
+                        <LogsRequest {selectedLog} product="function" />
+                    </Accordion>
+                    <Accordion title="Response" open hideDivider>
+                        <LogsResponse {selectedLog} product="function" {logging} />
+                    </Accordion>
+                </Layout.Stack>
+            </div>
         {/if}
     </Sheet>
 </div>
+
+<style lang="scss">
+    .log-content-scroll {
+        max-height: calc(100vh - 280px);
+        overflow-y: auto;
+    }
+</style>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
@@ -21,10 +21,12 @@
 
     let {
         columns,
-        executions
+        executions,
+        limit
     }: {
         columns: Column[];
         executions: Models.ExecutionList;
+        limit: number;
     } = $props();
 
     let open = $state(false);
@@ -121,4 +123,4 @@
     {/snippet}
 </MultiSelectionTable>
 
-<Sheet bind:open bind:selectedLogId logs={executions.executions} logging={$func.logging} />
+<Sheet bind:open bind:selectedLogId logs={executions.executions} logging={$func.logging} {limit} />


### PR DESCRIPTION
## What does this PR do?

### Problem

When viewing function execution details with only 6 rows per page in the table:
- Execution details sheet doesn't scroll properly
- Long log responses get cut off and are not fully visible
- Main page has no scroll (only 6 rows), so sheet is constrained by viewport height
- Users cannot access complete execution logs

This issue doesn't occur with larger page sizes (12, 24, 48, 96) because the main page becomes scrollable, allowing the sheet to expand fully.

### Solution

Added a scrollable container wrapper around the sheet content with:
- `max-height: calc(100vh - 280px)` to constrain height within viewport
- `overflow-y: auto` to enable vertical scrolling
- Ensures all execution details (Request, Response, logs) are accessible

The 280px offset is determined to ensure optimal visibility of the log content across different screen sizes.

### Changes Made

**File: `sheet.svelte`**
- Added `limit` value as a prop (passed from `page.svelte` > `table.svelte` > `sheet.svelte`)
- Applied conditional class: `<div class={limit === 6 ? 'log-content-scroll' : ''}>`
- Added `.log-content-scroll` wrapper for the sheet content to enable scrolling when `limit === 6`
- Implemented CSS with `max-height` and `overflow-y: auto` for the scrollable behavior
- No visual or functional impact for other page limits (e.g., 12, 24, 48, 96)

## Test Plan

### Local Testing Performed:

1. ✅ Set executions per page to **6 rows**
2. ✅ Opened execution sheet with short log response - displays correctly
3. ✅ Opened execution sheet with long log response - scrolls smoothly
4. ✅ Tested with **12, 24, 48, 96 rows** - no regression, still works perfectly
5. ✅ Tested sheet opening/closing - smooth transitions

### Cross-page Size Testing:
- ✅ 6 rows - Sheet scrollable, full content visible
- ✅ 12 rows - Works as before, no regression
- ✅ 24 rows - Works as before, no regression
- ✅ 48 rows - Works as before, no regression
- ✅ 96 rows - Works as before, no regression

## Screenshots/Video

**Before Fix (6 rows per page):**
https://github.com/user-attachments/assets/71fe7984-bd02-4bfc-9007-eaf4a9468321

**After Fix (6 rows per page):**
https://github.com/user-attachments/assets/2fc994b3-94c0-435d-82b2-13e98d173dd9

## Related PRs and Issues

Fixes #2557 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and followed the contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-page limit configuration for function executions table.

* **Improvements**
  * Reorganized execution details layout for better readability.
  * Enhanced status display with scheduled timestamp information.
  * Improved request path presentation in execution details.
  * Optimized scrolling behavior for execution logs and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->