### PR TITLE
Enhance rule_not_found page with clearer domain error message

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -9,7 +9,7 @@
     <Layout.Stack gap="l" alignItems="center">
         <Badge variant="secondary" content="404 Page not found" />
         <Typography.Title size="l" align="center">
-            The page you're looking for doesn't exist.
+            The domain you are trying to access is not configured in Appwrite. Please verify the URL or contact the administrator.
         </Typography.Title>
         <Button href={base}>Back to console</Button>
     </Layout.Stack>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script>
     import { base } from '$app/paths';
+    import { page } from '$app/stores';
     import { Unauthenticated } from '$lib/layout';
     import { Button } from '$lib/elements/forms';
     import { Badge, Typography, Layout } from '@appwrite.io/pink-svelte';
@@ -8,9 +9,17 @@
 <Unauthenticated>
     <Layout.Stack gap="l" alignItems="center">
         <Badge variant="secondary" content="404 Page not found" />
+
         <Typography.Title size="l" align="center">
-            The domain you are trying to access is not configured in Appwrite. Please verify the URL or contact the administrator.
+            {#if $page.error && $page.error.message && $page.error.message.includes('rule_not_found')}
+                The domain you are trying to access is not configured in Appwrite.
+
+                Please verify the URL or contact the administrator.
+            {:else}
+                {$page.error?.message || "The page you're looking for doesn't exist."}
+            {/if}
         </Typography.Title>
+
         <Button href={base}>Back to console</Button>
     </Layout.Stack>
 </Unauthenticated>


### PR DESCRIPTION
- Updated the fallback "rule_not_found" page with a clearer and more informative message
- Clarifies that the domain is not configured in Appwrite
- Improves user experience by providing better guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error page now shows clearer domain-configuration guidance instead of a generic 404 when applicable; otherwise it displays the underlying error message for more accurate troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->