### PR TITLE
fix(sites): keep Other as the last framework filter

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/+page.ts
@@ -36,11 +36,13 @@ export const load = async ({ url, params }) => {
         'Lynx',
         'Angular',
         'Analog',
-        'Vite',
-        'Other'
+        'Vite'
     ];
 
     const frameworks = Array.from(frameworksSet).sort((a, b) => {
+        // 'Other' always sorts last, regardless of any other framework's position.
+        if (a === 'Other') return 1;
+        if (b === 'Other') return -1;
         const aIndex = frameworkOrder.indexOf(a);
         const bIndex = frameworkOrder.indexOf(b);
         if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);


### PR DESCRIPTION
Fixes #2895.

When listing templates in **Create project > Create site > Clone a template**, the Framework filter currently ends with `React Native` after `Other`, even though `Other` is meant to be the catch-all bucket at the bottom of the list.

## Root cause

`src/routes/(console)/project-[region]-[project]/sites/create-site/templates/+page.ts` sorts the framework filter against a hard-coded `frameworkOrder` array that ends with `'Other'`. The comparator pushes frameworks not in that list to the end (`aIndex === -1` -> return `1`), so any newly added framework that isn't in `frameworkOrder` ends up *after* `Other`. `React Native` is one such framework -- it has live templates but is not listed in `frameworkOrder`, so it renders at the very bottom.

## Fix

- Hoist the `Other` comparison above the indexed lookup so it always sorts last, regardless of whether or not it appears in `frameworkOrder`.
- Remove `'Other'` from `frameworkOrder` since its position is no longer encoded positionally.

Net effect: any framework not explicitly enumerated (e.g. `React Native`) sits between the explicitly ordered frameworks and `Other`, which matches the reporter's screenshot expectation.

No behaviour change for frameworks already listed in `frameworkOrder`; their order is preserved.