### PR TITLE
feat: add backup policy migration support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@93d2dfa",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@8f00f95",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -124,7 +124,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@93d2dfa", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@8f00f95", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@93d2dfa",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@8f00f95",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -47,6 +47,9 @@ const initialFormData = {
     messaging: {
         root: false,
         messages: false
+    },
+    backups: {
+        root: false
     }
 };
 
@@ -84,7 +87,8 @@ export const ResourcesFriendly = {
     provider: { singular: 'Provider', plural: 'Providers' },
     topic: { singular: 'Topic', plural: 'Topics' },
     subscriber: { singular: 'Subscriber', plural: 'Subscribers' },
-    message: { singular: 'Message', plural: 'Messages' }
+    message: { singular: 'Message', plural: 'Messages' },
+    'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -147,6 +151,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.messaging.messages) {
         addResource(MigrationResources.Message);
+    }
+    if (formData.backups.root) {
+        addResource(MigrationResources.Backuppolicy);
     }
 
     return resources as ProviderResourceMap[P];
@@ -223,6 +230,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Message)) {
         formData.messaging.messages = true;
+    }
+    if (resources.includes(MigrationResources.Backuppolicy)) {
+        formData.backups.root = true;
     }
 
     return formData;

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -115,6 +115,10 @@
             return resources.includes(MigrationResources.Provider);
         }
 
+        if (groupKey === 'backups') {
+            return resources.includes(MigrationResources.Backuppolicy);
+        }
+
         const groupToResource: Record<string, MigrationResource> = {
             users: MigrationResources.User,
             databases: MigrationResources.Database
@@ -135,7 +139,8 @@
             functions: 'function',
             storage: 'bucket',
             sites: 'site',
-            messaging: 'provider'
+            messaging: 'provider',
+            backups: 'backuppolicy'
         };
         return map[groupKey] || groupKey;
     };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -140,7 +140,7 @@
             storage: 'bucket',
             sites: 'site',
             messaging: 'provider',
-            backups: 'backuppolicy'
+            backups: 'backup-policy'
         };
         return map[groupKey] || groupKey;
     };

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -33,6 +33,9 @@
         messaging: {
             root: 'Messaging',
             messages: 'Include messages'
+        },
+        backups: {
+            root: 'Backup policies'
         }
     };
 
@@ -56,6 +59,9 @@
         messaging: {
             root: 'Import all messaging providers, topics and subscribers',
             messages: 'Import all messages'
+        },
+        backups: {
+            root: 'Import all backup policies'
         }
     };
 


### PR DESCRIPTION
## Summary

Adds **Backup Policies** as a selectable resource group in the Appwrite migration wizard. When users migrate from one cloud project to another, they can now opt to import backup policies alongside users, databases, storage, etc.

Backed by the cloud backup-policy migration support shipped in [appwrite-labs/cloud#3619](https://github.com/appwrite-labs/cloud/pull/3619) (cloud `Sources/Appwrite::exportBackupPolicies` + `Destinations/Appwrite::importBackupResource`) and [appwrite/appwrite#11632](https://github.com/appwrite/appwrite/pull/11632) (`utopia-php/migration` 1.9.6 added `Resource::TYPE_BACKUP_POLICY`).

## Changes

| File | Change |
|---|---|
| `package.json` | Bumped `@appwrite.io/console` SDK pin (`93d2dfa` → `8f00f95`) for `AppwriteMigrationResource.Backuppolicy` enum value and `MigrationReport.backuppolicy` field |
| `bun.lock` | Refreshed |
| `src/lib/stores/migration.ts` | Added `backups: { root: false }` form section; added `'backup-policy'` to `ResourcesFriendly`; mapped form ↔ resource in `migrationFormToResources` and `resourcesToMigrationForm` |
| `src/routes/(console)/(migration-wizard)/resource-form.svelte` | Added `'backups'` case in `shouldRenderGroup` (only shown if source supports `Backuppolicy`); added `'backups': 'backup-policy'` in `getReportKey` so the count badge resolves against the JSON field name |
| `src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte` | Added `backups: { root: 'Backup policies' }` label and matching description |

## Verification

- `bun run check` — 0 errors (85 pre-existing warnings, none in touched files)
- `bun run format` — clean
- `bun run lint` — 0 errors (336 pre-existing warnings)
- `bun run test:unit` — 235 tests, all passed
- Manually verified end-to-end against a cloud stack pointed at `appwrite-labs/cloud#3619`: the form's "Backup policies" checkbox lights up when source supports it, the count badge populates from the migration report, and selecting it triggers a successful round-trip migration of policies between two Pro-tier projects.

## Test plan

- [ ] Open the migration wizard for a project where the source supports `backup-policy`
- [ ] Verify the "Backup policies" group appears at the bottom of the resource list with a count badge
- [ ] Select the checkbox and run the migration; verify policies arrive on the destination with the same `name`, `services`, `retention`, `schedule`, `enabled`
- [ ] Verify the "Backup policies" group is hidden when the source doesn't support it (e.g., self-hosted Appwrite)

## Cross-repo dependency

Requires the matching cloud changes in [#3619](https://github.com/appwrite-labs/cloud/pull/3619) to be merged first (so the SDK enum and report field are live).