### PR TITLE
fix(console): prevent framework cards overflow on small screens

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
@@ -496,5 +496,9 @@ APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).c
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         gap: var(--gap-l, 16px);
+
+        @media (max-width: 900px) {
+            grid-template-columns: repeat(2, 1fr);
+        }
     }
 </style>


### PR DESCRIPTION
## What does this PR do? 

Fixes [[Issue #2889](https://github.com/appwrite/console/issues/2889)](https://github.com/appwrite/console/issues/2889) — framework selection cards overflowing on smaller screens. The grid now adjusts responsively to prevent content overflow.

---

## Problem Description ❌

The framework selection grid in the Web platform wizard was hardcoded to:

```css
grid-template-columns: repeat(3, 1fr);
```

On smaller screens, this caused the card content to overflow and compress excessively.

---

## Solution ✅

Added a responsive breakpoint at `900px` to switch the grid to 2 columns:

```scss
@media (max-width: 900px) {
  grid-template-columns: repeat(2, 1fr);
}
```

This ensures cards remain readable and the layout stays consistent on smaller viewports.

---

## Screenshots 📸

Before the fix:

<img width="376" height="678" alt="Screenshot 2026-02-26 220730" src="https://github.com/user-attachments/assets/f181d1d2-fb02-4a29-afe0-a99ee1637af6" />

After the fix:
<img width="366" height="696" alt="Screenshot 2026-02-26 220708" src="https://github.com/user-attachments/assets/7ae885f0-ff0f-44d3-80aa-17ed3a0f2b72" />

---


## Notes 📝

* Tested on mobile and smaller screen widths.
* No new dependencies introduced.
* Related issue: [[#2889](https://github.com/appwrite/console/issues/2889)](https://github.com/appwrite/console/issues/2889)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the frameworks grid in the platform creation interface. Grid layout now adapts from three columns to two columns on screens 900px wide or smaller for enhanced usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->