### PR TITLE
Fix table page not loading when column name is 'actions'

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -5,7 +5,7 @@
     import { onMount } from 'svelte';
     import { updateOAuth } from '../updateOAuth';
     import type { Models } from '@appwrite.io/console';
-    import { oAuthProviders, type Provider } from '$lib/stores/oauth-providers';
+    import { oAuthProviders, Provider } from '$lib/stores/oauth-providers';
     import { Link, Alert } from '@appwrite.io/pink-svelte';
     import { getApiEndpoint } from '$lib/stores/sdk';
 
@@ -52,7 +52,7 @@
     <InputSwitch id="state" bind:value={enabled} label={enabled ? 'Enabled' : 'Disabled'} />
     <InputText
         id="appID"
-        label="App ID"
+        label={provider.key === 'github' ? 'Client ID' : 'App ID'}
         autofocus={true}
         placeholder="Enter ID"
         bind:value={appId}

--- a/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/(providers)/mainOAuth.svelte
@@ -52,7 +52,7 @@
     <InputSwitch id="state" bind:value={enabled} label={enabled ? 'Enabled' : 'Disabled'} />
     <InputText
         id="appID"
-        label={provider.key === 'github' ? 'Client ID' : 'App ID'}
+        label={provider.key === 'github' || provider.key === 'githubenterprise' ? 'Client ID' : 'App ID'}
         autofocus={true}
         placeholder="Enter ID"
         bind:value={appId}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table.svelte
@@ -58,7 +58,8 @@
     {onDelete}>
     {#snippet header(root)}
         {#each $tableViewColumns as { id, title } (id)}
-            <Table.Header.Cell column={id} {root}>{title}</Table.Header.Cell>
+            {@const safeid = id === 'actions' ? '__actions' : id}
+            <Table.Header.Cell column={safeid} {root}>{title}</Table.Header.Cell>
         {/each}
     {/snippet}
 
@@ -69,7 +70,8 @@
                 id={entity.$id}
                 href={buildEntityRoute(page, entitySingular, entity.$id)}>
                 {#each $tableViewColumns as column}
-                    <Table.Cell column={column.id} {root}>
+                    {@const safeId = column.id === 'actions' ? '__actions' : column.id}
+                    <Table.Cell column={safeId} {root}>
                         {#if column.id === '$id'}
                             {#key $tableViewColumns}
                                 <Id value={entity.$id}>{entity.$id}</Id>

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table.svelte
@@ -58,8 +58,8 @@
     {onDelete}>
     {#snippet header(root)}
         {#each $tableViewColumns as { id, title } (id)}
-            {@const safeid = id === 'actions' ? '__actions' : id}
-            <Table.Header.Cell column={safeid} {root}>{title}</Table.Header.Cell>
+            {@const safeId = id === 'actions' ? '__actions' : id}
+            <Table.Header.Cell column={safeId} {root}>{title}</Table.Header.Cell>
         {/each}
     {/snippet}
 


### PR DESCRIPTION
Fixes #2977

Handled conflict when a user creates a column named "actions" by mapping it to a safe internal key to avoid collision with the system-defined "actions" column.

This prevents the table page from getting stuck on loading and ensures it renders correctly.