### PR TITLE
fix: correct backup storage usage unit label

### DIFF
--- a/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/usage/[[invoice]]/+page.svelte
@@ -584,7 +584,7 @@
                         color: '#68A3FE',
                         tooltip: {
                             title: 'Backups storage',
-                            label: `${Math.round(bytesToSize(data.organizationUsage.backupsStorageTotal, 'GB') * 100) / 100}MB`
+                            label: `${Math.round(bytesToSize(data.organizationUsage.backupsStorageTotal, 'GB') * 100) / 100}GB`
                         }
                     },
                     {


### PR DESCRIPTION
  ## What does this PR do?

  Fixes an incorrect unit label in the organization usage breakdown.

  Backup storage was being converted to GB, but the displayed label used MB. This updates the label to GB so the value and unit match.

  ## Test Plan

  Verified the code path manually by checking the organization usage breakdown calculation.

  The backup storage value now uses bytesToSize(..., 'GB') and displays the GB unit consistently.

  ## Related PRs and Issues

  N/A

  ### Have you read the Contributing Guidelines on issues (https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

  Yes.