### PR TITLE
feat: combine bandwidth and realtime bandwidth into a single row with breakdown

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -376,6 +376,25 @@
                         maxFactory: ({ planLimit, hasLimit }) =>
                             hasLimit ? (planLimit || 0) * 1000 * 1000 * 1000 : null
                     }),
+                    // Legacy orgs still track realtime bandwidth separately (not yet
+                    // rolled into the bandwidth resource). Surface it as its own row
+                    // so the value is visible even though it can't fit as a slice
+                    // of the bandwidth bar.
+                    ...(realtimeBandwidthValue > bandwidthValue
+                        ? [
+                              createRow({
+                                  id: 'realtime-bandwidth',
+                                  label: 'Realtime bandwidth',
+                                  resource: realtimeBandwidth,
+                                  usageFormatter: ({ value }) => {
+                                      const size = humanFileSize(value);
+                                      return `${size.value} ${size.unit}`;
+                                  },
+                                  priceFormatter: ({ amount }) => formatCurrency(amount),
+                                  includeProgress: false
+                              })
+                          ]
+                        : []),
                     // standard resources (numeric)
                     createResourceRow(
                         'users',

--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -148,6 +148,50 @@
         ];
     }
 
+    function createBandwidthProgressData(
+        regularBytes: number,
+        realtimeBytes: number,
+        maxGB: number
+    ): Array<{ size: number; color: string; tooltip?: { title: string; label: string } }> {
+        if (maxGB <= 0) return [];
+
+        const maxBytes = maxGB * 1000 * 1000 * 1000;
+        const total = regularBytes + realtimeBytes;
+        const percentage = Math.min((total / maxBytes) * 100, 100);
+        const regularSize = humanFileSize(regularBytes);
+        const realtimeSize = humanFileSize(realtimeBytes);
+
+        const segments: Array<{
+            size: number;
+            color: string;
+            tooltip?: { title: string; label: string };
+        }> = [];
+
+        if (regularBytes > 0) {
+            segments.push({
+                size: regularBytes,
+                color: 'var(--bgcolor-neutral-invert)',
+                tooltip: {
+                    title: `${percentage.toFixed(0)}% used`,
+                    label: `Bandwidth: ${regularSize.value} ${regularSize.unit}`
+                }
+            });
+        }
+
+        if (realtimeBytes > 0) {
+            segments.push({
+                size: realtimeBytes,
+                color: 'var(--bgcolor-neutral-invert-weak)',
+                tooltip: {
+                    title: 'Realtime bandwidth',
+                    label: `${realtimeSize.value} ${realtimeSize.unit}`
+                }
+            });
+        }
+
+        return segments;
+    }
+
     function getResource(resources: Array<Models.UsageResources> | undefined, resourceId: string) {
         return resources?.find((resource) => resource.resourceId === resourceId);
     }
@@ -282,8 +326,15 @@
         const projects = (currentAggregation?.breakdown || []).map((projectData) => {
             const resources = projectData.resources || [];
             const bandwidth = getResource(resources, 'bandwidth');
+            const realtimeBandwidth = getResource(resources, 'realtimeBandwidth');
             const storage = getResource(resources, 'storage');
             const authPhone = getResource(resources, 'authPhone');
+
+            const bandwidthValue = bandwidth?.value || 0;
+            const realtimeBandwidthValue = realtimeBandwidth?.value || 0;
+            const combinedBandwidthValue = bandwidthValue + realtimeBandwidthValue;
+            const combinedBandwidthAmount =
+                (bandwidth?.amount || 0) + (realtimeBandwidth?.amount || 0);
 
             return {
                 id: `project-${projectData.$id}`,
@@ -302,14 +353,20 @@
                         label: 'Bandwidth',
                         resource: bandwidth,
                         planLimit: currentPlan?.bandwidth,
-                        usageFormatter: ({ value, planLimit, hasLimit }) =>
+                        usageFormatter: ({ planLimit, hasLimit }) =>
                             formatBandwidthUsage(
-                                value,
+                                combinedBandwidthValue,
                                 hasLimit ? (planLimit ?? undefined) : undefined
                             ),
-                        priceFormatter: ({ amount }) => formatCurrency(amount),
-                        progressFactory: ({ value, planLimit, hasLimit }) =>
-                            hasLimit ? createStorageProgressData(value, planLimit || 0) : [],
+                        priceFormatter: () => formatCurrency(combinedBandwidthAmount),
+                        progressFactory: ({ planLimit, hasLimit }) =>
+                            hasLimit
+                                ? createBandwidthProgressData(
+                                      bandwidthValue,
+                                      realtimeBandwidthValue,
+                                      planLimit || 0
+                                  )
+                                : [],
                         maxFactory: ({ planLimit, hasLimit }) =>
                             hasLimit ? (planLimit || 0) * 1000 * 1000 * 1000 : null
                     }),
@@ -383,15 +440,6 @@
                         getResource(resources, 'realtimeMessages'),
                         currentPlan?.realtimeMessages
                     ),
-                    createRow({
-                        id: 'realtime-bandwidth',
-                        label: 'Realtime bandwidth',
-                        resource: getResource(resources, 'realtimeBandwidth'),
-                        usageFormatter: ({ value }) =>
-                            humanFileSize(value).value + humanFileSize(value).unit,
-                        priceFormatter: ({ amount }) => formatCurrency(amount),
-                        includeProgress: false
-                    }),
                     createRow({
                         id: 'sms',
                         label: 'Phone OTP',

--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -149,17 +149,20 @@
     }
 
     function createBandwidthProgressData(
-        regularBytes: number,
+        totalBytes: number,
         realtimeBytes: number,
         maxGB: number
     ): Array<{ size: number; color: string; tooltip?: { title: string; label: string } }> {
         if (maxGB <= 0) return [];
 
         const maxBytes = maxGB * 1000 * 1000 * 1000;
-        const total = regularBytes + realtimeBytes;
-        const percentage = Math.min((total / maxBytes) * 100, 100);
-        const regularSize = humanFileSize(regularBytes);
-        const realtimeSize = humanFileSize(realtimeBytes);
+        const percentage = Math.min((totalBytes / maxBytes) * 100, 100);
+        // Backend already rolls realtimeBytes into totalBytes; carve the realtime
+        // slice out of the total instead of summing them. Clamp in case of dirty data.
+        const realtimePortion = Math.max(0, Math.min(realtimeBytes, totalBytes));
+        const regularPortion = Math.max(0, totalBytes - realtimePortion);
+        const regularSize = humanFileSize(regularPortion);
+        const realtimeSize = humanFileSize(realtimePortion);
 
         const segments: Array<{
             size: number;
@@ -167,9 +170,9 @@
             tooltip?: { title: string; label: string };
         }> = [];
 
-        if (regularBytes > 0) {
+        if (regularPortion > 0) {
             segments.push({
-                size: regularBytes,
+                size: regularPortion,
                 color: 'var(--bgcolor-neutral-invert)',
                 tooltip: {
                     title: `${percentage.toFixed(0)}% used`,
@@ -178,9 +181,9 @@
             });
         }
 
-        if (realtimeBytes > 0) {
+        if (realtimePortion > 0) {
             segments.push({
-                size: realtimeBytes,
+                size: realtimePortion,
                 color: 'var(--bgcolor-neutral-invert-weak)',
                 tooltip: {
                     title: 'Realtime bandwidth',
@@ -330,11 +333,11 @@
             const storage = getResource(resources, 'storage');
             const authPhone = getResource(resources, 'authPhone');
 
+            // Backend already rolls realtimeBandwidth value + amount into bandwidth;
+            // use the bandwidth resource directly and pass realtime only as a slice
+            // for the progress segment, never as an additive total.
             const bandwidthValue = bandwidth?.value || 0;
             const realtimeBandwidthValue = realtimeBandwidth?.value || 0;
-            const combinedBandwidthValue = bandwidthValue + realtimeBandwidthValue;
-            const combinedBandwidthAmount =
-                (bandwidth?.amount || 0) + (realtimeBandwidth?.amount || 0);
 
             return {
                 id: `project-${projectData.$id}`,
@@ -353,16 +356,16 @@
                         label: 'Bandwidth',
                         resource: bandwidth,
                         planLimit: currentPlan?.bandwidth,
-                        usageFormatter: ({ planLimit, hasLimit }) =>
+                        usageFormatter: ({ value, planLimit, hasLimit }) =>
                             formatBandwidthUsage(
-                                combinedBandwidthValue,
+                                value,
                                 hasLimit ? (planLimit ?? undefined) : undefined
                             ),
-                        priceFormatter: () => formatCurrency(combinedBandwidthAmount),
-                        progressFactory: ({ planLimit, hasLimit }) =>
+                        priceFormatter: ({ amount }) => formatCurrency(amount),
+                        progressFactory: ({ value, planLimit, hasLimit }) =>
                             hasLimit
                                 ? createBandwidthProgressData(
-                                      bandwidthValue,
+                                      value,
                                       realtimeBandwidthValue,
                                       planLimit || 0
                                   )

--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -157,10 +157,6 @@
 
         const maxBytes = maxGB * 1000 * 1000 * 1000;
         const percentage = Math.min((totalBytes / maxBytes) * 100, 100);
-        // Backend rolls realtimeBytes into totalBytes for billed orgs, so realtime
-        // is a slice of the total. A handful of legacy orgs still have realtime
-        // tracked separately (not billed yet) — for them realtime > total. In that
-        // case skip the breakdown and render the bandwidth as a single segment.
         const showRealtimeSegment = realtimeBytes > 0 && realtimeBytes <= totalBytes;
         const realtimePortion = showRealtimeSegment ? realtimeBytes : 0;
         const regularPortion = Math.max(0, totalBytes - realtimePortion);
@@ -336,9 +332,6 @@
             const storage = getResource(resources, 'storage');
             const authPhone = getResource(resources, 'authPhone');
 
-            // Backend already rolls realtimeBandwidth value + amount into bandwidth;
-            // use the bandwidth resource directly and pass realtime only as a slice
-            // for the progress segment, never as an additive total.
             const bandwidthValue = bandwidth?.value || 0;
             const realtimeBandwidthValue = realtimeBandwidth?.value || 0;
 
@@ -376,10 +369,6 @@
                         maxFactory: ({ planLimit, hasLimit }) =>
                             hasLimit ? (planLimit || 0) * 1000 * 1000 * 1000 : null
                     }),
-                    // Legacy orgs still track realtime bandwidth separately (not yet
-                    // rolled into the bandwidth resource). Surface it as its own row
-                    // so the value is visible even though it can't fit as a slice
-                    // of the bandwidth bar.
                     ...(realtimeBandwidthValue > bandwidthValue
                         ? [
                               createRow({

--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -157,9 +157,12 @@
 
         const maxBytes = maxGB * 1000 * 1000 * 1000;
         const percentage = Math.min((totalBytes / maxBytes) * 100, 100);
-        // Backend already rolls realtimeBytes into totalBytes; carve the realtime
-        // slice out of the total instead of summing them. Clamp in case of dirty data.
-        const realtimePortion = Math.max(0, Math.min(realtimeBytes, totalBytes));
+        // Backend rolls realtimeBytes into totalBytes for billed orgs, so realtime
+        // is a slice of the total. A handful of legacy orgs still have realtime
+        // tracked separately (not billed yet) — for them realtime > total. In that
+        // case skip the breakdown and render the bandwidth as a single segment.
+        const showRealtimeSegment = realtimeBytes > 0 && realtimeBytes <= totalBytes;
+        const realtimePortion = showRealtimeSegment ? realtimeBytes : 0;
         const regularPortion = Math.max(0, totalBytes - realtimePortion);
         const regularSize = humanFileSize(regularPortion);
         const realtimeSize = humanFileSize(realtimePortion);


### PR DESCRIPTION
## Summary

Combines the bandwidth and realtime bandwidth usage rows into a single row with a progress-bar breakdown so the two metrics show their relative contribution to the bandwidth quota in one view, rather than as two disconnected rows.

## Test plan

- [ ] Open Organization Billing → Usage and verify the bandwidth row now shows a single progress bar with realtime bandwidth visually distinguished as part of the total
- [ ] Hover / inspect to confirm both numeric values are still surfaced
- [ ] Confirm projects with zero realtime bandwidth still render correctly (no empty segment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)