### PR TITLE
fix: handle non-string user/team prefs to prevent Preferences UI crash

### DIFF
--- a/src/lib/helpers/prefs.ts
+++ b/src/lib/helpers/prefs.ts
@@ -1,12 +1,19 @@
 export type PrefRow = { key: string; value: string };
 
-export function normalizePrefs(entries: [string, string][] | PrefRow[]): [string, string][] {
+function stringTrim(s: unknown): string {
+    return String(s ?? '').trim();
+}
+
+export function normalizePrefs(
+    entries: [string, unknown][] | PrefRow[] | { key: unknown; value: unknown }[]
+): [string, string][] {
     return entries
         .map((item): [string, string] =>
-            Array.isArray(item) ? [item[0], item[1]] : [item.key, item.value]
+            Array.isArray(item)
+                ? [String(item[0] ?? ''), String(item[1] ?? '')]
+                : [String(item.key ?? ''), String(item.value ?? '')]
         )
-
-        .filter(([k, v]) => k.trim() && v.trim())
+        .filter(([k, v]) => stringTrim(k).length > 0 && stringTrim(v).length > 0)
         .sort(([a], [b]) => a.localeCompare(b));
 }
 
@@ -23,5 +30,5 @@ export function isAddDisabled(prefs: PrefRow[] | null): boolean {
 }
 
 export function sanitizePrefs(prefs: PrefRow[]) {
-    return prefs.filter((p) => p.key.trim() && p.value.trim());
+    return prefs.filter((p) => stringTrim(p.key).length > 0 && stringTrim(p.value).length > 0);
 }

--- a/src/routes/(console)/project-[region]-[project]/auth/teams/team-[team]/updatePrefs.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/teams/team-[team]/updatePrefs.svelte
@@ -22,9 +22,7 @@
 
     $: if (prefs) {
         const currentNormalized = normalizePrefs(prefs);
-        const originalNormalized = normalizePrefs(
-            Object.entries(($team?.prefs ?? {}) as Record<string, string>)
-        );
+        const originalNormalized = normalizePrefs(Object.entries($team?.prefs ?? {}));
 
         arePrefsDisabled = deepEqual(currentNormalized, originalNormalized);
     }
@@ -33,10 +31,12 @@
     let arePrefsDisabled = true;
 
     onMount(async () => {
-        const entries = Object.entries(($team?.prefs ?? {}) as Record<string, string>);
+        const entries = Object.entries($team?.prefs ?? {});
         prefs =
             entries.length > 0
-                ? entries.map(([key, value]) => createPrefRow(key, value))
+                ? entries.map(([key, value]) =>
+                      createPrefRow(String(key ?? ''), String(value ?? ''))
+                  )
                 : [createPrefRow()];
     });
 

--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updatePrefs.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updatePrefs.svelte
@@ -34,7 +34,9 @@
         const entries = Object.entries($user?.prefs ?? {});
         prefs =
             entries.length > 0
-                ? entries.map(([key, value]) => createPrefRow(key, value))
+                ? entries.map(([key, value]) =>
+                      createPrefRow(String(key ?? ''), String(value ?? ''))
+                  )
                 : [createPrefRow()];
     });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced preference handling utilities with improved input flexibility and consistent string normalization for preference keys and values across management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->