### PR TITLE
Expand apex CNAME verification note with CDN proxy guidance

### DIFF
--- a/src/lib/components/domains/recordTable.svelte
+++ b/src/lib/components/domains/recordTable.svelte
@@ -143,6 +143,8 @@
                     Since <Badge variant="secondary" size="s" content={domain} /> is an apex domain, CNAME
                     record is only supported by certain providers. If yours doesn't, please verify using
                     <Link variant="muted" on:click={onNavigateToNameservers}>nameservers</Link> instead.
+                    If you're using Cloudflare or another CDN, make sure the proxy is disabled (set to
+                    DNS only) for this record, since Appwrite serves your domain through its own CDN.
                 </Alert.Inline>
             {:else if aTabVisible || aaaaTabVisible}
                 <Alert.Inline>
@@ -155,7 +157,9 @@
                             >{/if}
                     {:else if aaaaTabVisible}
                         <Link variant="muted" on:click={onNavigateToAAAA}>AAAA record</Link>
-                    {/if} instead.
+                    {/if} instead. If you're using Cloudflare or another CDN, make sure the proxy is
+                    disabled (set to DNS only) for this record, since Appwrite serves your domain through
+                    its own CDN.
                 </Alert.Inline>
             {/if}
         {:else}

--- a/src/lib/components/domains/recordTable.svelte
+++ b/src/lib/components/domains/recordTable.svelte
@@ -157,9 +157,9 @@
                             >{/if}
                     {:else if aaaaTabVisible}
                         <Link variant="muted" on:click={onNavigateToAAAA}>AAAA record</Link>
-                    {/if} instead. If you're using Cloudflare or another CDN, make sure the proxy is
-                    disabled (set to DNS only) for this record, since Appwrite serves your domain through
-                    its own CDN.
+                    {/if} instead. If you're using Cloudflare or another CDN, make sure the proxy is disabled
+                    (set to DNS only) for this record, since Appwrite serves your domain through its own
+                    CDN.
                 </Alert.Inline>
             {/if}
         {:else}


### PR DESCRIPTION
## Summary
- The apex-domain inline alert in the verify-domain flow (`RecordTable`) previously only warned that CNAME support depends on the provider.
- It now also tells users to disable the CDN proxy (Cloudflare's orange cloud, or equivalent) and set the record to DNS only, since Appwrite serves the domain through its own CDN.
- Applies to all three verify flows that render `RecordTable`: sites, functions, and project settings.

## Test plan
- [ ] Navigate to Sites → Domains → Add domain → verify an apex domain on Cloud: confirm the expanded note appears
- [ ] Same flow for Functions → Domains
- [ ] Same flow for Project Settings → Domains (self-hosted with A/AAAA fallbacks): confirm the note appears with the A/AAAA link variant
- [ ] Verify existing apex-domain copy and links (nameservers / A / AAAA) still work