### PR TITLE
fix: correct Web Template frameworks order (#2895)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/+page.ts
@@ -37,6 +37,7 @@ export const load = async ({ url, params }) => {
         'Angular',
         'Analog',
         'Vite',
+        'React Native',
         'Other'
     ];
 


### PR DESCRIPTION
### What I did

Ensured that the “Other” option always appears last and React Native appears in the correct position by adding 'React Native' item in the correct order to the array of frameworkOrder.

### Issue

**Bug**: In the Web Template creation flow, the frameworks dropdown was displaying React Native as the last item and Other as the second last, which is confusing for users https://github.com/appwrite/console/issues/2895 .

### Reproduction Steps:

Go to Create Project → Access a project.

Click on Create Site.

Choose Clone a Template.

Observe the frameworks dropdown — the last framework is React Native, and the second last is Other.

### Expected Behavior:

Other should always be the last item in the frameworks list.

### Actual Behavior:

React Native appears last, and Other is second last.

### Before the fix:
<img width="1560" height="846" alt="react-native-order-before" src="https://github.com/user-attachments/assets/9a8170e0-bc7f-4742-9003-237ad5bea981" />

### After :

<img width="1568" height="866" alt="react-native-order-after" src="https://github.com/user-attachments/assets/664c238d-4541-4010-b568-12594c5ce98f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added React Native as a framework option when creating new sites with templates. This enables developers to select React Native alongside other available frameworks during the site creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->