### PR TITLE
fix: alert aligment issue in max file size card

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/updateMaxFileSize.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/updateMaxFileSize.svelte
@@ -46,15 +46,12 @@
         <svelte:fragment slot="aside">
             {#if isCloud}
                 {@const size = humanFileSize(sizeToBytes(service, 'MB', 1000))}
-                <Alert.Inline status="info">
-                    The {currentPlan.name} plan has a maximum upload file size limit of {Math.floor(
-                        parseInt(size.value)
-                    )}{size.unit}.
-                    {#if $organization?.billingPlan === BillingPlan.FREE}
-                        Upgrade to allow files of a larger size.
-                    {/if}
-                    <svelte:fragment slot="actions">
-                        {#if $organization?.billingPlan === BillingPlan.FREE}
+                {#if $organization?.billingPlan === BillingPlan.FREE}
+                    <Alert.Inline status="info">
+                        The {currentPlan.name} plan has a maximum upload file size limit of {Math.floor(
+                            parseInt(size.value)
+                        )}{size.unit}. Upgrade to allow files of a larger size.
+                        <svelte:fragment slot="actions">
                             <div class="alert-buttons u-flex">
                                 <Button
                                     text
@@ -65,10 +62,17 @@
                                         });
                                     }}>Upgrade plan</Button>
                             </div>
-                        {/if}
-                    </svelte:fragment>
-                </Alert.Inline>
+                        </svelte:fragment>
+                    </Alert.Inline>
+                {:else}
+                    <Alert.Inline status="info">
+                        The {currentPlan.name} plan has a maximum upload file size limit of {Math.floor(
+                            parseInt(size.value)
+                        )}{size.unit}.
+                    </Alert.Inline>
+                {/if}
             {/if}
+
             <InputNumber
                 required
                 id="size"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Gap at bottom seems bigger than on top, in alert

### Before

<img width="2504" height="1012" alt="image" src="https://github.com/user-attachments/assets/ae6eb594-bb93-4fea-89dc-94869f13fa43" />


### After

<img width="1602" height="343" alt="image" src="https://github.com/user-attachments/assets/e66fa4c5-323c-4c02-86e8-1fb895ae2690" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal organization of the cloud plan alert display in storage bucket settings to enhance code clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->