### PR TITLE
fix(platforms): let the Web framework grid reflow on narrow viewports

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/platforms/createWeb.svelte
@@ -494,7 +494,7 @@ APPWRITE_ENDPOINT = "${sdk.forProject(page.params.region, page.params.project).c
 
     .frameworks {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
         gap: var(--gap-l, 16px);
     }
 </style>


### PR DESCRIPTION
Fixes #2889.

The **Add Platform > Web** wizard uses a framework picker grid that is currently pinned at three equal columns:

```css
.frameworks {
    display: grid;
    grid-template-columns: repeat(3, 1fr);
    gap: var(--gap-l, 16px);
}
```

Below roughly 480px viewport width the three fixed tracks cannot accommodate each framework card's icon + title + description, so the card content overflows or wraps awkwardly (reproduction screenshot in the issue).

## Fix

Swap the track definition to `repeat(auto-fit, minmax(160px, 1fr))`. The grid now collapses to two columns, then one column, as the viewport narrows, and expands back to three columns (and beyond if the container ever grows wider) once there is room for three 160px cells. On wide viewports the layout is visually identical to what ships today.

## Why `auto-fit, minmax(160px, 1fr)`

- `160px` is the smallest width at which the existing card contents (64px icon + name + 1-line description) render cleanly without the content overflowing; the existing Flutter wizard uses the same approach for its platforms grid.
- `auto-fit` keeps rows balanced and doesn't leave ghost tracks on very wide viewports.
- `1fr` for the max keeps the three-up desktop look intact.