### PR TITLE
Add CNAME warning for apex domains

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/add-domain/verify-[domain]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/add-domain/verify-[domain]/+page.svelte
@@ -20,7 +20,6 @@
     import Wizard from '$lib/layout/wizard.svelte';
     import { base } from '$app/paths';
     import { writable } from 'svelte/store';
-    import { isASubdomain } from '$lib/helpers/tlds';
     import NameserverTable from '$lib/components/domains/nameserverTable.svelte';
     import RecordTable from '$lib/components/domains/recordTable.svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
@@ -28,24 +27,30 @@
     let { data } = $props();
 
     const ruleId = page.url.searchParams.get('rule');
-    const isSubDomain = $derived.by(() => isASubdomain(data.proxyRule.domain));
+
+    const showCNAMETab = $derived(
+        Boolean($regionalConsoleVariables._APP_DOMAIN_FUNCTIONS) &&
+            $regionalConsoleVariables._APP_DOMAIN_FUNCTIONS !== 'localhost'
+    );
+    const showATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_A) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'
+    );
+    const showAAAATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'
+    );
+    const showNSTab = isCloud;
 
     let selectedTab = $state<'cname' | 'nameserver' | 'a' | 'aaaa'>(getDefaultTab());
-
     let routeBase = `${base}/project-${page.params.region}-${page.params.project}/functions/function-${page.params.function}/domains`;
     let verified: boolean | undefined = $state(undefined);
     const isSubmitting = writable(false);
 
     function getDefaultTab() {
-        if (isSubDomain && $regionalConsoleVariables._APP_DOMAIN_FUNCTIONS) {
-            return 'cname';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_A) {
-            return 'a';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) {
-            return 'aaaa';
-        } else {
-            return 'nameserver';
-        }
+        return showCNAMETab ? 'cname' : showATab ? 'a' : showAAAATab ? 'aaaa' : 'nameserver';
     }
 
     async function verify() {
@@ -131,7 +136,7 @@
                 <Layout.Stack gap="xl">
                     <div>
                         <Tabs.Root variant="secondary" let:root>
-                            {#if isSubDomain && !!$regionalConsoleVariables._APP_DOMAIN_FUNCTIONS && $regionalConsoleVariables._APP_DOMAIN_FUNCTIONS !== 'localhost'}
+                            {#if showCNAMETab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'cname')}
@@ -139,7 +144,7 @@
                                     CNAME
                                 </Tabs.Item.Button>
                             {/if}
-                            {#if isCloud}
+                            {#if showNSTab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'nameserver')}
@@ -147,7 +152,7 @@
                                     Nameservers
                                 </Tabs.Item.Button>
                             {/if}
-                            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_A && $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'}
+                            {#if showATab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'a')}
@@ -155,7 +160,7 @@
                                     A
                                 </Tabs.Item.Button>
                             {/if}
-                            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'}
+                            {#if showAAAATab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'aaaa')}

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/retryDomainModal.svelte
@@ -8,7 +8,6 @@
     import { Dependencies } from '$lib/constants';
     import type { Models } from '@appwrite.io/console';
     import { page } from '$app/state';
-    import { isASubdomain } from '$lib/helpers/tlds';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { isCloud } from '$lib/system';
     import { Divider, Tabs } from '@appwrite.io/pink-svelte';
@@ -23,24 +22,29 @@
         selectedProxyRule: Models.ProxyRule;
     } = $props();
 
-    const isSubDomain = $derived.by(() => isASubdomain(selectedProxyRule?.domain));
+    const showCNAMETab = $derived(
+        Boolean($regionalConsoleVariables._APP_DOMAIN_FUNCTIONS) &&
+            $regionalConsoleVariables._APP_DOMAIN_FUNCTIONS !== 'localhost'
+    );
+    const showATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_A) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'
+    );
+    const showAAAATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'
+    );
+    const showNSTab = isCloud;
 
     let selectedTab = $state<'cname' | 'nameserver' | 'a' | 'aaaa'>(getDefaultTab());
-
-    function getDefaultTab() {
-        if (isSubDomain && $regionalConsoleVariables._APP_DOMAIN_FUNCTIONS) {
-            return 'cname';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_A) {
-            return 'a';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) {
-            return 'aaaa';
-        } else {
-            return 'nameserver';
-        }
-    }
-
     let error = $state(null);
     let verified = $state(false);
+
+    function getDefaultTab() {
+        return showCNAMETab ? 'cname' : showATab ? 'a' : showAAAATab ? 'aaaa' : 'nameserver';
+    }
 
     async function retryProxyRule() {
         try {
@@ -90,7 +94,7 @@
 <Modal title="Retry verification" bind:show onSubmit={retryProxyRule} bind:error>
     <div>
         <Tabs.Root variant="secondary" let:root>
-            {#if isSubDomain && !!$regionalConsoleVariables._APP_DOMAIN_FUNCTIONS && $regionalConsoleVariables._APP_DOMAIN_FUNCTIONS !== 'localhost'}
+            {#if showCNAMETab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'cname')}
@@ -98,7 +102,7 @@
                     CNAME
                 </Tabs.Item.Button>
             {/if}
-            {#if isCloud}
+            {#if showNSTab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'nameserver')}
@@ -106,7 +110,7 @@
                     Nameservers
                 </Tabs.Item.Button>
             {/if}
-            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_A && $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'}
+            {#if showATab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'a')}
@@ -114,7 +118,7 @@
                     A
                 </Tabs.Item.Button>
             {/if}
-            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'}
+            {#if showAAAATab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'aaaa')}

--- a/src/routes/(console)/project-[region]-[project]/settings/domains/add-domain/verify-[domain]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/domains/add-domain/verify-[domain]/+page.svelte
@@ -20,7 +20,6 @@
     import Wizard from '$lib/layout/wizard.svelte';
     import { base } from '$app/paths';
     import { writable } from 'svelte/store';
-    import { isASubdomain } from '$lib/helpers/tlds';
     import NameserverTable from '$lib/components/domains/nameserverTable.svelte';
     import RecordTable from '$lib/components/domains/recordTable.svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
@@ -28,7 +27,22 @@
     let { data } = $props();
 
     const ruleId = page.url.searchParams.get('rule');
-    const isSubDomain = $derived.by(() => isASubdomain(data.proxyRule.domain));
+
+    const showCNAMETab = $derived(
+        Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME !== 'localhost'
+    );
+    const showATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_A) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'
+    );
+    const showAAAATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'
+    );
+    const showNSTab = isCloud;
 
     let selectedTab = $state<'cname' | 'nameserver' | 'a' | 'aaaa'>(getDefaultTab());
 
@@ -37,15 +51,7 @@
     const isSubmitting = writable(false);
 
     function getDefaultTab() {
-        if (isSubDomain && $regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME) {
-            return 'cname';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_A) {
-            return 'a';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) {
-            return 'aaaa';
-        } else {
-            return 'nameserver';
-        }
+        return showCNAMETab ? 'cname' : showATab ? 'a' : showAAAATab ? 'aaaa' : 'nameserver';
     }
 
     async function verify() {
@@ -130,7 +136,7 @@
                 <Layout.Stack gap="xl">
                     <div>
                         <Tabs.Root variant="secondary" let:root>
-                            {#if isSubDomain && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME && $regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME !== 'localhost'}
+                            {#if showCNAMETab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'cname')}
@@ -138,7 +144,7 @@
                                     CNAME
                                 </Tabs.Item.Button>
                             {/if}
-                            {#if isCloud}
+                            {#if showNSTab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'nameserver')}
@@ -146,7 +152,7 @@
                                     Nameservers
                                 </Tabs.Item.Button>
                             {/if}
-                            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_A && $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'}
+                            {#if showATab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'a')}
@@ -154,7 +160,7 @@
                                     A
                                 </Tabs.Item.Button>
                             {/if}
-                            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'}
+                            {#if showAAAATab}
                                 <Tabs.Item.Button
                                     {root}
                                     on:click={() => (selectedTab = 'aaaa')}

--- a/src/routes/(console)/project-[region]-[project]/settings/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/domains/retryDomainModal.svelte
@@ -8,7 +8,6 @@
     import { Dependencies } from '$lib/constants';
     import type { Models } from '@appwrite.io/console';
     import { page } from '$app/state';
-    import { isASubdomain } from '$lib/helpers/tlds';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { isCloud } from '$lib/system';
     import { Divider, Tabs } from '@appwrite.io/pink-svelte';
@@ -23,23 +22,28 @@
         selectedProxyRule: Models.ProxyRule;
     } = $props();
 
-    const isSubDomain = $derived.by(() => isASubdomain(selectedProxyRule?.domain));
+    const showCNAMETab = $derived(
+        Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME !== 'localhost'
+    );
+    const showATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_A) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'
+    );
+    const showAAAATab = $derived(
+        !isCloud &&
+            Boolean($regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) &&
+            $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'
+    );
+    const showNSTab = isCloud;
 
     let selectedTab = $state<'cname' | 'nameserver' | 'a' | 'aaaa'>(getDefaultTab());
-
     let error = $state(null);
     let verified = $state(false);
 
     function getDefaultTab() {
-        if (isSubDomain && $regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME) {
-            return 'cname';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_A) {
-            return 'a';
-        } else if (!isCloud && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA) {
-            return 'aaaa';
-        } else {
-            return 'nameserver';
-        }
+        return showCNAMETab ? 'cname' : showATab ? 'a' : showAAAATab ? 'aaaa' : 'nameserver';
     }
 
     async function retryDomain() {
@@ -90,7 +94,7 @@
 <Modal title="Retry verification" bind:show onSubmit={retryDomain} bind:error>
     <div>
         <Tabs.Root variant="secondary" let:root>
-            {#if isSubDomain && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME && $regionalConsoleVariables._APP_DOMAIN_TARGET_CNAME !== 'localhost'}
+            {#if showCNAMETab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'cname')}
@@ -98,7 +102,7 @@
                     CNAME
                 </Tabs.Item.Button>
             {/if}
-            {#if isCloud}
+            {#if showNSTab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'nameserver')}
@@ -106,7 +110,7 @@
                     Nameservers
                 </Tabs.Item.Button>
             {/if}
-            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_A && $regionalConsoleVariables._APP_DOMAIN_TARGET_A !== '127.0.0.1'}
+            {#if showATab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'a')}
@@ -114,7 +118,7 @@
                     A
                 </Tabs.Item.Button>
             {/if}
-            {#if !isCloud && !!$regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA && $regionalConsoleVariables._APP_DOMAIN_TARGET_AAAA !== '::1'}
+            {#if showAAAATab}
                 <Tabs.Item.Button
                     {root}
                     on:click={() => (selectedTab = 'aaaa')}


### PR DESCRIPTION
Closes SER-330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned domain verification and retry workflows across projects, functions, and sites to dynamically control DNS record type tab visibility (CNAME, A, AAAA, Nameserver) based on regional settings and environment configuration, providing improved consistency in domain management experiences throughout the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->