### PR TITLE
perf: eliminate wasted API call, afterUpdate overhead, and sequential billing checks

### DIFF
--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -8,7 +8,7 @@
     import { database, checkForDatabaseBackupPolicies } from '$lib/stores/database';
     import { newOrgModal, organization } from '$lib/stores/organization';
     import { wizard } from '$lib/stores/wizard';
-    import { afterUpdate, onMount } from 'svelte';
+    import { onMount } from 'svelte';
     import { loading } from '$routes/store';
     import { requestedMigration } from '../store';
     import Create from './createOrganization.svelte';
@@ -280,10 +280,12 @@
         }
     }
 
-    database.subscribe(async (database) => {
-        if (!database || !page.params.region || !page.params.project) return;
-        // the component checks `isCloud` internally.
-        await checkForDatabaseBackupPolicies(page.params.region, page.params.project, database);
+    onMount(() => {
+        return database.subscribe(async (database) => {
+            if (!database || !page.params.region || !page.params.project) return;
+            // the component checks `isCloud` internally.
+            await checkForDatabaseBackupPolicies(page.params.region, page.params.project, database);
+        });
     });
 
     let currentOrganizationId = null;
@@ -293,18 +295,21 @@
         if (isCloud) {
             currentOrganizationId = org.$id;
             checkForEnterpriseTrial(org);
-            await checkForUsageLimit(org);
             checkForMarkedForDeletion(org);
-            await checkForNewDevUpgradePro(org);
+
+            const billingChecks: Promise<unknown>[] = [
+                checkForUsageLimit(org),
+                checkForNewDevUpgradePro(org)
+            ];
 
             if (org?.billingPlanDetails.requiresPaymentMethod) {
-                await paymentExpired(org);
-                await checkPaymentAuthorizationRequired(org);
-
+                billingChecks.push(paymentExpired(org), checkPaymentAuthorizationRequired(org));
                 if (org?.billingTrialDays) {
                     calculateTrialDay(org);
                 }
             }
+
+            await Promise.all(billingChecks);
             $activeHeaderAlert = headerAlert.getExcluding('impersonation');
         }
     }
@@ -317,9 +322,7 @@
 
     $registerSearchers(orgSearcher, projectsSearcher);
 
-    afterUpdate(() => {
-        $activeHeaderAlert = headerAlert.getExcluding('impersonation');
-    });
+    $: void $headerAlert, ($activeHeaderAlert = headerAlert.getExcluding('impersonation'));
 </script>
 
 <CommandCenter />

--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -322,7 +322,7 @@
 
     $registerSearchers(orgSearcher, projectsSearcher);
 
-    $: void $headerAlert, ($activeHeaderAlert = headerAlert.getExcluding('impersonation'));
+    $: (void $headerAlert, ($activeHeaderAlert = headerAlert.getExcluding('impersonation')));
 </script>
 
 <CommandCenter />

--- a/src/routes/(console)/+layout.ts
+++ b/src/routes/(console)/+layout.ts
@@ -3,7 +3,7 @@ import { isCloud } from '$lib/system';
 import type { LayoutLoad } from './$types';
 import type { Account } from '$lib/stores/user';
 import { Dependencies } from '$lib/constants';
-import { Platform, Query, type Models } from '@appwrite.io/console';
+import { Platform, type Models } from '@appwrite.io/console';
 import { makePlansMap } from '$lib/helpers/billing';
 import { plansInfo as plansInfoStore } from '$lib/stores/billing';
 import { normalizeConsoleVariables } from '$lib/helpers/domains';
@@ -54,7 +54,6 @@ export const load: LayoutLoad = async ({ depends, parent, url }) => {
             currentOrgId: undefined,
             organizations,
             consoleVariables,
-            allProjectsCount: 0,
             plansInfo: plansInfo ?? null,
             version: versionData?.version ?? null
         };
@@ -107,28 +106,6 @@ export const load: LayoutLoad = async ({ depends, parent, url }) => {
         preferences.organization ??
         (organizations.teams.length > 0 ? organizations.teams[0].$id : undefined);
 
-    // Load projects for the current organization if one is selected
-    let projectsCount = 0;
-    if (currentOrgId) {
-        try {
-            projectsCount = (
-                await sdk.forConsole.projects.list({
-                    queries: [
-                        Query.equal('teamId', currentOrgId),
-                        Query.limit(1),
-                        Query.select(['$id'])
-                    ]
-                })
-            ).total;
-        } catch (e) {
-            if (shouldRedirectToVerifyEmail(e)) {
-                redirect(303, verifyEmailUrl);
-            }
-
-            projectsCount = 0;
-        }
-    }
-
     // just in case!
     plansInfoStore.set(fallbackPlansInfoArray);
 
@@ -139,7 +116,6 @@ export const load: LayoutLoad = async ({ depends, parent, url }) => {
         currentOrgId,
         organizations,
         consoleVariables,
-        allProjectsCount: projectsCount,
         plansInfo: fallbackPlansInfoArray,
         version: versionData?.version ?? null
     };


### PR DESCRIPTION
… billing checks

- Remove unused projects.list() call fired on every console load (result was never consumed)
- Replace afterUpdate with reactive headerAlert subscription to avoid per-render overhead
- Parallelize billing checks with Promise.all instead of sequential awaits
- Fix database.subscribe() memory leak by wrapping in onMount for proper cleanup

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)