### PR TITLE
feat: add project scopes to API keys

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -500,6 +500,30 @@ export const scopes: ScopeDefinition[] = [
         description: "Access to create, update, and delete your project's API keys",
         category: 'Other',
         icon: 'globe'
+    },
+    {
+        scope: 'project.read',
+        description: "Access to read your project's information",
+        category: 'Other',
+        icon: 'globe'
+    },
+    {
+        scope: 'project.write',
+        description: "Access to update your project's information",
+        category: 'Other',
+        icon: 'globe'
+    },
+    {
+        scope: 'platforms.read',
+        description: "Access to read your project's platforms",
+        category: 'Other',
+        icon: 'globe'
+    },
+    {
+        scope: 'platforms.write',
+        description: "Access to create, update, and delete your project's platforms",
+        category: 'Other',
+        icon: 'globe'
     }
 ];
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -512,18 +512,6 @@ export const scopes: ScopeDefinition[] = [
         description: "Access to update your project's information",
         category: 'Other',
         icon: 'globe'
-    },
-    {
-        scope: 'platforms.read',
-        description: "Access to read your project's platforms",
-        category: 'Other',
-        icon: 'globe'
-    },
-    {
-        scope: 'platforms.write',
-        description: "Access to create, update, and delete your project's platforms",
-        category: 'Other',
-        icon: 'globe'
     }
 ];
 


### PR DESCRIPTION
## Summary

- Adds `project.read` and `project.write` to the API key scopes catalog (`src/lib/constants.ts`).
- Both land under the **Other** category in the API key creation/edit UI.
- Scopes already exist server-side in `appwrite/app/config/scopes/project.php` — this just exposes them in the console.

## Test plan

- [ ] Open Project → Overview → API keys → Create key
- [ ] Expand the **Other** accordion
- [ ] Verify `project.read` and `project.write` checkboxes appear with correct labels and descriptions
- [ ] Create a key with the new scopes selected; confirm it persists and the API call succeeds