### PR TITLE
fix: Prevent getWorldPosition error in promo shader

### DIFF
--- a/src/lib/components/promos/shader.svelte
+++ b/src/lib/components/promos/shader.svelte
@@ -3,10 +3,7 @@
     import { Uniform, MeshBasicMaterial, Vector2 } from 'three';
     import noise from './threlte/shaders/noise.glsl?raw';
     import { onMount } from 'svelte';
-    import { useViewport } from '@threlte/extras';
-
-    const { invalidate } = useThrelte();
-    const viewport = useViewport();
+    const { invalidate, size } = useThrelte();
 
     let uAspect: Uniform;
     let uOpacity: Uniform;
@@ -14,8 +11,8 @@
     let uViewportSize: Uniform;
 
     $effect(() => {
-        const width = $viewport.width;
-        const height = $viewport.height;
+        const width = $size.width || 1;
+        const height = $size.height || 1;
         if (uAspect) {
             uAspect.value = width / height;
             invalidate();
@@ -30,10 +27,13 @@
     let material = $state<MeshBasicMaterial>(new MeshBasicMaterial());
 
     onMount(() => {
-        uAspect = new Uniform($viewport.width / $viewport.height);
+        const width = $size.width || 1;
+        const height = $size.height || 1;
+
+        uAspect = new Uniform(width / height);
         uOpacity = new Uniform(0);
         uTime = new Uniform(0);
-        uViewportSize = new Uniform(new Vector2($viewport.width, $viewport.height));
+        uViewportSize = new Uniform(new Vector2(width, height));
 
         material.onBeforeCompile = (shader) => {
             shader.uniforms.uTime = uTime;
@@ -104,6 +104,6 @@
 </script>
 
 <T.OrthographicCamera position={[0, 0, 10]} fov={10} near={0.1} far={1000} makeDefault />
-<T.Mesh scale={[$viewport.width, $viewport.height, 1]} {material}>
+<T.Mesh scale={[$size.width || 1, $size.height || 1, 1]} {material}>
     <T.PlaneGeometry args={[1, 1]} />
 </T.Mesh>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
before:
<img width="1495" height="845" alt="image" src="https://github.com/user-attachments/assets/300b8135-1d12-434a-b084-ea196e059e11" />
after: 
<img width="1480" height="752" alt="image" src="https://github.com/user-attachments/assets/f7630844-dfcc-400b-9158-3cc40b5d7d9f" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated shader component's internal sizing mechanism for improved framework compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->