### PR TITLE
feat: support multiple file uploads in bucket

### DIFF
--- a/src/lib/stores/uploader.ts
+++ b/src/lib/stores/uploader.ts
@@ -39,6 +39,8 @@ const temporaryFunctions = (region: string, projectId: string) => {
     return new Functions(clientProject);
 };
 
+const MAX_CONCURRENT_UPLOADS = 5;
+
 const createUploader = () => {
     const { subscribe, set, update } = writable<Uploader>({
         isOpen: false,
@@ -104,8 +106,6 @@ const createUploader = () => {
             throw e;
         }
     };
-
-    const MAX_CONCURRENT_UPLOADS = 5;
 
     const uploadFiles = async (
         region: string,

--- a/src/lib/stores/uploader.ts
+++ b/src/lib/stores/uploader.ts
@@ -82,22 +82,29 @@ const createUploader = () => {
             n.files.unshift(newFile);
             return n;
         });
-        const uploadedFile = await temporaryStorage(region, projectId).createFile({
-            bucketId,
-            fileId: id ?? ID.unique(),
-            file,
-            permissions,
-            onProgress: (progress) => {
-                newFile.$id = progress.$id;
-                newFile.progress = progress.progress;
-                newFile.status = progress.progress === 100 ? 'success' : 'pending';
-                updateFile(progress.$id, newFile);
-            }
-        });
-        newFile.$id = uploadedFile.$id;
-        newFile.progress = 100;
-        newFile.status = 'success';
-        updateFile(newFile.$id, newFile);
+        try {
+            const uploadedFile = await temporaryStorage(region, projectId).createFile({
+                bucketId,
+                fileId: id ?? ID.unique(),
+                file,
+                permissions,
+                onProgress: (progress) => {
+                    newFile.$id = progress.$id;
+                    newFile.progress = progress.progress;
+                    newFile.status = progress.progress === 100 ? 'success' : 'pending';
+                    updateFile(progress.$id, newFile);
+                }
+            });
+            newFile.$id = uploadedFile.$id;
+            newFile.progress = 100;
+            newFile.status = 'success';
+            updateFile(newFile.$id, newFile);
+        } catch (e) {
+            newFile.status = 'failed';
+            newFile.error = e?.message ?? 'Upload failed';
+            updateFile(newFile.$id, newFile);
+            throw e;
+        }
     };
 
     const uploadFiles = async (

--- a/src/lib/stores/uploader.ts
+++ b/src/lib/stores/uploader.ts
@@ -39,6 +39,8 @@ const temporaryFunctions = (region: string, projectId: string) => {
     return new Functions(clientProject);
 };
 
+const MAX_CONCURRENT_UPLOADS = 5;
+
 const createUploader = () => {
     const { subscribe, set, update } = writable<Uploader>({
         isOpen: false,
@@ -56,6 +58,78 @@ const createUploader = () => {
 
             return n;
         });
+    };
+
+    const uploadFile = async (
+        region: string,
+        projectId: string,
+        bucketId: string,
+        id: string,
+        file: File,
+        permissions: string[]
+    ) => {
+        const newFile: UploaderFile = {
+            $id: id,
+            resourceId: bucketId,
+            name: file.name,
+            size: file.size,
+            progress: 0,
+            status: 'pending'
+        };
+        update((n) => {
+            n.isOpen = true;
+            n.isCollapsed = false;
+            n.files.unshift(newFile);
+            return n;
+        });
+        const uploadedFile = await temporaryStorage(region, projectId).createFile({
+            bucketId,
+            fileId: id ?? ID.unique(),
+            file,
+            permissions,
+            onProgress: (progress) => {
+                newFile.$id = progress.$id;
+                newFile.progress = progress.progress;
+                newFile.status = progress.progress === 100 ? 'success' : 'pending';
+                updateFile(progress.$id, newFile);
+            }
+        });
+        newFile.$id = uploadedFile.$id;
+        newFile.progress = 100;
+        newFile.status = 'success';
+        updateFile(newFile.$id, newFile);
+    };
+
+    const uploadFiles = async (
+        region: string,
+        projectId: string,
+        bucketId: string,
+        files: { id: string; file: File }[],
+        permissions: string[]
+    ) => {
+        const results: PromiseSettledResult<void>[] = [];
+        const executing = new Set<Promise<void>>();
+
+        for (const { id, file } of files) {
+            const task = uploadFile(region, projectId, bucketId, id, file, permissions).then(
+                () => {
+                    results.push({ status: 'fulfilled', value: undefined });
+                    executing.delete(task);
+                },
+                (reason) => {
+                    results.push({ status: 'rejected', reason });
+                    executing.delete(task);
+                }
+            );
+            executing.add(task);
+
+            if (executing.size >= MAX_CONCURRENT_UPLOADS) {
+                await Promise.race(executing);
+            }
+        }
+
+        await Promise.all(executing);
+        return results;
     };
 
     return {
@@ -78,45 +152,8 @@ const createUploader = () => {
                 isCollapsed: false,
                 files: []
             }),
-        uploadFile: async (
-            region: string,
-            projectId: string,
-            bucketId: string,
-            id: string,
-            file: File,
-            permissions: string[]
-        ) => {
-            const newFile: UploaderFile = {
-                $id: id,
-                resourceId: bucketId,
-                name: file.name,
-                size: file.size,
-                progress: 0,
-                status: 'pending'
-            };
-            update((n) => {
-                n.isOpen = true;
-                n.isCollapsed = false;
-                n.files.unshift(newFile);
-                return n;
-            });
-            const uploadedFile = await temporaryStorage(region, projectId).createFile({
-                bucketId,
-                fileId: id ?? ID.unique(),
-                file,
-                permissions,
-                onProgress: (progress) => {
-                    newFile.$id = progress.$id;
-                    newFile.progress = progress.progress;
-                    newFile.status = progress.progress === 100 ? 'success' : 'pending';
-                    updateFile(progress.$id, newFile);
-                }
-            });
-            newFile.$id = uploadedFile.$id;
-            newFile.progress = 100;
-            newFile.status = 'success';
-            updateFile(newFile.$id, newFile);
-        },
+        uploadFile,
+        uploadFiles,
         uploadSiteDeployment: async ({
             siteId,
             code,

--- a/src/lib/stores/uploader.ts
+++ b/src/lib/stores/uploader.ts
@@ -39,8 +39,6 @@ const temporaryFunctions = (region: string, projectId: string) => {
     return new Functions(clientProject);
 };
 
-const MAX_CONCURRENT_UPLOADS = 5;
-
 const createUploader = () => {
     const { subscribe, set, update } = writable<Uploader>({
         isOpen: false,
@@ -106,6 +104,8 @@ const createUploader = () => {
             throw e;
         }
     };
+
+    const MAX_CONCURRENT_UPLOADS = 5;
 
     const uploadFiles = async (
         region: string,

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
@@ -22,7 +22,7 @@
     import { uploader } from '$lib/stores/uploader';
     import { sdk } from '$lib/stores/sdk.js';
     import DeleteFile from './deleteFile.svelte';
-    import { Layout, Table, Icon, Popover, ActionMenu } from '@appwrite.io/pink-svelte';
+    import { Layout, Table, Icon, Popover, ActionMenu, Typography } from '@appwrite.io/pink-svelte';
     import { onMount } from 'svelte';
     import DualTimeView from '$lib/components/dualTimeView.svelte';
     import {
@@ -32,6 +32,8 @@
         IconTrash
     } from '@appwrite.io/pink-icons-svelte';
     import { isSmallViewport } from '$lib/stores/viewport';
+    import { ID } from '@appwrite.io/console';
+    import { addNotification } from '$lib/stores/notifications';
     import type { PageProps } from './$types';
 
     const { data }: PageProps = $props();
@@ -39,6 +41,7 @@
     let showDelete = $state(false);
     let isUploading = $state(false);
     let selectedFile: Models.File | null = $state(null);
+    let isDragging = $state(false);
 
     function getPreview(fileId: string) {
         return (
@@ -98,6 +101,35 @@
         }
     };
 
+    async function handleDrop(event: DragEvent) {
+        isDragging = false;
+        if (!event.dataTransfer?.files?.length) return;
+
+        const droppedFiles = Array.from(event.dataTransfer.files);
+        const count = droppedFiles.length;
+
+        addNotification({
+            type: 'success',
+            message: count === 1 ? 'File upload in progress' : `${count} file uploads in progress`
+        });
+
+        trackEvent(Submit.FileCreate, { customId: false });
+
+        const filesToUpload = droppedFiles.map((file) => ({
+            id: ID.unique(),
+            file
+        }));
+
+        await uploader.uploadFiles(
+            page.params.region,
+            page.params.project,
+            page.params.bucket,
+            filesToUpload,
+            []
+        );
+        invalidate(Dependencies.FILES);
+    }
+
     onMount(() => {
         return uploader.subscribe(() => {
             isUploading = $uploader.files.some(
@@ -110,160 +142,222 @@
 
 <svelte:window on:beforeunload={beforeunload} />
 
-<Container>
-    <Layout.Stack direction="row" justifyContent="space-between">
-        <Layout.Stack direction="row" alignItems="center">
-            <SearchQuery placeholder="Search files" />
-        </Layout.Stack>
-        <Layout.Stack direction="row" alignItems="center" justifyContent="flex-end">
-            <Button
-                href={`${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/create`}
-                event="create_file"
-                size="s">
-                <Icon icon={IconPlus} slot="start" size="s" />
-                Create file
-            </Button>
-        </Layout.Stack>
-    </Layout.Stack>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="drop-target"
+    class:is-dragging={isDragging}
+    ondrop={(e) => {
+        e.preventDefault();
+        handleDrop(e);
+    }}
+    ondragenter={(e) => {
+        e.preventDefault();
+        isDragging = true;
+    }}
+    ondragover={(e) => {
+        e.preventDefault();
+        isDragging = true;
+    }}
+    ondragleave={(e) => {
+        e.preventDefault();
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) isDragging = false;
+    }}>
+    {#if isDragging}
+        <div class="drop-overlay">
+            <Layout.Stack alignItems="center" gap="s">
+                <Icon icon={IconPlus} size="l" />
+                <Typography.Text variant="l-500">Drop files to upload</Typography.Text>
+            </Layout.Stack>
+        </div>
+    {/if}
 
-    {#if data.files.total}
-        <MultiSelectionTable
-            resource="file"
-            computeKey={data.files.total}
-            onDelete={handleBulkDelete}
-            columns={[
-                { id: 'filename', width: $isSmallViewport ? 24 : undefined },
-                { id: 'type', width: { min: 140 } },
-                { id: 'size', width: { min: 100 } },
-                { id: 'created', width: { min: 120 } },
-                { id: 'actions', width: 40 }
-            ]}>
-            {#snippet header(root)}
-                <Table.Header.Cell column="filename" {root}>Filename</Table.Header.Cell>
-                <Table.Header.Cell column="type" {root}>Type</Table.Header.Cell>
-                <Table.Header.Cell column="size" {root}>Size</Table.Header.Cell>
-                <Table.Header.Cell column="created" {root}>Created</Table.Header.Cell>
-                <Table.Header.Cell column="actions" {root} />
-            {/snippet}
+    <Container>
+        <Layout.Stack direction="row" justifyContent="space-between">
+            <Layout.Stack direction="row" alignItems="center">
+                <SearchQuery placeholder="Search files" />
+            </Layout.Stack>
+            <Layout.Stack direction="row" alignItems="center" justifyContent="flex-end">
+                <Button
+                    href={`${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/create`}
+                    event="create_file"
+                    size="s">
+                    <Icon icon={IconPlus} slot="start" size="s" />
+                    Create file
+                </Button>
+            </Layout.Stack>
+        </Layout.Stack>
 
-            {#snippet children(root)}
-                {#each data.files.files as file}
-                    {#if file.chunksTotal / file.chunksUploaded !== 1}
-                        <Table.Row.Base {root} id={file.$id}>
-                            <Table.Cell column="filename" {root}>
-                                <Layout.Stack direction="row" alignItems="center">
-                                    <span class="avatar is-size-small is-color-empty"></span>
-                                    <span class="text u-trim">{file.name}</span>
-                                    <div>
-                                        <Badge
-                                            variant="secondary"
-                                            type="warning"
-                                            content="Pending" />
+        {#if data.files.total}
+            <MultiSelectionTable
+                resource="file"
+                computeKey={data.files.total}
+                onDelete={handleBulkDelete}
+                columns={[
+                    { id: 'filename', width: $isSmallViewport ? 24 : undefined },
+                    { id: 'type', width: { min: 140 } },
+                    { id: 'size', width: { min: 100 } },
+                    { id: 'created', width: { min: 120 } },
+                    { id: 'actions', width: 40 }
+                ]}>
+                {#snippet header(root)}
+                    <Table.Header.Cell column="filename" {root}>Filename</Table.Header.Cell>
+                    <Table.Header.Cell column="type" {root}>Type</Table.Header.Cell>
+                    <Table.Header.Cell column="size" {root}>Size</Table.Header.Cell>
+                    <Table.Header.Cell column="created" {root}>Created</Table.Header.Cell>
+                    <Table.Header.Cell column="actions" {root} />
+                {/snippet}
+
+                {#snippet children(root)}
+                    {#each data.files.files as file}
+                        {#if file.chunksTotal / file.chunksUploaded !== 1}
+                            <Table.Row.Base {root} id={file.$id}>
+                                <Table.Cell column="filename" {root}>
+                                    <Layout.Stack direction="row" alignItems="center">
+                                        <span class="avatar is-size-small is-color-empty"></span>
+                                        <span class="text u-trim">{file.name}</span>
+                                        <div>
+                                            <Badge
+                                                variant="secondary"
+                                                type="warning"
+                                                content="Pending" />
+                                        </div>
+                                    </Layout.Stack>
+                                </Table.Cell>
+                                <Table.Cell column="type" {root}>{file.mimeType}</Table.Cell>
+                                <Table.Cell column="size" {root}>
+                                    {calculateSize(file.sizeOriginal)}
+                                </Table.Cell>
+                                <Table.Cell column="created" {root}>
+                                    <DualTimeView time={file.$createdAt} />
+                                </Table.Cell>
+                                <Table.Cell column="actions" {root}>
+                                    <div class="u-flex u-main-center">
+                                        <button
+                                            class="button is-only-icon is-text"
+                                            aria-label="Delete item"
+                                            onclick={(event) => {
+                                                event.preventDefault();
+                                                deleteFile(file);
+                                            }}>
+                                            <span class="icon-trash" aria-hidden="true"></span>
+                                        </button>
                                     </div>
-                                </Layout.Stack>
-                            </Table.Cell>
-                            <Table.Cell column="type" {root}>{file.mimeType}</Table.Cell>
-                            <Table.Cell column="size" {root}>
-                                {calculateSize(file.sizeOriginal)}
-                            </Table.Cell>
-                            <Table.Cell column="created" {root}>
-                                <DualTimeView time={file.$createdAt} />
-                            </Table.Cell>
-                            <Table.Cell column="actions" {root}>
-                                <div class="u-flex u-main-center">
-                                    <button
-                                        class="button is-only-icon is-text"
-                                        aria-label="Delete item"
-                                        onclick={(event) => {
-                                            event.preventDefault();
-                                            deleteFile(file);
-                                        }}>
-                                        <span class="icon-trash" aria-hidden="true"></span>
-                                    </button>
-                                </div>
-                            </Table.Cell>
-                        </Table.Row.Base>
-                    {:else}
-                        {@const href = `${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/file-${file.$id}`}
-                        <Table.Row.Link {href} {root} id={file.$id}>
-                            <Table.Cell column="filename" {root}>
-                                <div class="u-flex u-gap-12 u-cross-center">
-                                    <Avatar size="xs" src={getPreview(file.$id)} alt={file.name} />
-                                    <span class="text u-trim">{file.name}</span>
-                                </div>
-                            </Table.Cell>
-                            <Table.Cell column="type" {root}>{file.mimeType}</Table.Cell>
-                            <Table.Cell column="size" {root}>
-                                {calculateSize(file.sizeOriginal)}
-                            </Table.Cell>
-                            <Table.Cell column="created" {root}>
-                                <DualTimeView time={file.$createdAt} />
-                            </Table.Cell>
-                            <Table.Cell column="actions" {root}>
-                                <Popover let:toggle placement="bottom-start" padding="none">
-                                    <Button
-                                        text
-                                        icon
-                                        ariaLabel="more options"
-                                        on:click={(e) => {
-                                            e.stopPropagation();
-                                            e.preventDefault();
-                                            toggle();
-                                        }}>
-                                        <Icon icon={IconDotsHorizontal} size="s" />
-                                    </Button>
-                                    <ActionMenu.Root slot="tooltip">
-                                        <ActionMenu.Item.Anchor {href} leadingIcon={IconPencil}>
-                                            Update
-                                        </ActionMenu.Item.Anchor>
-                                        <ActionMenu.Item.Button
-                                            leadingIcon={IconTrash}
+                                </Table.Cell>
+                            </Table.Row.Base>
+                        {:else}
+                            {@const href = `${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/file-${file.$id}`}
+                            <Table.Row.Link {href} {root} id={file.$id}>
+                                <Table.Cell column="filename" {root}>
+                                    <div class="u-flex u-gap-12 u-cross-center">
+                                        <Avatar
+                                            size="xs"
+                                            src={getPreview(file.$id)}
+                                            alt={file.name} />
+                                        <span class="text u-trim">{file.name}</span>
+                                    </div>
+                                </Table.Cell>
+                                <Table.Cell column="type" {root}>{file.mimeType}</Table.Cell>
+                                <Table.Cell column="size" {root}>
+                                    {calculateSize(file.sizeOriginal)}
+                                </Table.Cell>
+                                <Table.Cell column="created" {root}>
+                                    <DualTimeView time={file.$createdAt} />
+                                </Table.Cell>
+                                <Table.Cell column="actions" {root}>
+                                    <Popover let:toggle placement="bottom-start" padding="none">
+                                        <Button
+                                            text
+                                            icon
+                                            ariaLabel="more options"
                                             on:click={(e) => {
                                                 e.stopPropagation();
                                                 e.preventDefault();
-                                                selectedFile = file;
-                                                showDelete = true;
+                                                toggle();
                                             }}>
-                                            Delete
-                                        </ActionMenu.Item.Button>
-                                    </ActionMenu.Root>
-                                </Popover>
-                            </Table.Cell>
-                        </Table.Row.Link>
-                    {/if}
-                {/each}
-            {/snippet}
+                                            <Icon icon={IconDotsHorizontal} size="s" />
+                                        </Button>
+                                        <ActionMenu.Root slot="tooltip">
+                                            <ActionMenu.Item.Anchor {href} leadingIcon={IconPencil}>
+                                                Update
+                                            </ActionMenu.Item.Anchor>
+                                            <ActionMenu.Item.Button
+                                                leadingIcon={IconTrash}
+                                                on:click={(e) => {
+                                                    e.stopPropagation();
+                                                    e.preventDefault();
+                                                    selectedFile = file;
+                                                    showDelete = true;
+                                                }}>
+                                                Delete
+                                            </ActionMenu.Item.Button>
+                                        </ActionMenu.Root>
+                                    </Popover>
+                                </Table.Cell>
+                            </Table.Row.Link>
+                        {/if}
+                    {/each}
+                {/snippet}
 
-            {#snippet deleteContentNotice()}
-                This action is irreversible and will permanently remove the selected files.
-            {/snippet}
-        </MultiSelectionTable>
+                {#snippet deleteContentNotice()}
+                    This action is irreversible and will permanently remove the selected files.
+                {/snippet}
+            </MultiSelectionTable>
 
-        <PaginationWithLimit
-            name="Files"
-            limit={data.limit}
-            offset={data.offset}
-            total={data.files.total} />
-    {:else if data.search}
-        <EmptySearch target="files" search={data.search} hidePagination={data.files.total === 0}>
-            <Button
-                secondary
-                size="s"
-                href={`${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}`}>
-                Clear Search
-            </Button>
-        </EmptySearch>
-    {:else}
-        <Empty
-            single
-            href="https://appwrite.io/docs/products/storage"
-            target="file"
-            allowCreate
-            on:click={() =>
-                goto(
-                    `${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/create`
-                )} />
-    {/if}
-</Container>
+            <PaginationWithLimit
+                name="Files"
+                limit={data.limit}
+                offset={data.offset}
+                total={data.files.total} />
+        {:else if data.search}
+            <EmptySearch
+                target="files"
+                search={data.search}
+                hidePagination={data.files.total === 0}>
+                <Button
+                    secondary
+                    size="s"
+                    href={`${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}`}>
+                    Clear Search
+                </Button>
+            </EmptySearch>
+        {:else}
+            <Empty
+                single
+                href="https://appwrite.io/docs/products/storage"
+                target="file"
+                allowCreate
+                on:click={() =>
+                    goto(
+                        `${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/create`
+                    )} />
+        {/if}
+    </Container>
+</div>
 
 <DeleteFile bind:showDelete file={selectedFile} on:deleted={fileDeleted} />
+
+<style>
+    .drop-target {
+        position: relative;
+        min-height: 100%;
+    }
+
+    .drop-target.is-dragging {
+        outline: 2px dashed var(--color-border-neutral-strong, hsl(var(--p-body-text-color)));
+        outline-offset: -2px;
+        border-radius: var(--border-radius-s);
+    }
+
+    .drop-overlay {
+        position: absolute;
+        inset: 0;
+        z-index: 10;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--bgcolor-neutral-default, hsl(var(--p-body-bg-color)));
+        opacity: 0.9;
+        border-radius: var(--border-radius-s);
+        pointer-events: none;
+    }
+</style>

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/+page.svelte
@@ -105,9 +105,30 @@
         isDragging = false;
         if (!event.dataTransfer?.files?.length) return;
 
+        const allowedExtensions: string[] = data.bucket.allowedFileExtensions ?? [];
         const droppedFiles = Array.from(event.dataTransfer.files);
-        const count = droppedFiles.length;
 
+        const validFiles: File[] = [];
+        const rejectedFiles: File[] = [];
+        for (const file of droppedFiles) {
+            const ext = file.name.split('.').pop()?.toLowerCase();
+            if (allowedExtensions.length && (!ext || !allowedExtensions.includes(ext))) {
+                rejectedFiles.push(file);
+            } else {
+                validFiles.push(file);
+            }
+        }
+
+        if (rejectedFiles.length) {
+            addNotification({
+                type: 'error',
+                message: `${rejectedFiles.length} file(s) rejected — only ${allowedExtensions.join(', ')} allowed`
+            });
+        }
+
+        if (!validFiles.length) return;
+
+        const count = validFiles.length;
         addNotification({
             type: 'success',
             message: count === 1 ? 'File upload in progress' : `${count} file uploads in progress`
@@ -115,18 +136,25 @@
 
         trackEvent(Submit.FileCreate, { customId: false });
 
-        const filesToUpload = droppedFiles.map((file) => ({
+        const filesToUpload = validFiles.map((file) => ({
             id: ID.unique(),
             file
         }));
 
-        await uploader.uploadFiles(
+        const results = await uploader.uploadFiles(
             page.params.region,
             page.params.project,
             page.params.bucket,
             filesToUpload,
             []
         );
+        const failures = results.filter((r) => r.status === 'rejected');
+        if (failures.length) {
+            addNotification({
+                type: 'error',
+                message: `${failures.length} file(s) failed to upload`
+            });
+        }
         invalidate(Dependencies.FILES);
     }
 

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/create/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/create/+page.svelte
@@ -69,7 +69,14 @@
             trackEvent(Submit.FileCreate, {
                 customId: !!id
             });
-            await promise;
+            const results = await promise;
+            const failures = results.filter((r) => r.status === 'rejected');
+            if (failures.length) {
+                addNotification({
+                    type: 'error',
+                    message: `${failures.length} file(s) failed to upload`
+                });
+            }
             invalidate(Dependencies.FILES);
         } catch (e) {
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/create/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/create/+page.svelte
@@ -42,15 +42,19 @@
     let permissions: string[] = [];
 
     async function create() {
-        const fileId = id ?? ID.unique();
+        const fileArray = Array.from(files);
+        const isSingle = fileArray.length === 1;
 
         try {
-            const promise = uploader.uploadFile(
+            const filesToUpload = fileArray.map((file) => ({
+                id: isSingle ? (id ?? ID.unique()) : ID.unique(),
+                file
+            }));
+            const promise = uploader.uploadFiles(
                 page.params.region,
                 page.params.project,
                 page.params.bucket,
-                fileId,
-                files[0],
+                filesToUpload,
                 permissions
             );
             await goto(
@@ -58,7 +62,9 @@
             );
             addNotification({
                 type: 'success',
-                message: `File upload in progress`
+                message: isSingle
+                    ? 'File upload in progress'
+                    : `${fileArray.length} file uploads in progress`
             });
             trackEvent(Submit.FileCreate, {
                 customId: !!id
@@ -66,7 +72,6 @@
             await promise;
             invalidate(Dependencies.FILES);
         } catch (e) {
-            uploader.removeFromQueue(fileId);
             addNotification({
                 type: 'error',
                 message: e.message
@@ -94,7 +99,7 @@
 <Wizard
     column
     confirmExit
-    title="Create file"
+    title={files?.length > 1 ? `Create ${files.length} files` : 'Create file'}
     bind:showExitModal
     href={`${base}/project-${page.params.region}-${page.params.project}/storage/bucket-${page.params.bucket}/`}>
     <Form bind:this={formComponent} onSubmit={create} bind:isSubmitting>
@@ -119,6 +124,7 @@
                     <Upload.Dropzone
                         bind:files
                         required
+                        multiple
                         extensions={data.bucket.allowedFileExtensions}
                         on:invalid={handleInvalid}>
                         <Typography.Text variant="l-500"
@@ -139,15 +145,17 @@
                             on:remove={(e) => (files = removeFile(e.detail, files))} />
                     {/if}
 
-                    {#if !showCustomId}
-                        <div>
-                            <Tag on:click={() => (showCustomId = !showCustomId)}>
-                                <Icon icon={IconPencil} slot="start" />
-                                <span class="text"> File ID </span>
-                            </Tag>
-                        </div>
-                    {:else}
-                        <CustomId autofocus bind:show={showCustomId} name="File" bind:id />
+                    {#if files?.length === 1}
+                        {#if !showCustomId}
+                            <div>
+                                <Tag on:click={() => (showCustomId = !showCustomId)}>
+                                    <Icon icon={IconPencil} slot="start" />
+                                    <span class="text"> File ID </span>
+                                </Tag>
+                            </div>
+                        {:else}
+                            <CustomId autofocus bind:show={showCustomId} name="File" bind:id />
+                        {/if}
                     {/if}
                 </Layout.Stack>
             </Fieldset>


### PR DESCRIPTION
## Summary
- Allow selecting and dropping multiple files at once when uploading to a storage bucket
- Files upload in parallel with a concurrency limit of 5 to avoid overwhelming browser/server
- Drag-and-drop multiple files directly onto the bucket file list page for quick uploads
- Custom file ID option only shown when a single file is selected
- Wizard title and notification messages adapt to file count

## Test plan
- [ ] Navigate to a bucket → click "Create file" → select multiple files via file picker → verify all upload and appear in list
- [ ] Navigate to a bucket → drag and drop multiple files onto the file list → verify all upload
- [ ] Upload > 5 files → verify concurrency is capped (only ~5 active at a time in network tab)
- [ ] Verify upload progress box shows all files with correct status

Before:
<img width="1920" height="1016" alt="image" src="https://github.com/user-attachments/assets/f05af3a8-4760-46b8-ac24-3b1373a2a572" />


After:
<img width="1920" height="1016" alt="image" src="https://github.com/user-attachments/assets/38b2c9e0-8b2c-4d9c-94ce-c09dcb8c0897" />

<img width="1920" height="1016" alt="image" src="https://github.com/user-attachments/assets/dc0baf23-e915-4a09-abd3-ad1e2532678f" />
