### PR TITLE
fix: hide placeholder when tags exist in allowed file extensions input

### DIFF
--- a/src/lib/elements/forms/inputTags.svelte
+++ b/src/lib/elements/forms/inputTags.svelte
@@ -35,7 +35,7 @@
 <Input.Tags
     {label}
     {id}
-    {placeholder}
+    placeholder={tags.length ? '' : placeholder}
     {disabled}
     {pattern}
     {required}


### PR DESCRIPTION
## What does this PR do?
Fixes the placeholder behavior in the allowed file extensions input.

Previously, when users added file extensions (tags), the placeholder text shifted to the right instead of disappearing. This change hides the placeholder once tags exist, ensuring consistent input behavior.

## Test Plan
1. Go to Storage → Bucket → Settings
2. Add file extensions (e.g. mp4, jpg, pdf)
3. The placeholder should disappear instead of shifting to the right.

## Related Issues
Fixes #1018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the input tags component behavior. The placeholder text now hides when tags are present, providing a cleaner and more intuitive user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->