### PR TITLE
Fix GitHub OAuth label from App ID to Client ID

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -5,7 +5,7 @@
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
     import type { Models } from '@appwrite.io/console';
-    import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
+    import { oAuthProviders, Provider } from '$lib/stores/oauth-providers';
     import { Link, Alert } from '@appwrite.io/pink-svelte';
     import { getApiEndpoint } from '$lib/stores/sdk';
 
@@ -52,7 +52,7 @@
     <InputSwitch id="state" bind:value={enabled} label={enabled ? 'Enabled' : 'Disabled'} />
     <InputText
         id="appID"
-        label="App ID"
+        label={provider.key === 'github' ? 'Client ID' : 'App ID'}
         autofocus={true}
         placeholder="Enter ID"
         bind:value={appId}

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -52,7 +52,7 @@
     <InputSwitch id="state" bind:value={enabled} label={enabled ? 'Enabled' : 'Disabled'} />
     <InputText
         id="appID"
-        label={provider.key === 'github' ? 'Client ID' : 'App ID'}
+        label={provider.key === 'github' || provider.key === 'githubenterprise' ? 'Client ID' : 'App ID'}
         autofocus={true}
         placeholder="Enter ID"
         bind:value={appId}


### PR DESCRIPTION
Fixes #11875

Updated the GitHub OAuth label from "App ID" to "Client ID" to match GitHub terminology and improve clarity.
Other providers remain unchanged.