### PR TITLE
Fix: refresh when organization dependency change

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/+page.svelte
@@ -25,7 +25,9 @@
     import type { PageData } from './$types';
 
     export let data: PageData;
-    let organization = data.organization;
+
+    // Reactive statement to update organization when data changes
+    $: organization = data.organization;
 
     // why are these reactive?
     $: defaultPaymentMethod = data?.paymentMethods?.paymentMethods?.find(


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix: refresh billing page when organization dependency change

before: Invalidating organization was not refreshing the page because it kept local copy of organization

now: Invalidating organization correctly refreshes the page

## Test Plan

- Manually verified

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where organization information on the billing page was not updating properly when changes occurred, ensuring payment method details and other billing information reflect current data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->