### PR TITLE
fix: update site/function execution duration to not count while waiting

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/table.svelte
@@ -117,7 +117,7 @@
                                 </span>
                             </Tooltip>
                         {:else if column.id === 'duration'}
-                            {#if ['processing', 'waiting'].includes(log.status)}
+                            {#if log.status === ExecutionStatus.Processing}
                                 <span use:timer={{ start: log.$createdAt }}></span>
                             {:else}
                                 {calculateTime(log.duration)}

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/logs/table.svelte
@@ -6,7 +6,7 @@
         MultiSelectionTable
     } from '$lib/components';
     import type { Column } from '$lib/helpers/types';
-    import type { Models } from '@appwrite.io/console';
+    import { ExecutionStatus, type Models } from '@appwrite.io/console';
     import { Badge, Table, Typography } from '@appwrite.io/pink-svelte';
     import Sheet from './sheet.svelte';
     import DualTimeView from '$lib/components/dualTimeView.svelte';
@@ -83,7 +83,7 @@
                                 {log.requestMethod}
                             </Typography.Code>
                         {:else if column.id === 'duration'}
-                            {#if ['processing', 'waiting'].includes(log.status)}
+                            {#if log.status === ExecutionStatus.Processing}
                                 <span use:timer={{ start: log.$createdAt }}></span>
                             {:else}
                                 {calculateTime(log.duration)}


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

We don't charge people for executions in waiting so having that timer would just make people worry.

The final duration does not include the waiting time so if it's waiting for 5s and then execution takes 20ms, the user will see the duration go from 5s to 20ms which is confusing.

## Test Plan

Manual

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes