### PR TITLE
fix(billing): avoid crash when billingPlanDetails is undefined in ContainerButton

### DIFF
--- a/src/lib/layout/containerButton.svelte
+++ b/src/lib/layout/containerButton.svelte
@@ -10,10 +10,10 @@
 
     export let title: string;
     export let tooltipContent =
-        $organization?.billingPlanDetails.group === BillingPlanGroup.Starter
+        $organization?.billingPlanDetails?.group === BillingPlanGroup.Starter
             ? `Upgrade to add more ${title.toLocaleLowerCase()}`
             : `You've reached the ${title.toLocaleLowerCase()} limit for the ${
-                  $organization?.billingPlanDetails.name
+                  $organization?.billingPlanDetails?.name
               } plan`;
 
     export let disabled: boolean;


### PR DESCRIPTION
Fixes #2975.

## Symptom

On Appwrite 1.9.0 **self-hosted**, opening **Project > Functions > Templates** blanks the page with:

```
Uncaught TypeError: can't access property "group", n().billingPlanDetails is undefined
```

The same stack trace was previously reported against **Auth Security** and fixed by #2958; the underlying source still lives in `src/lib/layout/containerButton.svelte`, which is also used by the Functions Templates page and several other surfaces, so the bug resurfaces there.

## Root cause

`ContainerButton` computes its default `tooltipContent` at component instantiation:

```svelte
export let tooltipContent =
    $organization?.billingPlanDetails.group === BillingPlanGroup.Starter
        ? `Upgrade to add more ${title.toLocaleLowerCase()}`
        : `You've reached the ${title.toLocaleLowerCase()} limit for the ${
              $organization?.billingPlanDetails.name
          } plan`;
```

On self-hosted deployments, `organization` is populated but `billingPlanDetails` is `undefined` (there's no billing system). The optional chain stops at `organization`, but `.billingPlanDetails.group` / `.billingPlanDetails.name` are direct property reads, so the expression throws the moment any page containing a `ContainerButton` mounts.

## Fix

Promote both property reads to optional chaining:

```diff
-    $organization?.billingPlanDetails.group === BillingPlanGroup.Starter
+    $organization?.billingPlanDetails?.group === BillingPlanGroup.Starter
...
-                  $organization?.billingPlanDetails.name
+                  $organization?.billingPlanDetails?.name
```

On cloud, behaviour is unchanged -- `billingPlanDetails` is always populated, both reads resolve normally. On self-hosted, `group` becomes `undefined` (falling through to the plan-limit branch with `undefined` in place of the plan name), but the tooltip is only shown when the wrapping `disabled` prop is true, which self-hosted never hits via this path, so the cosmetic fallback is acceptable and the crash is gone.
