### PR TITLE
Add `billingPlanDetails` prelim support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@cced6e3",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@f21fc7f",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@865e2fc",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.1.24
         version: 1.1.24(svelte@5.25.3)(zod@3.24.3)
       '@appwrite.io/console':
-        specifier: https://pkg.vc/-/@appwrite/@appwrite.io/console@cced6e3
-        version: https://pkg.vc/-/@appwrite/@appwrite.io/console@cced6e3
+        specifier: https://pkg.vc/-/@appwrite/@appwrite.io/console@f21fc7f
+        version: https://pkg.vc/-/@appwrite/@appwrite.io/console@f21fc7f
       '@appwrite.io/pink-icons':
         specifier: 0.25.0
         version: 0.25.0
@@ -272,8 +272,8 @@ packages:
   '@analytics/type-utils@0.6.2':
     resolution: {integrity: sha512-TD+xbmsBLyYy/IxFimW/YL/9L2IEnM7/EoV9Aeh56U64Ify8o27HJcKjo38XY9Tcn0uOq1AX3thkKgvtWvwFQg==}
 
-  '@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@cced6e3':
-    resolution: {tarball: https://pkg.vc/-/@appwrite/@appwrite.io/console@cced6e3}
+  '@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@f21fc7f':
+    resolution: {tarball: https://pkg.vc/-/@appwrite/@appwrite.io/console@f21fc7f}
     version: 1.10.0
 
   '@appwrite.io/pink-icons-svelte@2.0.0-RC.1':
@@ -3823,7 +3823,7 @@ snapshots:
 
   '@analytics/type-utils@0.6.2': {}
 
-  '@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@cced6e3': {}
+  '@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@f21fc7f': {}
 
   '@appwrite.io/pink-icons-svelte@2.0.0-RC.1(svelte@5.25.3)':
     dependencies:

--- a/src/lib/stores/organization.ts
+++ b/src/lib/stores/organization.ts
@@ -16,6 +16,7 @@ export type OrganizationError = {
 export type Organization = Models.Team<Record<string, unknown>> & {
     billingBudget: number;
     billingPlan: Tier;
+    billingPlanId: Tier /* unused for now! */;
     billingPlanDetails: Plan /* unused for now! */;
     budgetAlerts: number[];
     paymentMethodId: string;


### PR DESCRIPTION
## What does this PR do?

Use `organization.billingPlanId` as a part of internal and planned refactor.

## Test Plan

N/A.

## Related PRs and Issues

Cloud#3061

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated console dependency to a newer release.
  * Extended organization data to include additional billing plan identifiers and plan details (fields are present for future use; no user-facing behavior changed).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->