### PR TITLE
Add webhook migration wizard support

### DIFF
--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -14,17 +14,19 @@ export type MigrationResource =
     | SupabaseMigrationResource
     | 'platform'
     | 'api-key'
-    | 'project-variable';
+    | 'project-variable'
+    | 'webhook';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform, ApiKey and ProjectVariable are augmented locally until @appwrite.io/console
-// SDK is regenerated against the new spec.
+// Platform, ApiKey, ProjectVariable and Webhook are augmented locally until
+// @appwrite.io/console SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
     ApiKey: 'api-key',
-    ProjectVariable: 'project-variable'
+    ProjectVariable: 'project-variable',
+    Webhook: 'webhook'
 } as const;
 
 type ProviderResourceMap = {
@@ -66,7 +68,8 @@ const initialFormData = {
         apiKeys: false
     },
     settings: {
-        root: false
+        root: false,
+        webhooks: false
     }
 };
 
@@ -108,7 +111,8 @@ export const ResourcesFriendly = {
     'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
     platform: { singular: 'Platform', plural: 'Platforms' },
     'api-key': { singular: 'API Key', plural: 'API Keys' },
-    'project-variable': { singular: 'Project Variable', plural: 'Project Variables' }
+    'project-variable': { singular: 'Project Variable', plural: 'Project Variables' },
+    webhook: { singular: 'Webhook', plural: 'Webhooks' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -116,7 +120,8 @@ export const providerResources: ProviderResourceMap = {
         ...Object.values(AppwriteMigrationResource),
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
-        MigrationResources.ProjectVariable as AppwriteMigrationResource
+        MigrationResources.ProjectVariable as AppwriteMigrationResource,
+        MigrationResources.Webhook as AppwriteMigrationResource
     ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
@@ -188,6 +193,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.settings.root) {
         addResource(MigrationResources.ProjectVariable);
+        if (formData.settings.webhooks) {
+            addResource(MigrationResources.Webhook);
+        }
     }
 
     return resources as ProviderResourceMap[P];
@@ -277,6 +285,10 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.ProjectVariable)) {
         formData.settings.root = true;
+    }
+    if (resources.includes(MigrationResources.Webhook)) {
+        formData.settings.root = true;
+        formData.settings.webhooks = true;
     }
 
     return formData;

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -127,7 +127,10 @@
         }
 
         if (groupKey === 'settings') {
-            return resources.includes(MigrationResources.ProjectVariable);
+            return (
+                resources.includes(MigrationResources.ProjectVariable) ||
+                resources.includes(MigrationResources.Webhook)
+            );
         }
 
         const groupToResource: Record<string, MigrationResource> = {

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -42,7 +42,8 @@
             apiKeys: 'Include API keys'
         },
         settings: {
-            root: 'Project variables'
+            root: 'Project variables',
+            webhooks: 'Include webhooks'
         }
     };
 
@@ -75,7 +76,8 @@
             apiKeys: 'Import all API keys with their scopes and expiration'
         },
         settings: {
-            root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)'
+            root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)',
+            webhooks: 'Import all webhooks (signing secrets are not exposed by the SDK; the destination regenerates a fresh signature key for each)'
         }
     };
 


### PR DESCRIPTION
## Summary

Stacks on #3044. Adds webhook as its own top-level group in the migration wizard, parallel to platforms / api-keys / project-variables.

The description text warns operators that signing secrets don't survive the migration (SDK constraint — see utopia-php/migration#185).

## Cross-repo

- utopia-php/migration#185
- appwrite/appwrite#12314
- appwrite-labs/cloud#4035