### PR TITLE
fix: Docs button in create site repository connection modal

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte
@@ -66,7 +66,10 @@
                         </Typography.Text>
                     </Layout.Stack>
                     <Layout.Stack gap="s" direction="row">
-                        <Button href="#" secondary>Docs</Button>
+                        <Button
+                            href="https://appwrite.io/docs/products/sites/deploy-from-git"
+                            external
+                            secondary>Docs</Button>
                         <Button
                             href={`https://github.com/${data.installations.installations[0].organization}`}
                             text>Go to GitHub</Button>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the non-functional Docs button in the "Create site" modal when connecting to a Git repository. Previously, the button had a placeholder `href="#"` which prevented it from navigating anywhere. 

The fix:
- Updates the Docs button to link to `https://appwrite.io/docs/products/sites/deploy-from-git`
- Adds the `external` prop to ensure the documentation opens in a new tab
- Provides users with access to relevant documentation when they encounter the "Missing a repository?" message

## Test Plan

**Manual Testing:**
1. Navigate to Sites → Create site → Connect a repository
2. When the "Missing a repository?" section appears in the aside panel
3. Click the "Docs" button
4. **Expected:** The button should open `https://appwrite.io/docs/products/sites/deploy-from-git` in a new tab
5. **Verified:** The link works correctly and opens the "Deploy from Git" documentation page

**Files Changed:**
- `src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte` (lines 69-72)

## Related PRs and Issues

**Resolves:** #2356

**Issue Description:**
The Docs button in the "Create site" modal (when connecting to a repository) was not functional. The button had an underlying link pointing to `#` which didn't navigate anywhere.

**Solution:**
Updated the button to link to the appropriate documentation page (`https://appwrite.io/docs/products/sites/deploy-from-git`) which provides guidance on deploying sites from Git repositories, directly addressing the user's need when they see the "Missing a repository?" message.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read the Contributing Guidelines. I followed the project's conventions:
- Used the proper branch naming convention (`fix-2356-docs-button-create-site`)
- Ran all required checks (`format`, `check`, `lint`)
- Ensured the fix addresses the exact issue reported
- Added the `external` prop to match the pattern used elsewhere in the codebase for external documentation links
- The change is minimal and focused on fixing the specific bug without introducing side effects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the documentation link in the repository setup assistance section to correctly point to Deploy-from-Git documentation, ensuring users receive proper guidance when seeking help during repository configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->