### PR TITLE
Add: missing cloud scopes on Key

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -467,6 +467,45 @@ export const scopes: {
     }
 ];
 
+export const cloudOnlyBackupScopes = [
+    {
+        scope: 'policies.read',
+        description: 'Access to read your database backup policies',
+        category: 'Database',
+        icon: 'database'
+    },
+    {
+        scope: 'policies.write',
+        description: 'Access to create, update and delete your backup policies',
+        category: 'Database',
+        icon: 'database'
+    },
+    {
+        scope: 'archives.read',
+        description: 'Access to read your database backup archives',
+        category: 'Database',
+        icon: 'database'
+    },
+    {
+        scope: 'archives.write',
+        description: 'Access to create and delete your backup archives',
+        category: 'Database',
+        icon: 'database'
+    },
+    {
+        scope: 'restorations.read',
+        description: 'Access to read your backup restorations',
+        category: 'Database',
+        icon: 'database'
+    },
+    {
+        scope: 'restorations.write',
+        description: 'Access to create backup restorations',
+        category: 'Database',
+        icon: 'database'
+    }
+];
+
 export type EventService = {
     name: string;
     resources: EventResource[];


### PR DESCRIPTION
## What does this PR do?

As the title said.

## Test Plan

Manual.

<img width="1840" height="1191" alt="Screenshot 2025-11-27 at 2 39 24 PM" src="https://github.com/user-attachments/assets/07755c7c-161a-42e7-ac8f-68a9c0eda0c6" />

<img width="1840" height="1191" alt="Screenshot 2025-11-27 at 2 39 51 PM" src="https://github.com/user-attachments/assets/d3477380-c1c3-4575-9cf4-fca1d6811731" />

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key configuration in cloud environments now includes new backup management scopes. Users can configure granular permissions for backup policies, archives, and restoration operations, with separate controls for read and write access across each scope. These additions provide more precise control over backup-related API permissions in cloud deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->