### PR TITLE
fix(buckets): label the allowed-file-extensions input correctly

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/storage/bucket-[bucket]/settings/+page.svelte
@@ -412,9 +412,9 @@
                 <Layout.Stack gap="s">
                     {#key extensions.length}
                         <InputTags
-                            id="user-labels"
-                            label="Labels"
-                            placeholder="Select or type user labels"
+                            id="allowed-file-extensions"
+                            label="Allowed file extensions"
+                            placeholder="Select or type file extensions"
                             bind:tags={extensions} />
                     {/key}
                     <Layout.Stack direction="row" wrap="wrap">


### PR DESCRIPTION
Fixes #2443.

The tags input on **Storage > Bucket > Settings > Allowed File Extensions** is currently rendered as:

```svelte
<InputTags
    id=`user-labels`
    label=`Labels`
    placeholder=`Select or type user labels`
    bind:tags={extensions} />
```

which surfaces as `Labels` / `Select or type user labels` in the UI even though the field is the list of file extensions that the bucket will accept. The section heading directly above it already says `Allowed file extensions` and the surrounding state is `extensions` / `updateAllowedExtensions`, so the input is the only piece of the section still carrying the copy-paste name from an earlier labels component.

This PR updates the `id`, `label`, and `placeholder` on that `InputTags` so all three match the field's purpose. No behaviour change -- only the labelling that assistive tech and the placeholder hint read.

Before:
- id=`user-labels`, label=`Labels`, placeholder=`Select or type user labels`

After:
- id=`allowed-file-extensions`, label=`Allowed file extensions`, placeholder=`Select or type file extensions`

The previous attempt at this (#2530) was closed before landing; this revision also corrects the `id` / `label` alongside the placeholder so screen reader / form-autofill context is consistent with the visible section.