### PR TITLE
fix: remove unsupported Query.select causing invalid queries param (#2916)

### DIFF
--- a/src/routes/(console)/+layout.ts
+++ b/src/routes/(console)/+layout.ts
@@ -51,8 +51,7 @@ export const load: LayoutLoad = async ({ depends, parent }) => {
                 await sdk.forConsole.projects.list({
                     queries: [
                         Query.equal('teamId', currentOrgId),
-                        Query.limit(1),
-                        Query.select(['$id'])
+                        Query.limit(1)
                     ]
                 })
             ).total;

--- a/src/routes/(console)/organization-[organization]/createProject.svelte
+++ b/src/routes/(console)/organization-[organization]/createProject.svelte
@@ -36,7 +36,11 @@
             });
             show = false;
             dispatch('created', project);
-            await invalidate(Dependencies.ORGANIZATION);
+            try {
+                await invalidate(Dependencies.ORGANIZATION);
+            } catch (invalidateError) {
+                trackError(invalidateError, Submit.ProjectCreate);
+            }
             trackEvent(Submit.ProjectCreate, {
                 customId: !!id,
                 teamId

--- a/src/routes/(console)/organization-[organization]/createProject.svelte
+++ b/src/routes/(console)/organization-[organization]/createProject.svelte
@@ -10,6 +10,8 @@
     import { IconPencil } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Tag } from '@appwrite.io/pink-svelte';
     import { createEventDispatcher } from 'svelte';
+    import { invalidate } from '$app/navigation';
+    import { Dependencies } from '$lib/constants';
 
     export let show = false;
     export let teamId: string;
@@ -34,6 +36,7 @@
             });
             show = false;
             dispatch('created', project);
+            await invalidate(Dependencies.ORGANIZATION);
             trackEvent(Submit.ProjectCreate, {
                 customId: !!id,
                 teamId


### PR DESCRIPTION
## What does this PR do?

Fixes the "Invalid queries param: Invalid query method: select" error when listing projects.

This occurs because `Query.select()` is not supported for the `/projects` endpoint in Appwrite 1.8.

## Changes

- Removed unsupported `Query.select(['$id'])` from the projects query in `+layout.ts`
- Added `invalidate(Dependencies.ORGANIZATION)` after project creation to refresh the project list so the new project appears immediately

## Related Issue

Closes #2916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created projects now appear immediately in the project list without requiring a manual refresh.

* **Improvements**
  * Added an automatic refresh of organization data after project creation with graceful error handling to ensure tracking and user flow continue even if the refresh fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->