### PR TITLE
fix: prevent TypeError when updating relationship attribute

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/edit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/edit.svelte
@@ -53,6 +53,9 @@
 
     export async function submit() {
         try {
+            if (!option?.update) {
+                throw new Error('Unsupported column type');
+            }
             await option.update(databaseId, tableId, selectedColumn, originalKey);
             await invalidate(Dependencies.TABLE);
 
@@ -103,7 +106,7 @@
 
     // TODO: @itznotabug - runes?
     $: onShow(showEdit);
-    $: title = `Update ${columnOptions.find((v) => v.name === option.name)?.sentenceName ?? ''} column`;
+    $: title = `Update ${option ? (columnOptions.find((v) => v.name === option.name)?.sentenceName ?? '') : ''} column`;
 
     function onShow(show: boolean) {
         if (show) {


### PR DESCRIPTION
## Summary

Fixes an uncaught TypeError that crashes the console when clicking "Update" on a relationship attribute from the three-dots menu in the columns list.

**Root cause:** Two places in `edit.svelte` access the `option` variable without null checks:

1. **Line 106** — The reactive title statement `option.name` throws `TypeError: Cannot read property 'name' of undefined` when the `columnOptions.find()` on line 37-52 doesn't match the selected column type
2. **Line 56** — `option.update()` would also crash if called when `option` is undefined

**Fix:**
- Add a null guard on the title derivation: check `option` is defined before accessing `.name`
- Add a null guard in `submit()`: throw a descriptive error ("Unsupported column type") instead of crashing with an unhandled TypeError

Fixes appwrite/appwrite#9951

## Test plan

- [ ] Go to a database collection with a relationship attribute
- [ ] Click the three-dots menu on the relationship attribute
- [ ] Click "Update" — the edit dialog should open without any console errors
- [ ] Verify the dialog title renders correctly
- [ ] Verify you can modify `onDelete` behavior and save
- [ ] Verify non-relationship attributes (string, integer, enum) still update correctly