### PR TITLE
fix: ensure the entire $id cell is hidden if user hides

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
@@ -901,9 +901,9 @@
                         hoverEffect
                         showSelectOnHover
                         valueWithoutHover={row.$sequence}>
-                        {#each $tableColumns as { id: columnId, isEditable } (columnId)}
+                        {#each $tableColumns as { id: columnId, isEditable, hide } (columnId)}
                             {@const rowColumn = $columns.find((col) => col.key === columnId)}
-                            {#if columnId === '$id'}
+                            {#if columnId === '$id' && !hide}
                                 <button
                                     on:mouseenter={() => {
                                         showExpandIconForId = index;


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Since the logic is inside the Spreadsheet.Cell, there's still a <button> element so we need to make sure that is hidden too.

Fixes https://github.com/appwrite/console/issues/2687

## Test Plan

Manual test:

<img width="976" height="334" alt="image" src="https://github.com/user-attachments/assets/a8b04156-8b7f-4fd5-a897-7285f91e3d59" />

## Related PRs and Issues

* https://github.com/appwrite/console/issues/2687

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Columns in the database table spreadsheet view can now be hidden based on their configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->