### PR TITLE
fix(vcs): restore installation ID on project Git settings

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { page } from '$app/state';
-    import { Avatar, CardGrid, PaginationInline } from '$lib/components';
+    import { Avatar, CardGrid, PaginationInline, Id } from '$lib/components';
     import { Button as FormButton } from '$lib/elements/forms';
     import { getApiEndpoint } from '$lib/stores/sdk';
     import type { Models } from '@appwrite.io/console';
@@ -100,11 +100,13 @@
                     let:root
                     columns={[
                         { id: 'owner', width: { min: 150, max: 500 } },
+                        { id: 'installationId', width: { min: 200, max: 400 } },
                         { id: 'updated', width: { min: 150, max: 500 } },
                         { id: 'actions', width: 60 }
                     ]}>
                     <svelte:fragment slot="header" let:root>
                         <Table.Header.Cell column="owner" {root}>Owner</Table.Header.Cell>
+                        <Table.Header.Cell column="installationId" {root}>Installation ID</Table.Header.Cell>
                         <Table.Header.Cell column="updated" {root}>Updated</Table.Header.Cell>
                         <Table.Header.Cell column="actions" {root} />
                     </svelte:fragment>
@@ -121,6 +123,11 @@
                                         {installation.organization}
                                     </Link>
                                 </Layout.Stack>
+                            </Table.Cell>
+                            <Table.Cell column="installationId" {root}>
+                                <Id value={installation.$id}>
+                                    {installation.$id}
+                                </Id>
                             </Table.Cell>
                             <Table.Cell column="updated" {root}>
                                 <DualTimeView time={installation.$updatedAt} />


### PR DESCRIPTION
I noticed the Git configuration card on the project Settings page only showed the provider owner and the last updated time. The `v1/vcs/installations` payload still includes each installation’s Appwrite id (`$id`), and that is the same value the Functions flow uses when you pick an installation in the connect-repo dropdown, so users were stuck guessing which id to pass into the Server SDK.

I added an `Installation ID` column to that table and render it with the existing `Id` tag so you can read it and copy it in one click, matching the pattern we already use on storage and other id-heavy tables.

Fixes #1895.
