### PR TITLE
Replace HelpScout customFields IDs with semantic metaFields

### DIFF
--- a/src/lib/stores/feedback.ts
+++ b/src/lib/stores/feedback.ts
@@ -105,8 +105,6 @@ function createFeedbackStore() {
                 return feedback;
             });
         },
-        // TODO: update growth server to accept `billingPlan`.
-        // TODO: update growth server to accept `source` key to know the feedback source area.
         submitFeedback: async (
             subject: string,
             message: string,
@@ -122,18 +120,6 @@ function createFeedbackStore() {
             if (!VARS.GROWTH_ENDPOINT) return;
             trackEvent(Submit.FeedbackSubmit);
 
-            const customFields: Array<{ id: string; value: string | number }> = [
-                { id: '47364', value: currentPage }
-            ];
-
-            if (value) {
-                customFields.push({ id: '40655', value });
-            }
-
-            if (billingPlan) {
-                customFields.push({ id: '56109', value: billingPlan });
-            }
-
             const response = await fetch(`${VARS.GROWTH_ENDPOINT}/feedback`, {
                 method: 'POST',
                 headers: {
@@ -143,9 +129,11 @@ function createFeedbackStore() {
                     subject,
                     message,
                     email,
-                    customFields,
                     firstname: (name || 'Unknown').slice(0, 40),
                     metaFields: {
+                        currentPage,
+                        npsScore: value,
+                        billingPlan,
                         source: get(feedback).source,
                         orgId,
                         projectId,

--- a/src/routes/(console)/organization-[organization]/settings/BAAModal.svelte
+++ b/src/routes/(console)/organization-[organization]/settings/BAAModal.svelte
@@ -67,13 +67,11 @@
                 firstName: ($user?.name ?? '').slice(0, 40),
                 message: `BAA request for ${$organization?.name ?? ''} (${$organization?.$id ?? ''})`,
                 tags: ['cloud'],
-                customFields: [
-                    { id: '41612', value: 'BAA' },
-                    { id: '48493', value: $user?.name ?? '' },
-                    { id: '48492', value: $organization?.$id ?? '' },
-                    { id: '48490', value: $user?.$id ?? '' }
-                ],
                 metaFields: {
+                    category: 'BAA',
+                    userName: $user?.name ?? '',
+                    orgId: $organization?.$id ?? '',
+                    userId: $user?.$id ?? '',
                     employees: employees,
                     country: country,
                     role: role,

--- a/src/routes/(console)/organization-[organization]/settings/Soc2Modal.svelte
+++ b/src/routes/(console)/organization-[organization]/settings/Soc2Modal.svelte
@@ -68,13 +68,11 @@
                 firstName: ($user?.name ?? '').slice(0, 40),
                 message: `SOC-2 request for ${$organization?.name ?? ''} (${$organization?.$id ?? ''})`,
                 tags: ['cloud'],
-                customFields: [
-                    { id: '41612', value: 'SOC-2' },
-                    { id: '48493', value: $user?.name ?? '' },
-                    { id: '48492', value: $organization?.$id ?? '' },
-                    { id: '48490', value: $user?.$id ?? '' }
-                ],
                 metaFields: {
+                    category: 'SOC-2',
+                    userName: $user?.name ?? '',
+                    orgId: $organization?.$id ?? '',
+                    userId: $user?.$id ?? '',
                     employees: employees,
                     country: country,
                     role: role,

--- a/src/routes/(console)/supportWizard.svelte
+++ b/src/routes/(console)/supportWizard.svelte
@@ -136,14 +136,14 @@
         formData.append('message', $supportData.message);
         formData.append('tags[]', categoryTopicTag);
         formData.append(
-            'customFields',
-            JSON.stringify([
-                { id: '41612', value: $supportData.category },
-                { id: '48492', value: $organization?.$id ?? '' },
-                { id: '48491', value: $supportData?.project ?? '' },
-                { id: '56023', value: $supportData?.severity ?? '' },
-                { id: '56024', value: $organization?.billingPlanId ?? '' }
-            ])
+            'metaFields',
+            JSON.stringify({
+                category: $supportData.category,
+                orgId: $organization?.$id ?? '',
+                projectId: $supportData?.project ?? '',
+                severity: $supportData?.severity ?? '',
+                billingPlan: $organization?.billingPlanId ?? ''
+            })
         );
         if (files && files.length > 0) {
             formData.append('attachment', files[0]);


### PR DESCRIPTION
## Summary
- Removed all raw HelpScout custom field IDs (`41612`, `48492`, `48491`, `56023`, etc.) from frontend API calls
- All `VARS.GROWTH_ENDPOINT` calls now use `metaFields` with semantic key names instead of `customFields` with provider-specific IDs
- The backend (growth server) handles mapping named keys to HelpScout field IDs

### Files changed
- **`supportWizard.svelte`** — replaced `customFields` with `metaFields`: `category`, `orgId`, `projectId`, `severity`, `billingPlan`
- **`feedback.ts`** — removed `customFields`, merged into `metaFields`: `currentPage`, `npsScore`, `billingPlan` (alongside existing `source`, `orgId`, `projectId`, `userId`). Removed resolved TODOs.
- **`Soc2Modal.svelte`** — removed `customFields`, merged into `metaFields`: `category`, `userName`, `orgId`, `userId`
- **`BAAModal.svelte`** — same as SOC-2

### Companion PR
- Growth server: https://github.com/appwrite-labs/growth/pull/186 (deploy backend first, it has backward compatibility)

## Test plan
- [ ] Submit a support ticket via the support wizard and verify it creates a HelpScout conversation with correct custom fields
- [ ] Submit feedback and verify HelpScout fields (currentPage, npsScore, billingPlan) are populated
- [ ] Submit SOC-2 and BAA requests and verify all fields appear in HelpScout
- [ ] Verify file attachments still work in the support wizard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal data handling in feedback submission, Business Associate Agreement requests, SOC2 compliance requests, and support wizard for improved consistency and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->