### PR TITLE
fix(migrations): redirect 404 on self-hosted instances

### DIFF
--- a/src/routes/(console)/(migration-wizard)/wizard.svelte
+++ b/src/routes/(console)/(migration-wizard)/wizard.svelte
@@ -57,6 +57,7 @@
 
     let newProjName = '';
     let projectType: 'existing' | 'new' = 'existing';
+    let newlyCreatedProject: Models.Project | null = null;
 
     async function getProjects(orgId: string | null) {
         if (!orgId) {
@@ -125,8 +126,9 @@
             });
             onExit();
             await invalidate(Dependencies.PROJECTS);
+            const targetProject = newlyCreatedProject ?? currentSelectedProject;
             await goto(
-                `${base}/project-${currentSelectedProject.region}-${currentSelectedProject.$id}/settings/migrations`
+                `${base}/project-${targetProject.region ?? 'default'}-${targetProject.$id}/settings/migrations`
             );
         } catch (error) {
             addNotification({
@@ -257,6 +259,7 @@
                                         } else {
                                             const project = await createNewProject();
                                             if (project !== null) {
+                                                newlyCreatedProject = project;
                                                 projectSdkInstance = sdk.forProject(
                                                     project.region,
                                                     project.$id


### PR DESCRIPTION
## Problem
After migrating a project from Cloud to a self-hosted instance, users were redirected to a non-existent URL (`/console/project-{projectId}/settings/migrations`) causing a 404 error.

## Root Cause
1. The `region` parameter was missing from the redirect URL on self-hosted instances (where `region` is undefined).
2. The project object wasn't being correctly captured after creation.

## Solution
- Captured the newly created project in `newlyCreatedProject`.
- Added a fallback `targetProject.region ?? 'default'` to matches the self-hosted URL pattern.

## Related Issue
Closes #2183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed migration wizard to properly handle newly created projects, ensuring correct navigation to the migrations page for both newly created and existing projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->