### PR TITLE
fix: make us state selection modal dismissible

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/paymentMethods.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/paymentMethods.svelte
@@ -54,6 +54,7 @@
     let showUpdateState = $state(false);
     let isSelectedBackup = $state(false);
     let paymentMethodNeedingState: Models.PaymentMethod | null = $state(null);
+    let dismissedPaymentMethodIds = $state<string[]>([]);
 
     const hasPaymentError = $derived.by(() => {
         return (
@@ -117,7 +118,8 @@
                 (method: Models.PaymentMethod) =>
                     method?.country?.toLowerCase() === 'us' &&
                     (!method.state || method.state.trim() === '') &&
-                    !!method.last4
+                    !!method.last4 &&
+                    !dismissedPaymentMethodIds.includes(method.$id)
             );
 
             if (usMethodWithoutState) {
@@ -129,6 +131,10 @@
 
     $effect(() => {
         if (!showUpdateState && paymentMethodNeedingState) {
+            dismissedPaymentMethodIds = [
+                ...dismissedPaymentMethodIds,
+                paymentMethodNeedingState.$id
+            ];
             paymentMethodNeedingState = null;
         }
     });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where users would be repeatedly prompted to provide state information for payment methods they had already dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->