### PR TITLE
refactor: remove inline styling from list.svelte

### DIFF
--- a/src/lib/components/list.svelte
+++ b/src/lib/components/list.svelte
@@ -1,4 +1,9 @@
-<!-- TODO: remove inline styling -->
-<ul class="list" style:gap="0.25rem">
+<ul class="list">
     <slot />
 </ul>
+
+<style>
+.list {
+    gap: 0.25rem;
+}
+</style>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Removes inline styling from the `list.svelte` component by moving the `gap` property into the component CSS block.

## Why is this change needed?

Inline styles reduce maintainability and go against the project's styling conventions. This change also resolves the TODO comment in the file.

## Test Plan

UI rendering remains unchanged. Only styling structure was updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored internal styling approach for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->