### PR TITLE
fix: gate documentsdb/vectorsdb list calls behind multi-db flag

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(entity)/helpers/sdk.ts
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(entity)/helpers/sdk.ts
@@ -1,4 +1,8 @@
 import { sdk } from '$lib/stores/sdk';
+import { flags } from '$lib/flags';
+import { user } from '$lib/stores/user';
+import { organization } from '$lib/stores/organization';
+import { get } from 'svelte/store';
 import type { Page } from '@sveltejs/kit';
 import type { TerminologyResult } from './types';
 import {
@@ -173,11 +177,17 @@ export function useDatabaseSdk(
         },
 
         async list(params): Promise<Models.DatabaseList> {
-            const results = await Promise.all([
-                baseSdk.tablesDB.list(params),
-                baseSdk.documentsDB.list(params),
-                baseSdk.vectorsDB.list(params)
-            ]);
+            const isMultiDb = flags.multiDb({
+                account: get(user),
+                organization: get(organization)
+            });
+
+            const calls: Array<Promise<Models.DatabaseList>> = [baseSdk.tablesDB.list(params)];
+            if (isMultiDb) {
+                calls.push(baseSdk.documentsDB.list(params), baseSdk.vectorsDB.list(params));
+            }
+
+            const results = await Promise.all(calls);
 
             return results.reduce(
                 (acc, curr) => ({


### PR DESCRIPTION
## Summary

The `useDatabaseSdk().list()` helper was unconditionally calling all three backends in parallel (`tablesDB`, `documentsDB`, `vectorsDB`), causing 404s on environments where the documentsdb/vectorsdb routes aren't exposed (e.g. staging/production with `isDevelopment()` gate) even when the `multi-db` feature flag is off.

## Fix

Gate the documentsdb/vectorsdb list calls behind `flags.multiDb`. When the flag is off, only `tablesDB.list()` is called.

## Test plan

- [ ] With `PUBLIC_CONSOLE_FEATURE_FLAGS=` (empty): only `/v1/tablesdb` is called from the databases page
- [ ] With `PUBLIC_CONSOLE_FEATURE_FLAGS=multi-db`: all three endpoints are called as before
- [ ] User/org prefs for `flags-multi-db` also enable all three