### PR TITLE
chore: Suggest `npm ci` instead of `npm install`

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/deploy/+page.svelte
@@ -239,7 +239,7 @@
                         id="installCommand"
                         name="installCommand"
                         bind:value={installCommand}
-                        placeholder="e.g., npm install" />
+                        placeholder="e.g., npm ci" />
                 </Layout.Stack>
             </Fieldset>
 

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/configuration.svelte
@@ -16,7 +16,7 @@
                     id="installCommand"
                     label="Install command"
                     bind:value={buildCommand}
-                    placeholder="npm install" />
+                    placeholder="npm ci" />
             </Layout.Stack>
         </Accordion>
         <Accordion title="Execute access" badge="Optional" hideDivider>

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/configuration.svelte
@@ -20,7 +20,7 @@
                     id="installCommand"
                     label="Install command"
                     bind:value={buildCommand}
-                    placeholder="npm install" />
+                    placeholder="npm ci" />
             </Layout.Stack>
         </Accordion>
         <Accordion title="Execute access" badge="Optional" hideDivider>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildCommand.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildCommand.svelte
@@ -63,7 +63,7 @@
             <InputText
                 label="Build command"
                 id="buildCommand"
-                placeholder="npm install"
+                placeholder="npm ci"
                 bind:value={buildCommand} />
         </svelte:fragment>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
@@ -266,7 +266,7 @@
                 <Layout.Stack gap="m">
                     <Input.Text
                         label="Install command"
-                        placeholder={installCommand || 'npm install'}
+                        placeholder={installCommand || 'npm ci'}
                         bind:value={installCommand} />
                     <Input.Text
                         label="Build command"


### PR DESCRIPTION
Towards SER-1176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated placeholder text for installation command input fields across project function and site deployment interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->