### PR TITLE
fix(dashboard): correct user/team prefs deletion and binding issues

### DIFF
--- a/src/lib/helpers/prefs.ts
+++ b/src/lib/helpers/prefs.ts
@@ -2,12 +2,10 @@ export type PrefRow = { key: string; value: string };
 
 export function normalizePrefs(entries: [string, string][] | PrefRow[]): [string, string][] {
     return entries
-    .map((item): [string, string] =>
-        Array.isArray(item)
-            ? [item[0], item[1]]
-            : [item.key, item.value]
-    )
-    
+        .map((item): [string, string] =>
+            Array.isArray(item) ? [item[0], item[1]] : [item.key, item.value]
+        )
+
         .filter(([k, v]) => k.trim() && v.trim())
         .sort(([a], [b]) => a.localeCompare(b));
 }

--- a/src/routes/(console)/project-[region]-[project]/auth/teams/team-[team]/updatePrefs.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/teams/team-[team]/updatePrefs.svelte
@@ -13,8 +13,12 @@
     import { page } from '$app/state';
     import deepEqual from 'deep-equal';
     import type { PrefRow } from '$lib/helpers/prefs';
-    import { normalizePrefs, createPrefRow, isAddDisabled, sanitizePrefs } from '$lib/helpers/prefs';
-
+    import {
+        normalizePrefs,
+        createPrefRow,
+        isAddDisabled,
+        sanitizePrefs
+    } from '$lib/helpers/prefs';
 
     $: if (prefs) {
         const currentNormalized = normalizePrefs(prefs);

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updatePrefs.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updatePrefs.svelte
@@ -13,8 +13,12 @@
     import { page } from '$app/state';
     import deepEqual from 'deep-equal';
     import type { PrefRow } from '$lib/helpers/prefs';
-    import { normalizePrefs, createPrefRow, isAddDisabled, sanitizePrefs } from '$lib/helpers/prefs';
-
+    import {
+        normalizePrefs,
+        createPrefRow,
+        isAddDisabled,
+        sanitizePrefs
+    } from '$lib/helpers/prefs';
 
     $: if (prefs) {
         const currentNormalized = normalizePrefs(prefs);


### PR DESCRIPTION
What does this PR do?

This PR fixes incorrect behavior when deleting user/team preferences from the Appwrite Dashboard.

Previously, deleting the first or last preference caused:

Fake deletion by inserting an empty key-value pair (['', ''])

Serialization into { "": "" }, corrupting stored preferences

Update button not enabling correctly

Preferences appearing again after refresh

Ghost bindings due to index-based bind:value in Svelte

This PR resolves the issue by:

Replacing tuple-based prefs with a stable PrefRow { id, key, value } structure

Removing fake deletion logic and deleting preference rows for real

Fixing Svelte binding issues by removing bind:value on array indices

Using immutable updates and stable keys in {#each}

Sanitizing preferences before saving (filtering empty keys/values)

Explicitly sending {} when no preferences remain

Normalizing preference comparison so deletions are detected correctly

No backend or SDK behavior was changed.

Test Plan

Manually verified using the Appwrite Dashboard:

Open a user and add one or more preferences

Delete the first preference → Update button enables correctly

Click Update → refresh page → preferences remain correct

Delete the last remaining preference → click Update → refresh → prefs are empty

Add, edit, and delete multiple preferences in different orders

Verified no { "": "" } payload is sent in API calls

Verified same behavior for team preferences

Tested on Appwrite Cloud Dashboard.

Related PRs and Issues

Fixes: 
#1458

Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)
?

Yes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Preferences UI now represents entries as editable rows and always shows an editable row when none exist.
  * Inputs update reactively and immutably to prevent stale UI/state issues during edits.
  * Saving persists only sanitized, non-empty key/value pairs so empty preferences are not stored.
  * Add/Remove controls and Add-button disabled state are more predictable, preventing creation of invalid entries.
  * Change detection improved to reduce false "unsaved" indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->