### PR TITLE
fix: treat filter datetime inputs as local; convert to UTC on apply

### DIFF
--- a/src/lib/components/filters/content.svelte
+++ b/src/lib/components/filters/content.svelte
@@ -14,6 +14,7 @@
     import type { Column } from '$lib/helpers/types';
     import type { Writable } from 'svelte/store';
     import { TagList } from '.';
+    import { toLocalDateTimeISO } from '$lib/helpers/date';
     import { Icon, Layout } from '@appwrite.io/pink-svelte';
     import { IconPlus } from '@appwrite.io/pink-icons-svelte';
 
@@ -79,7 +80,7 @@
         value = column?.array ? [] : null;
         if (column?.type === 'datetime') {
             const now = new Date();
-            value = now.toISOString().slice(0, 16);
+            value = toLocalDateTimeISO(now.toISOString()).slice(0, 16);
         }
         // Initialize spatial data with default values
         if (column?.type === 'point') {
@@ -108,7 +109,11 @@
         if (isDistanceOperator && distanceValue !== null && value !== null) {
             addFilter(columnsArray, columnId, operatorKey, value, arrayValues, distanceValue);
         } else {
-            addFilter(columnsArray, columnId, operatorKey, value, arrayValues);
+            const preparedValue =
+                column?.type === 'datetime' && typeof value === 'string' && value
+                    ? new Date(value).toISOString()
+                    : value;
+            addFilter(columnsArray, columnId, operatorKey, preparedValue, arrayValues);
         }
 
         columnId = null;

--- a/src/lib/components/filters/filtersModal.svelte
+++ b/src/lib/components/filters/filtersModal.svelte
@@ -57,7 +57,11 @@
     }
 
     function addCondition() {
-        const newTag = generateTag(selectedColumn, operatorKey, value || arrayValues);
+        const preparedValue =
+            column?.type === 'datetime' && typeof value === 'string' && value
+                ? new Date(value).toISOString()
+                : value;
+        const newTag = generateTag(selectedColumn, operatorKey, preparedValue || arrayValues);
         if (localTags.some((t) => t.tag === newTag.tag && t.value === newTag.value)) {
             return;
         } else {
@@ -66,7 +70,7 @@
                 {
                     id: selectedColumn,
                     operator: operatorKey,
-                    value: value,
+                    value: preparedValue,
                     arrayValues: arrayValues
                 }
             ];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datetime filter handling to ensure consistent ISO string formatting across filter operations.
  * Standardized datetime value normalization for more reliable filter comparisons and storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->