### PR TITLE
Fix tab selection issue in Integrations section (#2893)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/+layout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/+layout.svelte
@@ -222,23 +222,25 @@
         <Layout.Stack gap="xl">
             <Typography.Title>Integrations</Typography.Title>
             <Layout.Stack gap="xl" direction="row" justifyContent="space-between">
-                <Tabs>
-                    <Tab
-                        noscroll
-                        event="platforms"
-                        href={`${path}/platforms`}
-                        selected={isTabSelected('platforms')}>Platforms</Tab>
-                    <Tab
-                        noscroll
-                        event="api-keys"
-                        href={`${path}/api-keys`}
-                        selected={isTabSelected('api-keys')}>API keys</Tab>
-                    <Tab
-                        noscroll
-                        event="dev-keys"
-                        href={`${path}/dev-keys`}
-                        selected={isTabSelected('dev-keys')}>Dev keys</Tab>
-                </Tabs>
+                {#key page.url.pathname}
+                    <Tabs>
+                        <Tab
+                            noscroll
+                            event="platforms"
+                            href={`${path}/platforms`}
+                            selected={isTabSelected('platforms')}>Platforms</Tab>
+                        <Tab
+                            noscroll
+                            event="api-keys"
+                            href={`${path}/api-keys`}
+                            selected={isTabSelected('api-keys')}>API keys</Tab>
+                        <Tab
+                            noscroll
+                            event="dev-keys"
+                            href={`${path}/dev-keys`}
+                            selected={isTabSelected('dev-keys')}>Dev keys</Tab>
+                    </Tabs>
+                {/key}
                 {#if $action}
                     <svelte:component this={$action} />
                 {/if}


### PR DESCRIPTION
### What I did

Fixed the issue https://github.com/appwrite/console/issues/2893 where the Integrations tabs always highlighted the default Platforms tab, regardless of which tab was clicked.

Wrapped the <Tabs> component with a {#key page.url.pathname} block to ensure Svelte properly re-renders the active tab when the URL changes.

Updated the selected attribute for each <Tab> to use the isTabSelected function consistently, ensuring the correct tab is highlighted immediately upon click.


### Issue

**Bug**: The Integrations tabs were not visually responsive to user selection.
Reproduction:

Go to Personal projects.

Click on a project.

Scroll down to the Integrations section.

Click any tab — the content updates correctly, but the tab highlight always stays on Platforms.

Expected behavior: The clicked tab should be highlighted.
Actual behavior: The default tab (Platforms) is always highlighted, even when another tab is active.

### How I fixed it

Added a {#key page.url.pathname} block around the <Tabs> component to force Svelte to re-render the tab set when the route changes.

Ensured the selected state is correctly evaluated for each tab using isTabSelected(event).


### Before the fix:

https://github.com/user-attachments/assets/b8a10f79-b9e7-48b1-b103-667b62874da0

### After the fix:

https://github.com/user-attachments/assets/028035be-733a-4c6a-b369-8158afc06391



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where navigation tabs were not properly resetting their state when moving between different pages in the console, ensuring a cleaner browsing experience with correct tab selection on each page visit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->