### PR TITLE
fix: prevent sending empty title or body in push messages

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
@@ -36,6 +36,13 @@
     let scheduledAt: string;
 
     async function create() {
+        if (!title?.trim() || !body?.trim()) {
+            addNotification({
+                type: 'error',
+                 message: 'Title and message body cannot be empty.'
+         });
+         return;
+        }
         try {
             const messageId = id || ID.unique();
             const fileCompoundId = file ? `${file.bucketId}:${file.$id}` : undefined;

--- a/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
@@ -36,7 +36,7 @@
     let scheduledAt: string;
 
     async function create() {
-        if (!title?.trim() || !body?.trim()) {
+        if (!draft && (!title?.trim() || !body?.trim())) {
             addNotification({
                 type: 'error',
                  message: 'Title and message body cannot be empty.'

--- a/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
@@ -36,13 +36,23 @@
     let scheduledAt: string;
 
     async function create() {
-        if (!draft && (!title?.trim() || !body?.trim())) {
+        const isDraft = draft;
+        draft = false;
+
+        const trimmedTitle = title?.trim() ?? '';
+        const trimmedBody = body?.trim() ?? '';
+
+        if (!isDraft && (!trimmedTitle || !trimmedBody)) {
             addNotification({
                 type: 'error',
-                 message: 'Title and message body cannot be empty.'
-         });
-         return;
+                message: 'Title and message body cannot be empty.'
+            });
+            return;
         }
+
+        title = trimmedTitle;
+        body = trimmedBody;
+
         try {
             const messageId = id || ID.unique();
             const fileCompoundId = file ? `${file.bucketId}:${file.$id}` : undefined;
@@ -63,7 +73,7 @@
                     targets,
                     data: customData,
                     image: fileCompoundId,
-                    draft,
+                    draft: isDraft,
                     scheduledAt
                 });
 

--- a/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/create-[type]/(type)/push.svelte
@@ -50,8 +50,8 @@
             return;
         }
 
-        title = trimmedTitle;
-        body = trimmedBody;
+        if (title !== undefined) title = trimmedTitle;
+        if (body !== undefined) body = trimmedBody;
 
         try {
             const messageId = id || ID.unique();


### PR DESCRIPTION
## What does this PR do?

Fixes #968

Adds validation to prevent sending push messages when the title or body contains only whitespace.

The inputs are trimmed before submission, and if either field is empty an error notification is shown to the user.

## Test Plan

1. Open the Messaging section in the console
2. Try creating a push message with only spaces in the title or body
3. The system now prevents submission and shows an error notification

## Related Issues

Fixes #968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Push notification creation now trims title and body and validates they are not empty, showing an immediate error if required fields are missing.
  * Draft status is preserved correctly during submission so submissions reflect the intended draft setting; success and error flows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->