### PR TITLE
fix: use structuredClone to handle BigInt in conservative stores

### DIFF
--- a/src/lib/helpers/stores.ts
+++ b/src/lib/helpers/stores.ts
@@ -1,5 +1,5 @@
 import { writable, type Writable } from 'svelte/store';
-import { deepClone, objectEntries } from './object';
+import { objectEntries } from './object';
 
 /**
  * Given an object `obj`, returns an object of writable stores for each key in that object.
@@ -16,7 +16,7 @@ export function createConservative<Obj extends Record<string, unknown>>(obj: Obj
         [K in keyof Obj]: Writable<Obj[K]>;
     };
 
-    const history = deepClone(obj);
+    const history = structuredClone(obj);
 
     function listen(input: Obj) {
         objectEntries(input).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- Replace `deepClone` (which uses `JSON.stringify`) with `structuredClone` in `createConservative` to fix BigInt serialization crash
- Integer columns with 64-bit boundary min/max values (BigInt) cause `JSON.stringify` to throw `TypeError: Do not know how to serialize a BigInt`, silently preventing the edit panel from opening

## Before

<img width="1906" height="917" alt="image" src="https://github.com/user-attachments/assets/86cfe5a5-e7c3-4ca5-82f2-b681c126c4f8" />

## After

<img width="1906" height="917" alt="image" src="https://github.com/user-attachments/assets/a224c90b-3270-4377-8c3b-be2cef64d15e" />


## Test plan
- [ ] Open an integer column's edit panel via the three-dot menu "Update" action
- [ ] Verify the edit side sheet opens without errors
- [ ] Confirm column name and other fields can be updated successfully

Fixes appwrite/appwrite#11225