### PR TITLE
fix: correct usage labels from 'Total functions/sites' to 'Total deployments'

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/usage/[[period]]/+page.svelte
@@ -13,7 +13,7 @@
         path={`${base}/project-${page.params.region}-${page.params.project}/functions/usage`}
         countMetadata={{
             legend: 'Functions',
-            title: 'Total functions'
+            title: 'Total Deployments'
         }}
         {total}
         {count} />

--- a/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/usage/[[period]]/+page.svelte
@@ -13,7 +13,7 @@
         path={`${base}/project-${page.params.region}-${page.params.project}/sites/usage`}
         countMetadata={{
             legend: 'Sites',
-            title: 'Total sites'
+            title: 'Total site Deployments'
         }}
         {total}
         {count} />


### PR DESCRIPTION
Fixes #2224 

The usage pages for Functions and Sites were showing labels that said "Total functions" and "Total sites", but the actual metric being displayed was the total number of deployments across all functions/sites.

Changed both labels to "Total deployments" to accurately reflect what's being counted.

This is a simple label fix - I know it's not a complex PR, just correcting the misleading text.

## Changes
- Updated Functions usage page label
- Updated Sites usage page label (mentioned in issue comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Functions usage view label to display "Total Deployments"
  * Updated Sites usage view label to display "Total site Deployments"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->