### PR TITLE
feat: add internal notes for collection attributes (#11945)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,15 +113,15 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@f063676", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@f063676", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-dT2Uri9+T8j9SzVoEHxyQ4qnvX9Qen7NANLJPNMCdBP1Sh1iOsSkSqoBX5jkMceRMPtOicrzBN2ZjOModeDxWQ=="],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 
-    "@appwrite.io/pink-icons-svelte": ["@appwrite.io/pink-icons-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3", { "peerDependencies": { "svelte": "^4.0.0" } }],
+    "@appwrite.io/pink-icons-svelte": ["@appwrite.io/pink-icons-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3", { "peerDependencies": { "svelte": "^4.0.0" } }, "sha512-2HYl/CC2OlfZIR7LzbLXuSPBn0iNkjbnxpaeGCkZ7UNZ/hFeSeeWjDJqTBMdZ8+X95uuZqHx62XPTiE/svuSXQ=="],
 
     "@appwrite.io/pink-legacy": ["@appwrite.io/pink-legacy@1.0.3", "", { "dependencies": { "@appwrite.io/pink-icons": "1.0.0", "the-new-css-reset": "^1.11.2" } }, "sha512-GGde5fmPhs+s6/3aFeMPc/kKADG/gTFkYQSy6oBN8pK0y0XNCLrZZgBv+EBbdhwdtqVEWXa0X85Mv9w7jcIlwQ=="],
 
-    "@appwrite.io/pink-svelte": ["@appwrite.io/pink-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-svelte@8dcaa17", { "dependencies": { "@appwrite.io/pink-icons-svelte": "2.0.0-RC.1", "@floating-ui/dom": "^1.6.13", "@melt-ui/pp": "^0.3.2", "@melt-ui/svelte": "^0.86.6", "@tanstack/svelte-virtual": "^3.13.10", "ansicolor": "^2.0.3", "d3": "^7.9.0", "fuse.js": "^7.1.0", "pretty-bytes": "^6.1.1", "shiki": "^1.18.0", "svelte-motion": "^0.12.2", "svelte-sonner": "^0.3.28" }, "peerDependencies": { "svelte": "^4.0.0" } }],
+    "@appwrite.io/pink-svelte": ["@appwrite.io/pink-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-svelte@8dcaa17", { "dependencies": { "@appwrite.io/pink-icons-svelte": "2.0.0-RC.1", "@floating-ui/dom": "^1.6.13", "@melt-ui/pp": "^0.3.2", "@melt-ui/svelte": "^0.86.6", "@tanstack/svelte-virtual": "^3.13.10", "ansicolor": "^2.0.3", "d3": "^7.9.0", "fuse.js": "^7.1.0", "pretty-bytes": "^6.1.1", "shiki": "^1.18.0", "svelte-motion": "^0.12.2", "svelte-sonner": "^0.3.28" }, "peerDependencies": { "svelte": "^4.0.0" } }, "sha512-rw3zXN7/cUciCnhj0FR8M0H5Db+LYYMaKtPxvOAIMxNTBmStzU8kTw6grqIvdtFu9vybIsjKtIwm9QLHpNDBjA=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 

--- a/src/lib/components/AttributeNote.svelte
+++ b/src/lib/components/AttributeNote.svelte
@@ -35,6 +35,17 @@
     // Draft copy while the user types
     let draft = $state(note);
 
+    $effect(() => {
+        const nextNote = attributeNotes.getNote(databaseId, collectionId, attributeKey);
+
+        note = nextNote;
+
+        // Only overwrite draft if user is NOT editing
+        if (!editing) {
+            draft = nextNote;
+        }
+    });
+
     // Textarea ref for auto-focus
     let textareaRef = $state<HTMLTextAreaElement | null>(null);
 

--- a/src/lib/components/AttributeNote.svelte
+++ b/src/lib/components/AttributeNote.svelte
@@ -102,7 +102,7 @@
                 maxlength="500"
                 onkeydown={handleKeydown}></textarea>
             <div class="attribute-note__editor-actions">
-                <span class="attribute-note__hint">Ctrl+Enter to save · Esc to cancel</span>
+                <span class="attribute-note__hint">Ctrl+Enter / Cmd+Enter to save · Esc to cancel</span>
                 <div class="attribute-note__buttons">
                     {#if note}
                         <button

--- a/src/lib/components/AttributeNote.svelte
+++ b/src/lib/components/AttributeNote.svelte
@@ -97,6 +97,7 @@
                 bind:this={textareaRef}
                 bind:value={draft}
                 class="attribute-note__textarea"
+                aria-label={`Note for ${attributeKey}`}
                 placeholder="Add a note about this column (optional)…"
                 rows="3"
                 maxlength="500"

--- a/src/lib/components/AttributeNote.svelte
+++ b/src/lib/components/AttributeNote.svelte
@@ -1,0 +1,363 @@
+<script lang="ts">
+    /**
+     * AttributeNote.svelte
+     *
+     * Reusable inline note component for a single collection attribute/column.
+     * Renders as a subtle "Add note" trigger when empty, or shows the note text
+     * with an edit pencil icon when a note exists.
+     *
+     * Usage:
+     *   <AttributeNote
+     *       databaseId={$page.params.database}
+     *       collectionId={$page.params.collection}
+     *       attributeKey={attribute.key}
+     *   />
+     *
+     * Issue: https://github.com/appwrite/appwrite/issues/11945
+     */
+
+    import { attributeNotes } from '$lib/stores/attributeNotes';
+
+    interface Props {
+        databaseId: string;
+        collectionId: string;
+        attributeKey: string;
+    }
+
+    let { databaseId, collectionId, attributeKey }: Props = $props();
+
+    // Current persisted note value
+    let note = $state(attributeNotes.getNote(databaseId, collectionId, attributeKey));
+
+    // Whether the inline editor is open
+    let editing = $state(false);
+
+    // Draft copy while the user types
+    let draft = $state(note);
+
+    // Textarea ref for auto-focus
+    let textareaRef = $state<HTMLTextAreaElement | null>(null);
+
+    $effect(() => {
+        if (editing && textareaRef) {
+            textareaRef.focus();
+            // Place cursor at end
+            const len = textareaRef.value.length;
+            textareaRef.setSelectionRange(len, len);
+        }
+    });
+
+    function openEditor() {
+        draft = note;
+        editing = true;
+    }
+
+    function saveNote() {
+        const trimmed = draft.trim();
+        attributeNotes.setNote(databaseId, collectionId, attributeKey, trimmed);
+        note = trimmed;
+        editing = false;
+    }
+
+    function cancelEdit() {
+        draft = note;
+        editing = false;
+    }
+
+    function handleKeydown(event: KeyboardEvent) {
+        if (event.key === 'Escape') {
+            cancelEdit();
+        } else if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+            saveNote();
+        }
+    }
+
+    function clearNote() {
+        attributeNotes.setNote(databaseId, collectionId, attributeKey, '');
+        note = '';
+        editing = false;
+    }
+</script>
+
+<div class="attribute-note">
+    {#if editing}
+        <div class="attribute-note__editor">
+            <textarea
+                bind:this={textareaRef}
+                bind:value={draft}
+                class="attribute-note__textarea"
+                placeholder="Add a note about this column (optional)…"
+                rows="3"
+                maxlength="500"
+                onkeydown={handleKeydown}></textarea>
+            <div class="attribute-note__editor-actions">
+                <span class="attribute-note__hint">Ctrl+Enter to save · Esc to cancel</span>
+                <div class="attribute-note__buttons">
+                    {#if note}
+                        <button
+                            type="button"
+                            class="attribute-note__btn attribute-note__btn--danger"
+                            onclick={clearNote}
+                            title="Remove note">
+                            Remove
+                        </button>
+                    {/if}
+                    <button
+                        type="button"
+                        class="attribute-note__btn attribute-note__btn--secondary"
+                        onclick={cancelEdit}>
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        class="attribute-note__btn attribute-note__btn--primary"
+                        onclick={saveNote}>
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    {:else if note}
+        <button
+            type="button"
+            class="attribute-note__display"
+            onclick={openEditor}
+            title="Click to edit note">
+            <span class="attribute-note__icon attribute-note__icon--note" aria-hidden="true">
+                <!-- Sticky note icon (inline SVG, no external deps) -->
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M4 2h12a2 2 0 0 1 2 2v10l-4 4H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2z"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linejoin="round" />
+                    <path d="M14 14v4l4-4h-4z" fill="currentColor" opacity="0.4" />
+                    <path
+                        d="M6 7h8M6 10h6"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round" />
+                </svg>
+            </span>
+            <span class="attribute-note__text">{note}</span>
+            <span class="attribute-note__icon attribute-note__icon--edit" aria-hidden="true">
+                <!-- Pencil icon -->
+                <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M14.69 2.21a1.5 1.5 0 0 1 2.1 2.1L6 15.1 2 16l.9-4L14.69 2.21z"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linejoin="round" />
+                </svg>
+            </span>
+        </button>
+    {:else}
+        <button
+            type="button"
+            class="attribute-note__add"
+            onclick={openEditor}
+            title="Add a note to this column">
+            <span class="attribute-note__icon" aria-hidden="true">
+                <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M10 4v12M4 10h12"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round" />
+                </svg>
+            </span>
+            Add note
+        </button>
+    {/if}
+</div>
+
+<style>
+    .attribute-note {
+        display: inline-flex;
+        flex-direction: column;
+        max-width: 100%;
+    }
+
+    /* ── "Add note" trigger ─────────────────────────────────────── */
+    .attribute-note__add {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px 6px;
+        border: 1px dashed var(--color-border, #e0e0e0);
+        border-radius: 4px;
+        background: transparent;
+        color: var(--color-text-tertiary, #999);
+        font-size: 11px;
+        line-height: 1.4;
+        cursor: pointer;
+        transition:
+            color 0.15s,
+            border-color 0.15s;
+        white-space: nowrap;
+    }
+    .attribute-note__add:hover {
+        color: var(--color-text-secondary, #666);
+        border-color: var(--color-border-strong, #bbb);
+    }
+
+    /* ── Existing note display ──────────────────────────────────── */
+    .attribute-note__display {
+        display: inline-flex;
+        align-items: flex-start;
+        gap: 5px;
+        padding: 4px 6px;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        background: var(--color-surface-note, rgba(255, 200, 0, 0.08));
+        color: var(--color-text-secondary, #555);
+        font-size: 12px;
+        line-height: 1.4;
+        cursor: pointer;
+        text-align: left;
+        max-width: 320px;
+        transition:
+            background 0.15s,
+            border-color 0.15s;
+        word-break: break-word;
+    }
+    .attribute-note__display:hover {
+        background: var(--color-surface-note-hover, rgba(255, 200, 0, 0.15));
+        border-color: var(--color-border, #e0e0e0);
+    }
+
+    .attribute-note__text {
+        flex: 1;
+        white-space: pre-wrap;
+        /* Clamp to 3 lines with ellipsis */
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    /* ── Icons ───────────────────────────────────────────────────── */
+    .attribute-note__icon {
+        display: inline-flex;
+        align-items: center;
+        flex-shrink: 0;
+        margin-top: 1px;
+        color: var(--color-text-tertiary, #aaa);
+    }
+    .attribute-note__icon--edit {
+        opacity: 0;
+        transition: opacity 0.15s;
+    }
+    .attribute-note__display:hover .attribute-note__icon--edit {
+        opacity: 1;
+    }
+
+    /* ── Inline editor ───────────────────────────────────────────── */
+    .attribute-note__editor {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        width: 320px;
+    }
+
+    .attribute-note__textarea {
+        width: 100%;
+        padding: 8px 10px;
+        border: 1px solid var(--color-border-strong, #ccc);
+        border-radius: 6px;
+        background: var(--color-surface-input, #fff);
+        color: var(--color-text-primary, #111);
+        font-size: 12px;
+        line-height: 1.5;
+        font-family: inherit;
+        resize: vertical;
+        min-height: 72px;
+        box-sizing: border-box;
+        transition:
+            border-color 0.15s,
+            box-shadow 0.15s;
+    }
+    .attribute-note__textarea:focus {
+        outline: none;
+        border-color: var(--color-primary, #e05a4b);
+        box-shadow: 0 0 0 2px rgba(224, 90, 75, 0.15);
+    }
+
+    .attribute-note__editor-actions {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+    }
+
+    .attribute-note__hint {
+        font-size: 10px;
+        color: var(--color-text-tertiary, #aaa);
+        flex-shrink: 0;
+    }
+
+    .attribute-note__buttons {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        flex-shrink: 0;
+    }
+
+    .attribute-note__btn {
+        padding: 4px 10px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 500;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition:
+            background 0.15s,
+            border-color 0.15s,
+            color 0.15s;
+        line-height: 1.4;
+    }
+
+    .attribute-note__btn--primary {
+        background: var(--color-primary, #e05a4b);
+        color: #fff;
+        border-color: var(--color-primary, #e05a4b);
+    }
+    .attribute-note__btn--primary:hover {
+        background: var(--color-primary-dark, #c94b3d);
+        border-color: var(--color-primary-dark, #c94b3d);
+    }
+
+    .attribute-note__btn--secondary {
+        background: transparent;
+        color: var(--color-text-secondary, #555);
+        border-color: var(--color-border, #ddd);
+    }
+    .attribute-note__btn--secondary:hover {
+        background: var(--color-surface-hover, #f5f5f5);
+    }
+
+    .attribute-note__btn--danger {
+        background: transparent;
+        color: var(--color-danger, #e05a4b);
+        border-color: transparent;
+    }
+    .attribute-note__btn--danger:hover {
+        background: var(--color-surface-danger, rgba(224, 90, 75, 0.08));
+        border-color: var(--color-danger, #e05a4b);
+    }
+</style>

--- a/src/lib/stores/attributeNotes.ts
+++ b/src/lib/stores/attributeNotes.ts
@@ -88,8 +88,11 @@ function createAttributeNotesStore() {
             update((notes) => {
                 const key = buildNoteKey(databaseId, collectionId, attributeKey);
                 const updated = { ...notes };
-                if (note.trim()) {
-                    updated[key] = note;
+                
+                const trimmedNote = note.trim();
+
+                if (trimmedNote) {
+                    updated[key] = trimmedNote;
                 } else {
                     delete updated[key];
                 }

--- a/src/lib/stores/attributeNotes.ts
+++ b/src/lib/stores/attributeNotes.ts
@@ -13,6 +13,7 @@
  * Issue: https://github.com/appwrite/appwrite/issues/11945
  */
 
+import { browser } from '$app/environment';
 import { writable } from 'svelte/store';
 
 const STORAGE_KEY = 'appwrite_attribute_notes';
@@ -38,6 +39,7 @@ function isNotesMap(value: unknown): value is NotesMap {
 }
 
 function loadFromStorage(): NotesMap {
+    if (!browser) return {};
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (!raw) return {};
@@ -52,6 +54,7 @@ function loadFromStorage(): NotesMap {
  * Persist notes map to localStorage.
  */
 function saveToStorage(notes: NotesMap): void {
+    if (!browser) return;
     try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
     } catch {

--- a/src/lib/stores/attributeNotes.ts
+++ b/src/lib/stores/attributeNotes.ts
@@ -1,0 +1,127 @@
+/**
+ * attributeNotes.ts
+ *
+ * Store for persisting developer notes on collection attributes/columns.
+ * Notes are stored in localStorage because the Appwrite API does not currently
+ * expose a `notes` field on attribute objects. This is a console-only feature.
+ *
+ * Storage key format:  appwrite_attribute_notes
+ * Data shape:          Record<string, string>
+ *   where key = `${databaseId}/${collectionId}/${attributeKey}`
+ *   and value = the note text
+ *
+ * Issue: https://github.com/appwrite/appwrite/issues/11945
+ */
+
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'appwrite_attribute_notes';
+
+type NotesMap = Record<string, string>;
+
+/**
+ * Build the compound key used to look up a note.
+ */
+export function buildNoteKey(
+    databaseId: string,
+    collectionId: string,
+    attributeKey: string
+): string {
+    return `${databaseId}/${collectionId}/${attributeKey}`;
+}
+
+/**
+ * Load notes map from localStorage, returning an empty object on any error.
+ */
+function loadFromStorage(): NotesMap {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return {};
+        return JSON.parse(raw) as NotesMap;
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Persist notes map to localStorage.
+ */
+function saveToStorage(notes: NotesMap): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+    } catch {
+        // Silently ignore storage errors (e.g. private browsing quota)
+    }
+}
+
+function createAttributeNotesStore() {
+    const { subscribe, set, update } = writable<NotesMap>(loadFromStorage());
+
+    return {
+        subscribe,
+
+        /**
+         * Get the note for a specific attribute.
+         */
+        getNote(databaseId: string, collectionId: string, attributeKey: string): string {
+            const notes = loadFromStorage();
+            return notes[buildNoteKey(databaseId, collectionId, attributeKey)] ?? '';
+        },
+
+        /**
+         * Save or clear a note for a specific attribute.
+         */
+        setNote(
+            databaseId: string,
+            collectionId: string,
+            attributeKey: string,
+            note: string
+        ): void {
+            update((notes) => {
+                const key = buildNoteKey(databaseId, collectionId, attributeKey);
+                const updated = { ...notes };
+                if (note.trim()) {
+                    updated[key] = note;
+                } else {
+                    delete updated[key];
+                }
+                saveToStorage(updated);
+                return updated;
+            });
+        },
+
+        /**
+         * Delete a note for a specific attribute (e.g. when attribute is deleted).
+         */
+        deleteNote(databaseId: string, collectionId: string, attributeKey: string): void {
+            update((notes) => {
+                const key = buildNoteKey(databaseId, collectionId, attributeKey);
+                const updated = { ...notes };
+                delete updated[key];
+                saveToStorage(updated);
+                return updated;
+            });
+        },
+
+        /**
+         * Delete all notes for a collection (e.g. when collection is deleted).
+         */
+        deleteCollectionNotes(databaseId: string, collectionId: string): void {
+            update((notes) => {
+                const prefix = `${databaseId}/${collectionId}/`;
+                const updated = Object.fromEntries(
+                    Object.entries(notes).filter(([k]) => !k.startsWith(prefix))
+                );
+                saveToStorage(updated);
+                return updated;
+            });
+        },
+
+        /** Re-sync from localStorage (useful after external changes). */
+        reload(): void {
+            set(loadFromStorage());
+        }
+    };
+}
+
+export const attributeNotes = createAttributeNotesStore();

--- a/src/lib/stores/attributeNotes.ts
+++ b/src/lib/stores/attributeNotes.ts
@@ -33,11 +33,16 @@ export function buildNoteKey(
 /**
  * Load notes map from localStorage, returning an empty object on any error.
  */
+function isNotesMap(value: unknown): value is NotesMap {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function loadFromStorage(): NotesMap {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (!raw) return {};
-        return JSON.parse(raw) as NotesMap;
+        const parsed: unknown = JSON.parse(raw);
+        return isNotesMap(parsed) ? parsed : {};
     } catch {
         return {};
     }

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import AttributeNote from '$lib/components/AttributeNote.svelte';
     import { Button } from '$lib/elements/forms';
     import { Container } from '$lib/layout';
     import {
@@ -408,6 +409,7 @@
                             alignItems="center"
                             justifyContent="space-between"
                             style="min-width:0">
+                
                             <Layout.Stack
                                 gap="s"
                                 inline
@@ -472,6 +474,13 @@
                                         <Badge size="xs" variant="secondary" content="required" />
                                     {/if}
                                 </Layout.Stack>
+
+                                <AttributeNote
+                                    databaseId={databaseId}
+                                    collectionId={table}
+                                    attributeKey={column.$id || column.key}
+                                />
+
                             </Layout.Stack>
                             {@const minMaxSize = getMinMaxSizeForColumn(column)}
                             {@const relationType = getRelationshipTypeForColumn(column)}


### PR DESCRIPTION
###  Summary

Adds support for internal notes on collection attributes, allowing better documentation and context management within the console.

###  Changes

* Added `AttributeNote.svelte` component for displaying and managing notes
* Created `attributeNotes.ts` store for handling state and logic
* Integrated notes functionality into attribute-related UI

###  Testing

* Verified UI renders correctly for attributes with and without notes
* Ensured notes persist and update properly through the store

###  Related Issue

Closes #11945

###  Notes

* This introduces a new UI component and store for attribute-level notes
* No breaking changes observed
