### PR TITLE
Render text/mediumtext/longtext (and large varchar) as textarea

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
@@ -43,6 +43,12 @@
 
     const nullable = $derived(!limited ? !column.required : false);
     const columnSize = $derived('size' in column ? column.size : 0);
+    const forceTextarea = $derived(
+        column.type === 'text' ||
+            column.type === 'mediumtext' ||
+            column.type === 'longtext' ||
+            (column.type === 'varchar' && columnSize > 255)
+    );
 
     let stringValue = $state('');
 
@@ -148,7 +154,7 @@
     };
 </script>
 
-{#if columnSize >= 50 || array || isSpatialType(column)}
+{#if forceTextarea || columnSize >= 50 || array || isSpatialType(column)}
     <InputTextarea
         {id}
         {label}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
@@ -47,7 +47,7 @@
         column.type === 'text' ||
             column.type === 'mediumtext' ||
             column.type === 'longtext' ||
-            (column.type === 'varchar' && columnSize > 255)
+            column.type === 'varchar'
     );
 
     let stringValue = $state('');

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
@@ -46,8 +46,7 @@
     const forceTextarea = $derived(
         column.type === 'text' ||
             column.type === 'mediumtext' ||
-            column.type === 'longtext' ||
-            column.type === 'varchar'
+            column.type === 'longtext'
     );
 
     let stringValue = $state('');

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/string.svelte
@@ -44,9 +44,7 @@
     const nullable = $derived(!limited ? !column.required : false);
     const columnSize = $derived('size' in column ? column.size : 0);
     const forceTextarea = $derived(
-        column.type === 'text' ||
-            column.type === 'mediumtext' ||
-            column.type === 'longtext'
+        column.type === 'text' || column.type === 'mediumtext' || column.type === 'longtext'
     );
 
     let stringValue = $state('');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Textarea inputs now automatically display for text-like columns (text, mediumtext, longtext) regardless of declared size, in addition to existing rules for large column sizes, arrays, and spatial types—making editing long-form text fields more convenient and consistent across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->