### PR TITLE
Hide internal OAuth providers from UI

### DIFF
--- a/src/lib/stores/oauth-providers.ts
+++ b/src/lib/stores/oauth-providers.ts
@@ -13,6 +13,7 @@ export type Provider = {
     name: string;
     icon: string;
     docs?: string;
+    internal?: true;
     component: Component;
 };
 
@@ -113,6 +114,13 @@ export const oAuthProviders: Record<string, Provider> = {
         docs: 'https://developer.github.com',
         component: Main
     },
+    githubImagine: {
+        name: 'GitHub',
+        icon: 'github',
+        docs: 'https://developer.github.com',
+        component: Main,
+        internal: true
+    },
     gitlab: {
         name: 'GitLab',
         icon: 'gitlab',
@@ -124,6 +132,13 @@ export const oAuthProviders: Record<string, Provider> = {
         icon: 'google',
         docs: 'https://support.google.com/googleapi/answer/6158849',
         component: Google
+    },
+    googleImagine: {
+        name: 'Google',
+        icon: 'google',
+        docs: 'https://support.google.com/googleapi/answer/6158849',
+        component: Google,
+        internal: true
     },
     linkedin: {
         name: 'LinkedIn',

--- a/src/routes/(console)/project-[region]-[project]/auth/settings/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/settings/+page.svelte
@@ -77,7 +77,7 @@
                         .filter((p) => p.name !== 'Mock')
                         .sort( (a, b) => (a.enabled === b.enabled ? 0 : a.enabled ? -1 : 1) ) as provider}
                         {@const oAuthProvider = oAuthProviders[provider.key]}
-                        {#if oAuthProvider}
+                        {#if oAuthProvider && !oAuthProvider.internal}
                             <Card.Button
                                 padding="s"
                                 on:click={() => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth provider selection to exclude internal-only providers from user-facing options, ensuring only applicable providers appear in the authentication settings interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->