### PR TITLE
Improve payments modal

### DIFF
--- a/src/lib/components/billing/selectPaymentMethod.svelte
+++ b/src/lib/components/billing/selectPaymentMethod.svelte
@@ -18,14 +18,14 @@
     let showTaxId = false;
     let showPaymentModal = false;
 
-    async function cardSaved(event: CustomEvent<PaymentMethodData>) {
-        value = event.detail.$id;
+    async function cardSaved(card: PaymentMethodData) {
+        value = card.$id;
 
         if (value) {
             methods = {
                 ...methods,
                 total: methods.total + 1,
-                paymentMethods: [...methods.paymentMethods, event.detail]
+                paymentMethods: [...methods.paymentMethods, card]
             };
         }
 
@@ -98,7 +98,7 @@
 </Layout.Stack>
 
 {#if showPaymentModal && isCloud && hasStripePublicKey}
-    <PaymentModal bind:show={showPaymentModal} on:submit={cardSaved}>
+    <PaymentModal bind:show={showPaymentModal} onCardSubmit={cardSaved}>
         <svelte:fragment slot="end">
             <Selector.Checkbox
                 id="taxIdCheck"

--- a/src/lib/components/fakeModal.svelte
+++ b/src/lib/components/fakeModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import { Alert } from '@appwrite.io/pink-svelte';
-    import { onMount } from 'svelte';
+    import { clickOnEnter } from '$lib/helpers/a11y';
     import Form from '$lib/elements/forms/form.svelte';
     import { Click, trackEvent } from '$lib/actions/analytics';
-    import { clickOnEnter } from '$lib/helpers/a11y';
 
+    export let title = '';
     export let show = false;
     export let size: 'small' | 'big' = 'big';
     export let icon: string = null;
@@ -15,11 +15,13 @@
     export let onSubmit: (e: SubmitEvent) => Promise<void> | void = function () {
         return;
     };
-    export let title = '';
+
+    /**
+     * needed when using `StatePicker`
+     */
+    export let skipEnterOnBackdrop = false;
 
     let backdrop: HTMLDivElement;
-
-    onMount(async () => {});
 
     function handleBLur(event: MouseEvent) {
         if (event.target === backdrop) {
@@ -60,12 +62,12 @@
 <svelte:window on:keydown={handleKeydown} />
 
 {#if show}
-    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
+        bind:this={backdrop}
+        onclick={handleBLur}
         class="payment-modal-backdrop"
-        on:keyup={clickOnEnter}
-        on:click={handleBLur}
-        bind:this={backdrop}>
+        onkeyup={skipEnterOnBackdrop ? undefined : clickOnEnter}>
         <div
             class="modal"
             class:is-small={size === 'small'}
@@ -99,11 +101,12 @@
                                 style="--button-size:1.5rem;"
                                 aria-label="Close Modal"
                                 title="Close Modal"
-                                on:click={() =>
+                                onclick={() => {
+                                    closeModal();
                                     trackEvent(Click.ModalCloseClick, {
                                         from: 'button'
-                                    })}
-                                on:click={closeModal}>
+                                    });
+                                }}>
                                 <span class="icon-x" aria-hidden="true"></span>
                             </button>
                         {/if}

--- a/src/lib/stores/stripe.ts
+++ b/src/lib/stores/stripe.ts
@@ -58,10 +58,20 @@ export async function initializeStripe(node: HTMLElement) {
 
 export async function unmountPaymentElement() {
     isStripeInitialized.set(false);
-    paymentElement?.unmount();
+
+    if (paymentElement) {
+        try {
+            paymentElement.unmount();
+            paymentElement.destroy();
+        } catch (e) {
+            console.debug('Payment element cleanup:', e.message);
+        }
+    }
+
+    elements = null;
     clientSecret = null;
     paymentMethod = null;
-    elements = null;
+    paymentElement = null;
 }
 
 export async function submitStripeCard(name: string, organizationId?: string) {

--- a/src/routes/(console)/organization-[organization]/billing/paymentMethods.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentMethods.svelte
@@ -308,11 +308,11 @@
 {#if showPayment && isCloud && hasStripePublicKey}
     <PaymentModal
         bind:show={showPayment}
-        on:submit={(e) => {
+        onCardSubmit={(card) => {
             if (isSelectedBackup) {
-                addBackupPaymentMethod(e.detail.$id);
+                addBackupPaymentMethod(card.$id);
             } else {
-                addPaymentMethod(e.detail.$id);
+                addPaymentMethod(card.$id);
             }
         }} />
 {/if}

--- a/src/routes/(console)/organization-[organization]/billing/replaceCard.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/replaceCard.svelte
@@ -19,7 +19,7 @@
     export let methods: PaymentList;
 
     let name: string;
-    let error: string;
+    let error: string = null;
     let selectedPaymentMethodId: string;
     let showState: boolean = false;
     let state: string = '';

--- a/src/routes/(console)/organization-[organization]/billing/retryPaymentModal.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/retryPaymentModal.svelte
@@ -147,7 +147,6 @@
     onSubmit={handleSubmit}
     size="big"
     title="Retry payment">
-    <!-- TODO: format currency -->
     <p class="text">
         Your payment of <span class="inline-tag">{formatCurrency(invoice.grossAmount)}</span> due on {toLocaleDate(
             invoice.dueAt


### PR DESCRIPTION
## What does this PR do?

1. Reset Stripe state on modal open
2. Fix Enter hits on State picker closing modal and reopen causing invalid Stripe state

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added state collection for US card transactions in the payment modal.

* **Improvements**
  * Enhanced payment modal accessibility with improved backdrop and keyboard behavior handling.
  * Strengthened payment element cleanup and state management for more reliable payment processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->