### PR TITLE
fix: use JSON serialization for array fields in spreadsheet editor

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
@@ -77,7 +77,7 @@
         if (isSpatialType(column) && Array.isArray(value)) {
             stringValue = JSON.stringify(value);
         } else if (array && Array.isArray(value)) {
-            stringValue = value.map(String).join(', ');
+            stringValue = JSON.stringify(value, null, 2);
         } else if (value !== null && value !== undefined) {
             stringValue = String(value);
         } else {
@@ -87,12 +87,13 @@
 
     $effect(() => {
         if (array) {
-            const newArray = stringValue
-                .split(',')
-                .map((item) => parseValue(item))
-                .filter((item) => item !== null);
-            if (JSON.stringify(newArray) !== JSON.stringify(value)) {
-                value = newArray as string[] | number[] | boolean[];
+            try {
+                const parsed = JSON.parse(stringValue);
+                if (Array.isArray(parsed) && JSON.stringify(parsed) !== JSON.stringify(value)) {
+                    value = parsed;
+                }
+            } catch {
+                // Invalid JSON - don't update value
             }
         } else {
             const parsedValue = isSpatialType(column)
@@ -120,14 +121,14 @@
         } else {
             switch (column.type) {
                 case 'integer':
-                    return 'Enter integers separated by commas';
+                    return 'Enter JSON array, e.g. [1, 2, 3]';
                 case 'double':
-                    return 'Enter numbers separated by commas';
+                    return 'Enter JSON array, e.g. [1.5, 2.5]';
                 case 'boolean':
-                    return 'Enter true/false separated by commas';
+                    return 'Enter JSON array, e.g. [true, false]';
                 case 'string':
                 default:
-                    return 'Enter strings separated by commas';
+                    return 'Enter JSON array, e.g. ["item1", "item2"]';
             }
         }
     };


### PR DESCRIPTION
## Summary

- Replace comma-based join/split with JSON serialization for array fields
- Prevents corruption of array items containing commas (JSON, CSV, plain text)
- Update placeholder text to reflect JSON array format

## Root Cause

The spreadsheet editor used comma-based serialization (`value.map(String).join(', ')` and `stringValue.split(',')`) which corrupted any array items containing commas. Simply opening a cell for editing would corrupt in-memory data through two-way binding.

See detailed analysis in #2740.

## ⚠️ Warning

**This is an experimental fix that changes console UX for array-based types.**

Users will now need to enter array values in JSON format (e.g., `["item1", "item2"]`) instead of comma-separated values. This needs careful review to ensure it doesn't negatively impact the user experience for simpler use cases.

Closes #2740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Array input fields now use JSON array format for better data handling and display
  * Updated placeholder guidance for integer, double, boolean, and string array inputs with clear examples of proper JSON formatting syntax
  * Enhanced user experience with clearer input format expectations for array-type fields

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->