### PR TITLE
fix: pass platform key to wizard when continuing platform setup

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/onboard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/onboard.svelte
@@ -69,7 +69,7 @@
 
     function openPlatformWizard(type: number, platform?: Models.Platform) {
         if (platform) {
-            continuePlatform(type, platform.name, platform.type);
+            continuePlatform(type, platform.name, platform.type, platform.key);
         } else {
             trackEvent(Click.PlatformCreateClick, { source: 'onboarding' });
             addPlatform(type);

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/+page.svelte
@@ -27,7 +27,12 @@
         });
     }
 
-    export async function continuePlatform(platform: Platform, name: string, type: PlatformType) {
+    export async function continuePlatform(
+        platform: Platform,
+        name: string,
+        type: PlatformType,
+        key?: string
+    ) {
         createPlatform.set({
             name: name,
             type: type
@@ -40,7 +45,8 @@
 
         wizard.start(platforms[platform], null, 1, {
             isConnectPlatform: true,
-            platform: type
+            platform: type,
+            key: key
         });
     }
 

--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
@@ -334,7 +334,7 @@ APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).c
                     {/if}
                 </Layout.Stack>
             </Form>
-        {:else}
+        {:else if selectedFramework}
             <Card.Base padding="s"
                 ><Layout.Stack direction="row" justifyContent="space-between" alignItems="center">
                     <Layout.Stack gap="xxs" direction="row">


### PR DESCRIPTION
Fixes #10873 - Cannot read properties of undefined (reading 'smallIcon')

When clicking 'Continue' on an existing web platform, the wizard was not receiving the framework key, causing selectedFramework to be undefined.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the crash that occurs when clicking "Continue" on an existing web platform in the onboarding flow.

**Root Cause:** The `continuePlatform()` function was not passing the framework `key` to the wizard, causing `selectedFramework` to be `undefined`.

**Changes:**
- [+page.svelte](cci:7://file:///Users/suhaniawasthi/Desktop/console/src/routes/%28console%29/project-%5Bregion%5D-%5Bproject%5D/overview/platforms/+page.svelte:0:0-0:0): Added `key` parameter to `continuePlatform()`
- [onboard.svelte](cci:7://file:///Users/suhaniawasthi/Desktop/console/src/routes/%28console%29/project-%5Bregion%5D-%5Bproject%5D/overview/onboard.svelte:0:0-0:0): Pass `platform.key` when calling the function
- [createWeb.svelte](cci:7://file:///Users/suhaniawasthi/Desktop/console/src/routes/%28console%29/project-%5Bregion%5D-%5Bproject%5D/overview/platforms/createWeb.svelte:0:0-0:0): Added defensive null check

## Test Plan

1. Create a project with both Web and Android platforms
2. Go to Project → Overview
3. Click "Continue" on the Web platform card
4. Verify the wizard opens without crashing

Ran `pnpm run check` (0 errors) and `pnpm run lint` (passed).

## Related PRs and Issues

Fixes https://github.com/appwrite/appwrite/issues/10873

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Framework details section now only displays when a framework is selected, improving clarity during setup.

* **Refactor**
  * Enhanced platform wizard initialization to properly handle additional platform metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->