### PR TITLE
fix: allow typing in relationship input field

### DIFF
--- a/src/lib/elements/forms/inputSelect.svelte
+++ b/src/lib/elements/forms/inputSelect.svelte
@@ -11,14 +11,7 @@
     export let placeholder = '';
     export let required = false;
     export let disabled = false;
-    export let options: {
-        value: string | boolean | number | null;
-        label: string;
-        disabled?: boolean;
-        leadingIcon?: ComponentType;
-        leadingHtml?: string;
-        badge?: string;
-    }[];
+    
     export let leadingIcon: ComponentType | undefined = undefined;
 
     let error: string;
@@ -44,22 +37,19 @@
     }
 </script>
 
-<Input.Select
-    {id}
-    {label}
-    {options}
-    {optionalText}
-    {placeholder}
-    {disabled}
-    {autofocus}
-    {leadingIcon}
-    helper={error ?? helper}
-    {required}
-    state={error ? 'error' : 'default'}
-    data-command-center-ignore
-    on:invalid={handleInvalid}
-    on:input
-    on:change
-    bind:value>
+<Input
+  {id}
+  {label}
+  {placeholder}
+  {disabled}
+  {autofocus}
+  {leadingIcon}
+  helper={error ?? helper}
+  {required}
+  state={error ? 'error' : 'default'}
+  data-command-center-ignore
+  on:invalid={handleInvalid}
+  on:input={(e) => value = e.target.value}
+  bind:value>
     <slot name="info" slot="info" />
-</Input.Select>
+</Input>


### PR DESCRIPTION
This fixes the issue where users were unable to type or paste values into the relationship field.

Previously, the component used `Input.Select`, which restricted input to a dropdown-only section. This prevented manual entry of IDs.

This PR replaces `Input.Select` with  `Input`, restoring the ability to type and paste values, matching the behaviour before v6.

##Changes:
- Replaced `Input-Select` with `Input`
- Removed unused `options` prop
- Enabled manual input handling

##Issue
Closes #2119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the input select component to use a generic input field instead of a specialized select component, removing options configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->