### PR TITLE
feat: Alert preference for deployment failures

### DIFF
--- a/src/lib/stores/user.ts
+++ b/src/lib/stores/user.ts
@@ -9,6 +9,7 @@ export type Account = Models.User<
         organization?: string;
         console: Models.Preferences;
         notificationPrefs: Record<string, NotificationPrefItem>;
+        deploymentFailedEmailAlert: boolean;
     } & Record<string, string>
 >;
 

--- a/src/routes/(console)/account/alerts/+page.svelte
+++ b/src/routes/(console)/account/alerts/+page.svelte
@@ -1,0 +1,38 @@
+<script>
+    import { CardGrid } from "$lib/components";
+    import { InputChoice } from "$lib/elements/forms";
+    import { Container } from "$lib/layout";
+    import { sdk } from '$lib/stores/sdk';
+    import { user } from '$lib/stores/user';
+    import { Layout } from "@appwrite.io/pink-svelte";
+
+    let deploymentFailedEmailAlert = $user.prefs.deploymentFailedEmailAlert ?? true;
+
+    function toggleDeploymentFailedEmailAlert() {
+      deploymentFailedEmailAlert = !deploymentFailedEmailAlert;
+      const newPrefs = {
+        ...$user.prefs,
+        deploymentFailedEmailAlert: deploymentFailedEmailAlert
+      };
+      sdk.forConsole.account.updatePrefs({ prefs: newPrefs });
+    }
+
+</script>
+
+<Container>
+  <CardGrid>
+    <svelte:fragment slot="title">Email Alerts</svelte:fragment>
+    Toggle email preferences to receive notifications when certain events occur.
+
+    <svelte:fragment slot="aside">
+      <Layout.Stack gap="xl">
+        <InputChoice
+            on:change={toggleDeploymentFailedEmailAlert}
+            type="switchbox"
+            id="mfa"
+            label="Deployment Failed"
+            value={deploymentFailedEmailAlert} />
+      </Layout.Stack>
+    </svelte:fragment>
+  </CardGrid>
+</Container>

--- a/src/routes/(console)/account/header.svelte
+++ b/src/routes/(console)/account/header.svelte
@@ -33,6 +33,11 @@
             title: 'Organizations',
             event: 'organizations',
             hasChildren: true
+        },
+        {
+            href: `${path}/alerts`,
+            title: 'Alerts',
+            event: 'alerts',
         }
     ];
 


### PR DESCRIPTION
Task: https://linear.app/appwrite/issue/SER-53/send-email-on-failed-deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Alerts" section in account settings
  * Users can now manage email notifications for deployment failures using a dedicated toggle
  * Deployment failure email alert preference added to user account management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->