### PR TITLE
Confirm create-org and upgrade-plan payments on-session

### DIFF
--- a/src/lib/components/billing/alerts/paymentProcessing.svelte
+++ b/src/lib/components/billing/alerts/paymentProcessing.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+    import { page } from '$app/state';
+    import { HeaderAlert } from '$lib/layout';
+    import { hideBillingHeaderRoutes, teamStatusUpgrading } from '$lib/stores/billing';
+    import { organization } from '$lib/stores/organization';
+</script>
+
+{#if $organization?.$id && $organization?.status === teamStatusUpgrading && !hideBillingHeaderRoutes.includes(page.url.pathname)}
+    <HeaderAlert title="Payment is processing" type="info">
+        Your plan will activate within a few minutes. You can keep using {$organization.name} while we
+        confirm the charge with your bank.
+    </HeaderAlert>
+{/if}

--- a/src/lib/components/billing/selectPaymentMethod.svelte
+++ b/src/lib/components/billing/selectPaymentMethod.svelte
@@ -50,10 +50,10 @@
         {#if selectedPaymentMethod?.country?.toLowerCase() === 'in'}
             <Alert.Inline status="warning">
                 <svelte:fragment slot="title">Indian credit or debit card-holders</svelte:fragment>
-                To comply with RBI regulations in India, Appwrite will ask for verification to charge
-                up to $150 USD on your payment method. We will never charge more than the cost of your
-                plan and the resources you use, or your budget cap limit. For higher usage limits, please
-                contact us.
+                To comply with RBI regulations in India, you will be asked to authenticate the first charge
+                during checkout, and Appwrite will set up a mandate to charge up to $150 USD on your payment
+                method for future renewals. We will never charge more than the cost of your plan and the
+                resources you use, or your budget cap limit. For higher usage limits, please contact us.
             </Alert.Inline>
         {/if}
         <InputSelect

--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -8,6 +8,7 @@ import MarkedForDeletion from '$lib/components/billing/alerts/markedForDeletion.
 import MissingPaymentMethod from '$lib/components/billing/alerts/missingPaymentMethod.svelte';
 import newDevUpgradePro from '$lib/components/billing/alerts/newDevUpgradePro.svelte';
 import PaymentAuthRequired from '$lib/components/billing/alerts/paymentAuthRequired.svelte';
+import PaymentProcessing from '$lib/components/billing/alerts/paymentProcessing.svelte';
 
 import { NEW_DEV_PRO_UPGRADE_COUPON } from '$lib/constants';
 import { cachedStore } from '$lib/helpers/cache';
@@ -57,6 +58,7 @@ export const roles = [
 ];
 
 export const teamStatusReadonly = 'readonly';
+export const teamStatusUpgrading = 'upgrading';
 export const billingLimitOutstandingInvoice = 'outstanding_invoice';
 
 export const paymentMethods = derived(
@@ -583,6 +585,17 @@ export function checkForMarkedForDeletion(org: Models.Organization) {
             component: MarkedForDeletion,
             show: true,
             importance: 10
+        });
+    }
+}
+
+export function checkForUpgradingStatus(org: Models.Organization) {
+    if (org?.status === teamStatusUpgrading) {
+        headerAlert.add({
+            id: 'paymentProcessing',
+            component: PaymentProcessing,
+            show: true,
+            importance: 5
         });
     }
 }

--- a/src/lib/stores/stripe.ts
+++ b/src/lib/stores/stripe.ts
@@ -200,11 +200,10 @@ export async function confirmPayment(config: {
     const { clientSecret, paymentMethodId, orgId, route, redirectIfRequired } = config;
 
     try {
-        const resolvedUrl = resolve('/(console)/organization-[organization]/billing', {
-            organization: orgId
-        });
-
-        const url = window.location.origin + (route ? route : resolvedUrl);
+        const url =
+            window.location.origin +
+            (route ??
+                resolve('/(console)/organization-[organization]/billing', { organization: orgId }));
 
         const paymentMethod = await sdk.forConsole.account.getPaymentMethod({ paymentMethodId });
 
@@ -252,16 +251,19 @@ export async function confirmPayment(config: {
             throw error.message;
         }
     } catch (e) {
+        const underlying =
+            typeof e === 'string' ? e : ((e as { message?: string })?.message ?? null);
         addNotification({
             title: 'Error',
             message:
+                underlying ??
                 'There was an error processing your payment, try again later. If the problem persists, please contact support.',
             type: 'error'
         });
         if (redirectIfRequired) {
             return {
                 status: 'error',
-                message: typeof e === 'string' ? e : (e?.message ?? 'Payment confirmation failed')
+                message: underlying ?? 'Payment confirmation failed'
             };
         }
     }

--- a/src/lib/stores/stripe.ts
+++ b/src/lib/stores/stripe.ts
@@ -186,13 +186,18 @@ export async function setPaymentMethod(providerMethodId: string, name: string, s
     }
 }
 
+export type ConfirmPaymentOutcome =
+    | { status: 'succeeded' | 'processing' | 'requires_action' }
+    | { status: 'error'; message: string };
+
 export async function confirmPayment(config: {
     clientSecret: string;
     paymentMethodId: string;
     orgId?: string;
     route?: string;
-}) {
-    const { clientSecret, paymentMethodId, orgId, route } = config;
+    redirectIfRequired?: boolean;
+}): Promise<ConfirmPaymentOutcome | undefined> {
+    const { clientSecret, paymentMethodId, orgId, route, redirectIfRequired } = config;
 
     try {
         const resolvedUrl = resolve('/(console)/organization-[organization]/billing', {
@@ -203,8 +208,40 @@ export async function confirmPayment(config: {
 
         const paymentMethod = await sdk.forConsole.account.getPaymentMethod({ paymentMethodId });
 
+        if (redirectIfRequired) {
+            const { paymentIntent, error } = await get(stripe).confirmPayment({
+                clientSecret,
+                confirmParams: {
+                    return_url: url,
+                    payment_method: paymentMethod.providerMethodId
+                },
+                redirect: 'if_required'
+            });
+
+            if (error) {
+                addNotification({
+                    title: 'Error',
+                    message:
+                        error.message ??
+                        'There was an error processing your payment, try again later. If the problem persists, please contact support.',
+                    type: 'error'
+                });
+                return { status: 'error', message: error.message ?? 'Payment confirmation failed' };
+            }
+
+            const status = paymentIntent?.status;
+            if (status === 'succeeded' || status === 'processing' || status === 'requires_action') {
+                return { status };
+            }
+
+            return {
+                status: 'error',
+                message: `Unexpected payment status: ${status ?? 'unknown'}`
+            };
+        }
+
         const { error } = await get(stripe).confirmPayment({
-            clientSecret: clientSecret,
+            clientSecret,
             confirmParams: {
                 return_url: url,
                 payment_method: paymentMethod.providerMethodId
@@ -221,6 +258,12 @@ export async function confirmPayment(config: {
                 'There was an error processing your payment, try again later. If the problem persists, please contact support.',
             type: 'error'
         });
+        if (redirectIfRequired) {
+            return {
+                status: 'error',
+                message: typeof e === 'string' ? e : (e?.message ?? 'Payment confirmation failed')
+            };
+        }
     }
 }
 

--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -18,6 +18,7 @@
         checkForMarkedForDeletion,
         checkForMissingPaymentMethod,
         checkForNewDevUpgradePro,
+        checkForUpgradingStatus,
         checkForUsageLimit,
         checkPaymentAuthorizationRequired,
         paymentExpired,
@@ -295,6 +296,7 @@
             checkForEnterpriseTrial(org);
             await checkForUsageLimit(org);
             checkForMarkedForDeletion(org);
+            checkForUpgradingStatus(org);
             await checkForNewDevUpgradePro(org);
 
             if (org?.billingPlanDetails.requiresPaymentMethod) {

--- a/src/routes/(console)/create-organization/+page.svelte
+++ b/src/routes/(console)/create-organization/+page.svelte
@@ -11,7 +11,8 @@
     import {
         billingIdToPlan,
         getBasePlanFromGroup,
-        isPaymentAuthenticationRequired
+        isPaymentAuthenticationRequired,
+        teamStatusUpgrading
     } from '$lib/stores/billing';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
@@ -106,11 +107,21 @@
             });
 
             if (!isPaymentAuthenticationRequired(org)) {
+                await invalidate(Dependencies.ACCOUNT);
                 await preloadAndNavigate(org.$id);
-                addNotification({
-                    type: 'success',
-                    message: `${org.name ?? 'Organization'} has been created`
-                });
+
+                if (org.status === teamStatusUpgrading) {
+                    addNotification({
+                        type: 'info',
+                        message:
+                            'Payment is processing — your plan will activate within a few minutes.'
+                    });
+                } else {
+                    addNotification({
+                        type: 'success',
+                        message: `${org.name ?? 'Organization'} has been created`
+                    });
+                }
             }
         } catch (e) {
             addNotification({
@@ -144,8 +155,8 @@
                 });
 
                 if (isPaymentAuthenticationRequired(org)) {
-                    let clientSecret = org.clientSecret;
-                    let params = new URLSearchParams();
+                    const clientSecret = org.clientSecret;
+                    const params = new URLSearchParams();
                     params.append('type', 'payment_confirmed');
                     params.append('id', org.organizationId);
                     for (const [key, value] of page.url.searchParams.entries()) {
@@ -156,11 +167,20 @@
                     params.append('invites', collaborators.join(','));
                     const resolvedUrl = resolve('/(console)/create-organization');
 
-                    await confirmPayment({
+                    const outcome = await confirmPayment({
                         clientSecret,
                         paymentMethodId,
-                        route: `${resolvedUrl}?${params}`
+                        route: `${resolvedUrl}?${params}`,
+                        redirectIfRequired: true
                     });
+
+                    if (!outcome || outcome.status === 'error') {
+                        return;
+                    }
+
+                    if (outcome.status === 'requires_action') {
+                        return;
+                    }
 
                     await validate(org.organizationId, collaborators);
                 }

--- a/src/routes/(console)/create-organization/+page.svelte
+++ b/src/routes/(console)/create-organization/+page.svelte
@@ -175,6 +175,14 @@
                     });
 
                     if (!outcome || outcome.status === 'error') {
+                        try {
+                            await sdk.forConsole.organizations.validatePayment({
+                                organizationId: org.organizationId,
+                                invites: []
+                            });
+                        } catch {
+                            // expected: backend throws BILLING_PAYMENT_FAILED after deleting the draft team
+                        }
                         return;
                     }
 

--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -293,6 +293,14 @@
                 });
 
                 if (!outcome || outcome.status === 'error') {
+                    try {
+                        await sdk.forConsole.organizations.validatePayment({
+                            organizationId: org.organizationId,
+                            invites: []
+                        });
+                    } catch {
+                        // expected: backend throws BILLING_PAYMENT_FAILED and rolls back the upgrade
+                    }
                     return;
                 }
 

--- a/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/change-plan/+page.svelte
@@ -12,7 +12,8 @@
     import {
         billingIdToPlan,
         getBasePlanFromGroup,
-        isPaymentAuthenticationRequired
+        isPaymentAuthenticationRequired,
+        teamStatusUpgrading
     } from '$lib/stores/billing';
     import { addNotification } from '$lib/stores/notifications';
     import { currentPlan, organization } from '$lib/stores/organization';
@@ -220,10 +221,19 @@
                 await invalidate(Dependencies.ORGANIZATION);
 
                 await goto(previousPage);
-                addNotification({
-                    type: 'success',
-                    message: 'Your organization has been upgraded'
-                });
+
+                if (org.status === teamStatusUpgrading) {
+                    addNotification({
+                        type: 'info',
+                        message:
+                            'Payment is processing — your plan will activate within a few minutes.'
+                    });
+                } else {
+                    addNotification({
+                        type: 'success',
+                        message: 'Your organization has been upgraded'
+                    });
+                }
 
                 trackEvent(Submit.OrganizationUpgrade, {
                     plan: selectedPlan?.name
@@ -259,8 +269,8 @@
             });
 
             if (isPaymentAuthenticationRequired(org)) {
-                let clientSecret = org.clientSecret;
-                let params = new URLSearchParams();
+                const clientSecret = org.clientSecret;
+                const params = new URLSearchParams();
                 for (const [key, value] of page.url.searchParams.entries()) {
                     if (key !== 'type' && key !== 'id') {
                         params.append(key, value);
@@ -275,11 +285,21 @@
                     organization: org.organizationId
                 });
 
-                await confirmPayment({
+                const outcome = await confirmPayment({
                     clientSecret,
                     paymentMethodId,
-                    route: `${resolvedUrl}?${params.toString()}`
+                    route: `${resolvedUrl}?${params.toString()}`,
+                    redirectIfRequired: true
                 });
+
+                if (!outcome || outcome.status === 'error') {
+                    return;
+                }
+
+                if (outcome.status === 'requires_action') {
+                    return;
+                }
+
                 await validate(org.organizationId, collaborators);
             }
 

--- a/src/routes/(console)/organization-[organization]/settings/BAA.svelte
+++ b/src/routes/(console)/organization-[organization]/settings/BAA.svelte
@@ -160,12 +160,48 @@
                 const settingsUrl = resolve('/(console)/organization-[organization]/settings', {
                     organization: $organization.$id
                 });
-                await confirmPayment({
+                const outcome = await confirmPayment({
                     clientSecret: paymentAuth.clientSecret,
                     paymentMethodId: $organization.paymentMethodId,
                     orgId: $organization.$id,
-                    route: `${settingsUrl}?type=confirm-addon&addonId=${paymentAuth.addonId}`
+                    route: `${settingsUrl}?type=confirm-addon&addonId=${paymentAuth.addonId}`,
+                    redirectIfRequired: true
                 });
+
+                if (!outcome || outcome.status === 'error') {
+                    trackError(
+                        new Error(outcome?.status === 'error' ? outcome.message : 'Payment failed'),
+                        Submit.BAAAddonEnable
+                    );
+                    return;
+                }
+
+                if (outcome.status === 'requires_action') {
+                    return;
+                }
+
+                await sdk.forConsole.organizations.confirmAddonPayment({
+                    organizationId: $organization.$id,
+                    addonId: paymentAuth.addonId
+                });
+
+                await Promise.all([
+                    invalidate(Dependencies.ADDONS),
+                    invalidate(Dependencies.ORGANIZATION)
+                ]);
+
+                if (outcome.status === 'processing') {
+                    addNotification({
+                        message: "BAA addon payment is processing — we'll activate it shortly.",
+                        type: 'info'
+                    });
+                } else {
+                    addNotification({
+                        message: 'BAA addon has been enabled',
+                        type: 'success'
+                    });
+                }
+                trackEvent(Submit.BAAAddonEnable);
                 return;
             }
 

--- a/src/routes/(console)/organization-[organization]/settings/BAAEnableModal.svelte
+++ b/src/routes/(console)/organization-[organization]/settings/BAAEnableModal.svelte
@@ -39,12 +39,49 @@
                 const settingsUrl = resolve('/(console)/organization-[organization]/settings', {
                     organization: $organization.$id
                 });
-                await confirmPayment({
+                const outcome = await confirmPayment({
                     clientSecret: paymentAuth.clientSecret,
                     paymentMethodId: $organization.paymentMethodId,
                     orgId: $organization.$id,
-                    route: `${settingsUrl}?type=confirm-addon&addonId=${paymentAuth.addonId}`
+                    route: `${settingsUrl}?type=confirm-addon&addonId=${paymentAuth.addonId}`,
+                    redirectIfRequired: true
                 });
+
+                if (!outcome || outcome.status === 'error') {
+                    if (outcome?.status === 'error') {
+                        error = outcome.message;
+                        trackError(new Error(outcome.message), Submit.BAAAddonEnable);
+                    }
+                    return;
+                }
+
+                if (outcome.status === 'requires_action') {
+                    return;
+                }
+
+                await sdk.forConsole.organizations.confirmAddonPayment({
+                    organizationId: $organization.$id,
+                    addonId: paymentAuth.addonId
+                });
+
+                await Promise.all([
+                    invalidate(Dependencies.ADDONS),
+                    invalidate(Dependencies.ORGANIZATION)
+                ]);
+
+                if (outcome.status === 'processing') {
+                    addNotification({
+                        message: "BAA addon payment is processing — we'll activate it shortly.",
+                        type: 'info'
+                    });
+                } else {
+                    addNotification({
+                        message: 'BAA addon has been enabled',
+                        type: 'success'
+                    });
+                }
+                trackEvent(Submit.BAAAddonEnable);
+                show = false;
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Updates the `create-organization` and `change-plan` submit flows to confirm PaymentIntents on-session via `stripe.confirmPayment({redirect: 'if_required'})`, treating `PaymentAuthentication` as the expected default path for paid plans rather than a 3DS edge case.
- Adds a `ConfirmPaymentOutcome` return shape to the `confirmPayment` helper in `lib/stores/stripe.ts` so callers can branch cleanly on `succeeded` / `processing` / `requires_action` / `error`. Other call sites (`account/payments`, `billing/+page.svelte`, BAA enable, retry-invoice) keep the existing redirect-default behavior.
- Adds a `paymentProcessing.svelte` header alert + `checkForUpgradingStatus()` which registers it at importance 5 (below readonly / budget / mark-for-deletion / enterpriseTrial / paymentAuthRequired) when team status is `upgrading`, so the user is not blocked while Stripe is still settling the first charge.
- Relaxes the Indian card-holder warning copy in `selectPaymentMethod.svelte`: the \$150 mandate context now refers to future renewals rather than the no-longer-applicable first-charge 24h delay.

## Why
For Indian cards bound by an RBI mandate, the first charge had to wait through a 24h pre-debit notification window when initiated off-session. The team document sat in `upgrading` / `draft` and the user was effectively blocked. Authenticating the first charge on-session removes the notification window. Renewals continue to use the existing off-session mandate flow.

## Test plan
- [x] `bun run lint` — no new errors
- [x] `bun run check` — no new errors in modified files
- [x] `bun run test:unit` — 235 passed
- [ ] Manual: create new org with US, EU-3DS and IN mandate cards; verify success / processing / error UX
- [ ] Manual: upgrade plan; verify "Payment is processing" alert appears while Stripe settles and clears once the webhook flips the team to `active`
- [ ] Manual: failed card during create-org; verify error surfaces and the form can be resubmitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)