### PR TITLE
feat: support platform resource in migration wizard

### DIFF
--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -11,11 +11,16 @@ export type MigrationResource =
     | AppwriteMigrationResource
     | FirebaseMigrationResource
     | NHostMigrationResource
-    | SupabaseMigrationResource;
+    | SupabaseMigrationResource
+    | 'platform';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-export const MigrationResources = AppwriteMigrationResource;
+// Platform is augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
+export const MigrationResources = {
+    ...AppwriteMigrationResource,
+    Platform: 'platform'
+} as const;
 
 type ProviderResourceMap = {
     appwrite: AppwriteMigrationResource[];
@@ -49,6 +54,9 @@ const initialFormData = {
         messages: false
     },
     backups: {
+        root: false
+    },
+    integrations: {
         root: false
     }
 };
@@ -88,11 +96,15 @@ export const ResourcesFriendly = {
     topic: { singular: 'Topic', plural: 'Topics' },
     subscriber: { singular: 'Subscriber', plural: 'Subscribers' },
     message: { singular: 'Message', plural: 'Messages' },
-    'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' }
+    'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
+    platform: { singular: 'Platform', plural: 'Platforms' }
 };
 
 export const providerResources: ProviderResourceMap = {
-    appwrite: Object.values(AppwriteMigrationResource),
+    appwrite: [
+        ...Object.values(AppwriteMigrationResource),
+        MigrationResources.Platform as AppwriteMigrationResource
+    ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
     firebase: Object.values(FirebaseMigrationResource)
@@ -154,6 +166,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.backups.root) {
         addResource(MigrationResources.Backuppolicy);
+    }
+    if (formData.integrations.root) {
+        addResource(MigrationResources.Platform);
     }
 
     return resources as ProviderResourceMap[P];
@@ -233,6 +248,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Backuppolicy)) {
         formData.backups.root = true;
+    }
+    if (resources.includes(MigrationResources.Platform)) {
+        formData.integrations.root = true;
     }
 
     return formData;

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -119,6 +119,10 @@
             return resources.includes(MigrationResources.Backuppolicy);
         }
 
+        if (groupKey === 'integrations') {
+            return resources.includes(MigrationResources.Platform);
+        }
+
         const groupToResource: Record<string, MigrationResource> = {
             users: MigrationResources.User,
             databases: MigrationResources.Database
@@ -140,7 +144,8 @@
             storage: 'bucket',
             sites: 'site',
             messaging: 'provider',
-            backups: 'backup-policy'
+            backups: 'backup-policy',
+            integrations: 'platform'
         };
         return map[groupKey] || groupKey;
     };

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -36,6 +36,9 @@
         },
         backups: {
             root: 'Backup policies'
+        },
+        integrations: {
+            root: 'Platforms'
         }
     };
 
@@ -62,6 +65,9 @@
         },
         backups: {
             root: 'Import all backup policies'
+        },
+        integrations: {
+            root: 'Import all platforms (web, Flutter, iOS, Android, etc.)'
         }
     };
 


### PR DESCRIPTION
## Summary
- Add `Platforms` group (Integrations) to the migration wizard's resource selection
- Augment `MigrationResources` locally with `Platform = 'platform'` until the [appwrite/console SDK](https://github.com/appwrite/sdk-for-console) regenerates against the new spec

## Test plan
- [ ] Open Project Settings → Migrations → New Migration
- [ ] Pick Appwrite as the provider, fill in credentials
- [ ] On the resource step, confirm the new "Platforms" group appears with the report count
- [ ] Run the migration and confirm platforms are migrated

## Cross-repo
Depends on:
- appwrite/appwrite#11439
- utopia-php/migration#154