### PR TITLE
fix: treat deprecated scopes as selectable and fix badge count

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/overview/api-keys/scopes.svelte
+++ b/src/routes/(console)/project-[region]-[project]/overview/api-keys/scopes.svelte
@@ -186,7 +186,7 @@
         const { detail } = event;
         if (detail === 'indeterminate') return;
         filteredScopes.forEach((s) => {
-            if (s.category === category && !s.deprecated) {
+            if (s.category === category) {
                 activeScopes[s.scope] = detail;
             }
         });
@@ -217,7 +217,7 @@
             {@const checked = categoryState(category, scopes)}
             {@const isLastItem = index === categories.length - 1}
             {@const scopesLength = filteredScopes.filter(
-                (n) => n.category === category && effectiveScopes.includes(n.scope)
+                (n) => n.category === category && activeScopes[n.scope]
             ).length}
             <Accordion
                 selectable


### PR DESCRIPTION
Deprecated scopes were excluded from category toggle and Select All, causing the selected scope count badge to disagree with actual state. Badge count now reads from activeScopes directly instead of effectiveScopes to avoid reactivity lag. Deprecated scopes still display the Deprecated badge for visibility.