### PR TITLE
fix(billing): skip cloud-only organization queries on self-hosted

### DIFF
--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -586,6 +586,8 @@ export function checkForMarkedForDeletion(org: Models.Organization) {
 }
 
 export async function checkForMissingPaymentMethod() {
+    if (!isCloud) return;
+
     const starterPlan = getBasePlanFromGroup(BillingPlanGroup.Starter);
     if (!starterPlan?.$id) {
         return;
@@ -613,6 +615,8 @@ export async function checkForMissingPaymentMethod() {
 
 // Display upgrade banner for new users after 1 week for 30 days
 export async function checkForNewDevUpgradePro(org: Models.Organization) {
+    if (!isCloud) return;
+
     // browser or plan check.
     if (!browser || !org.billingPlanDetails.supportsCredits) return;
 


### PR DESCRIPTION
﻿## Problem

On self-hosted Appwrite instances, the billing store calls ``organizations.list`` with cloud-only query filters (``Query.equal('platform', Platform.Appwrite)`` and ``Query.notEqual('billingPlan', ...)``). These queries return 400 errors because the self-hosted API does not support billing-related fields.

## Solution

Added early ``if (!isCloud) return`` guards at the start of ``checkForMissingPaymentMethod`` and ``checkForNewDevUpgradePro`` in ``src/lib/stores/billing.ts``. The ``isCloud`` flag was already imported from ``$lib/system``.

## How to test

1. Run Appwrite in self-hosted mode
2. Navigate to the Console
3. Verify no 400 errors from ``/v1/teams`` in the network tab

Fixes #2835
