### PR TITLE
fix(backups): show 'Skipped' label for skipped scheduled archives

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/backups/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/backups/table.svelte
@@ -99,6 +99,8 @@
                 return 'processing';
             case 'failed':
                 return 'failed';
+            // pink-svelte's Status union has no 'skipped' — fall back to the
+            // neutral 'waiting' visual and override the label below.
             case 'skipped':
                 return 'waiting';
             default:

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/backups/table.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/backups/table.svelte
@@ -99,9 +99,18 @@
                 return 'processing';
             case 'failed':
                 return 'failed';
+            case 'skipped':
+                return 'waiting';
             default:
                 return 'waiting';
         }
+    }
+
+    function getBackupStatusLabel(backup: Models.BackupArchive): string {
+        if (backup.status === 'skipped') {
+            return 'Skipped';
+        }
+        return capitalize(getBackupStatus(backup));
     }
 
     async function deleteSingleBackup(archiveId: string) {
@@ -231,7 +240,7 @@
                 </Table.Cell>
                 <Table.Cell column="status" {root}>
                     {@const backupStatus = getBackupStatus(backup)}
-                    <Status status={backupStatus} label={capitalize(backupStatus)} />
+                    <Status status={backupStatus} label={getBackupStatusLabel(backup)} />
                     <!--{#if backup.status === 'Failed'}-->
                     <!--    <span class="u-underline">Get support</span>-->
                     <!--{/if}-->


### PR DESCRIPTION
## Summary

Companion to appwrite-labs/cloud#3972. Cloud now records a terminal `archives` row with `status='skipped'` whenever a scheduled cron tick is dropped because the previous run hadn't finished. Without a console mapping the row would render as a generic "Waiting" badge with no clue why.

This maps `skipped` → the neutral `waiting` Status visual but overrides the label so the user sees **"Skipped"**.

- The Restore action stays gated on `status === 'completed'`, so skipped rows correctly show only Copy ID / Delete in the actions menu.
- The Size column already shows `-` for any non-`completed` status, so skipped rows render `-` automatically.

## Test plan

- [ ] Run cloud with the linked PR, create an hourly backup policy on a slow database, and confirm a row labeled "Skipped" appears in the backups table for each cron tick that overlapped a still-running backup.
- [x] `bun x prettier --check` clean on the touched file.
- [x] `bun run check` shows no new errors in the touched file (the existing 768 errors are pre-existing across the codebase).

## Notes

- `pink-svelte`'s `Status` component union type is `"waiting" | "ready" | "processing" | "pending" | "failed" | "complete"` — no `skipped`. Mapping to `waiting` is the cleanest no-redesign choice; the visual is gray/neutral, which reads as "didn't run". A dedicated `skipped` style in pink-svelte would be a follow-up if we want stronger visual differentiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)