### PR TITLE
fix(auth): correct Apple Sign-In documentation link

### DIFF
--- a/src/lib/stores/oauth-providers.ts
+++ b/src/lib/stores/oauth-providers.ts
@@ -27,7 +27,7 @@ export const oAuthProviders: Record<string, Provider> = {
     apple: {
         name: 'Apple',
         icon: 'apple',
-        docs: 'https://developer.apple.com/',
+        docs: 'https://developer.apple.com/sign-in-with-apple/',
         component: Apple
     },
     auth0: {


### PR DESCRIPTION
What does this PR do?

This PR fixes an incorrect documentation link shown in Auth → Settings → Apple.
Previously, the “click here” link redirected users to the generic Apple Developer homepage, which did not provide guidance for configuring Sign in with Apple.

The link has been updated to point directly to the official Sign in with Apple documentation so developers can easily follow the correct setup steps.

Test Plan

Open an Appwrite project.

Navigate to Auth → Settings.

Select Apple as the authentication provider.

Click the “click here” documentation link shown in the information message.

Verify that the link opens the Sign in with Apple integration documentation, not the generic Apple Developer homepage.

Tested on:

Appwrite Cloud

Appwrite v1.5.x

No regressions observed.

Related PRs and Issues

Fixes: https://github.com/appwrite/appwrite/issues/1072

fixes
#1072 

Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)
?

Yes, I have read and followed the contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Apple OAuth provider documentation link to point to a more specific resource for Sign in with Apple.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->