### PR TITLE
Fix float document editor step validation

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/integer.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/types/integer.svelte
@@ -7,10 +7,13 @@
     export let label: string;
     export let value: number;
     export let limited: boolean = false;
-    export let column: Models.ColumnInteger;
+    export let column: Models.ColumnInteger | Models.ColumnFloat;
+
+    const FLOAT_INPUT_STEP = 0.001;
 
     $: autofocus = limited;
     $: nullable = !limited ? !column.required : false;
+    $: isDecimalColumn = ['double', 'float'].includes(column.type as string);
     $: if (limited) {
         label = undefined;
     }
@@ -25,5 +28,5 @@
     min={column.min}
     max={column.max}
     required={column.required}
-    step={column.type === 'double' ? 'any' : 1}
+    step={isDecimalColumn ? FLOAT_INPUT_STEP : 1}
     leadingIcon={!limited ? IconHashtag : undefined} />


### PR DESCRIPTION
## What does this PR do?

Fixes float input validation in the row/document editor by using an explicit decimal step for float fields.

## Test Plan



Code-path verification:
- updated the row/document editor numeric input path
- float/double fields now use `step={0.001}`
- integer fields still use `step={1}`

Expected behavior:
- values like `1.23` should no longer fail browser step validation in the document editor

## Related PRs and Issues

Fixes #11657

## Have you read the Contributing Guidelines on issues?

Yes.
