### PR TITLE
Add project variable migration wizard support

### DIFF
--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -13,15 +13,18 @@ export type MigrationResource =
     | NHostMigrationResource
     | SupabaseMigrationResource
     | 'platform'
-    | 'api-key';
+    | 'api-key'
+    | 'project-variable';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform and ApiKey are augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
+// Platform, ApiKey and ProjectVariable are augmented locally until @appwrite.io/console
+// SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
-    ApiKey: 'api-key'
+    ApiKey: 'api-key',
+    ProjectVariable: 'project-variable'
 } as const;
 
 type ProviderResourceMap = {
@@ -61,6 +64,9 @@ const initialFormData = {
     integrations: {
         root: false,
         apiKeys: false
+    },
+    settings: {
+        root: false
     }
 };
 
@@ -101,14 +107,16 @@ export const ResourcesFriendly = {
     message: { singular: 'Message', plural: 'Messages' },
     'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
     platform: { singular: 'Platform', plural: 'Platforms' },
-    'api-key': { singular: 'API Key', plural: 'API Keys' }
+    'api-key': { singular: 'API Key', plural: 'API Keys' },
+    'project-variable': { singular: 'Project Variable', plural: 'Project Variables' }
 };
 
 export const providerResources: ProviderResourceMap = {
     appwrite: [
         ...Object.values(AppwriteMigrationResource),
         MigrationResources.Platform as AppwriteMigrationResource,
-        MigrationResources.ApiKey as AppwriteMigrationResource
+        MigrationResources.ApiKey as AppwriteMigrationResource,
+        MigrationResources.ProjectVariable as AppwriteMigrationResource
     ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
@@ -177,6 +185,9 @@ export const migrationFormToResources = <P extends Provider>(
         if (formData.integrations.apiKeys) {
             addResource(MigrationResources.ApiKey);
         }
+    }
+    if (formData.settings.root) {
+        addResource(MigrationResources.ProjectVariable);
     }
 
     return resources as ProviderResourceMap[P];
@@ -263,6 +274,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     if (resources.includes(MigrationResources.ApiKey)) {
         formData.integrations.root = true;
         formData.integrations.apiKeys = true;
+    }
+    if (resources.includes(MigrationResources.ProjectVariable)) {
+        formData.settings.root = true;
     }
 
     return formData;

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -126,6 +126,10 @@
             );
         }
 
+        if (groupKey === 'settings') {
+            return resources.includes(MigrationResources.ProjectVariable);
+        }
+
         const groupToResource: Record<string, MigrationResource> = {
             users: MigrationResources.User,
             databases: MigrationResources.Database
@@ -148,7 +152,8 @@
             sites: 'site',
             messaging: 'provider',
             backups: 'backup-policy',
-            integrations: 'platform'
+            integrations: 'platform',
+            settings: 'project-variable'
         };
         return map[groupKey] || groupKey;
     };

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -40,6 +40,9 @@
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
+        },
+        settings: {
+            root: 'Project variables'
         }
     };
 
@@ -70,6 +73,9 @@
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',
             apiKeys: 'Import all API keys with their scopes and expiration'
+        },
+        settings: {
+            root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)'
         }
     };
 


### PR DESCRIPTION
## Summary

Stacks on the api-key console PR. Adds project-variable as its own top-level group in the migration wizard, parallel to platforms and api-keys.

## Cross-repo

- utopia-php/migration#184
- appwrite/appwrite#12313
- appwrite-labs/cloud#4034