### PR TITLE
Fix CSV import notification staying visible after completion

### DIFF
--- a/src/lib/components/csvImportBox.svelte
+++ b/src/lib/components/csvImportBox.svelte
@@ -37,6 +37,12 @@
      */
     let importItems = $state<ImportItemsMap>(new Map());
 
+    /**
+     * Tracks removal timeouts for completed/failed imports.
+     * Used to prevent memory leaks and race conditions.
+     */
+    let removalTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
     async function showCompletionNotification(database: string, table: string, payload: Payload) {
         const isSuccess = payload.status === 'completed';
         const isError = !isSuccess && !!payload.errors;
@@ -117,11 +123,27 @@
         }
 
         if (status === 'completed' || status === 'failed') {
-            await showCompletionNotification(databaseId, tableId, importData);
+            try {
+                await showCompletionNotification(databaseId, tableId, importData);
+            } finally {
+                const existingTimeout = removalTimeouts.get(importData.$id);
+                if (existingTimeout) {
+                    clearTimeout(existingTimeout);
+                }
+                const timeoutId = setTimeout(() => {
+                    const next = new Map(importItems);
+                    next.delete(importData.$id);
+                    importItems = next;
+                    removalTimeouts.delete(importData.$id);
+                }, 5000);
+                removalTimeouts.set(importData.$id, timeoutId);
+            }
         }
     }
 
     function clear() {
+        removalTimeouts.forEach((timeout) => clearTimeout(timeout));
+        removalTimeouts = new Map();
         importItems = new Map();
     }
 
@@ -187,12 +209,18 @@
                 migrations.migrations.forEach(updateOrAddItem);
             });
 
-        return realtime.forConsole(page.params.region, 'console', (response) => {
+        const unsubscribe = realtime.forConsole(page.params.region, 'console', (response) => {
             if (!response.channels.includes(`projects.${getProjectId()}`)) return;
             if (response.events.includes('migrations.*')) {
                 updateOrAddItem(response.payload as Payload);
             }
         });
+
+        return () => {
+            unsubscribe();
+            removalTimeouts.forEach((timeout) => clearTimeout(timeout));
+            removalTimeouts = new Map();
+        };
     });
 
     let isOpen = $state(true);


### PR DESCRIPTION
## Summary

- Auto-remove completed and failed import notifications after 5 seconds
- Add timeout tracking to prevent memory leaks and race conditions
- Clean up timeouts on component unmount and manual clear

## Related Issue

Fixes appwrite/console#2877

## Test Plan

- [ ] Import a CSV file successfully and verify the notification disappears after 5 seconds
- [ ] Import a CSV file with invalid headers to trigger a failure and verify the notification disappears after 5 seconds
- [ ] Navigate away from the page during an import and return to verify no stale notifications persist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import items that reach completed or failed status now show completion notifications and are automatically removed from the import list after 5 seconds.
  * Improved cleanup on unload and during import clearing to cancel pending removals and prevent memory leaks during repeated CSV import operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->