### PR TITLE
feat: add quick create-organization button in org header

### DIFF
--- a/src/routes/(console)/organization-[organization]/header.svelte
+++ b/src/routes/(console)/organization-[organization]/header.svelte
@@ -29,7 +29,7 @@
         isOwner
     } from '$lib/stores/roles';
     import { GRACE_PERIOD_OVERRIDE, isCloud } from '$lib/system';
-    import { IconGithub, IconPlus } from '@appwrite.io/pink-icons-svelte';
+    import { IconGithub, IconPlus, IconPlusSm } from '@appwrite.io/pink-icons-svelte';
     import { Badge, Icon, Layout, Tooltip, Typography } from '@appwrite.io/pink-svelte';
 
     let areMembersLimited: boolean = $state(false);
@@ -125,7 +125,7 @@
                     size="xs"
                     on:click={() =>
                         isCloud ? goto(`${base}/create-organization`) : newOrgModal.set(true)}>
-                    <Icon icon={IconPlus} size="s" />
+                    <Icon icon={IconPlusSm} size="m" />
                 </Button>
             </Layout.Stack>
             <div class="u-margin-inline-start-auto">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

<img width="1620" height="684" alt="image" src="https://github.com/user-attachments/assets/0ff05179-425e-48ad-a7f8-4e263566b4f3" />



## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header action now either opens an inline "Create organization" modal or routes to the cloud creation page, depending on deployment.
* **UI Improvements**
  * Header spacing and layout updated for better alignment and visual balance.
  * Header action icon scaled down to a smaller plus to improve compactness and visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->