### PR TITLE
Add API key migration wizard support

### DIFF
--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -12,14 +12,16 @@ export type MigrationResource =
     | FirebaseMigrationResource
     | NHostMigrationResource
     | SupabaseMigrationResource
-    | 'platform';
+    | 'platform'
+    | 'api-key';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform is augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
+// Platform and ApiKey are augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
-    Platform: 'platform'
+    Platform: 'platform',
+    ApiKey: 'api-key'
 } as const;
 
 type ProviderResourceMap = {
@@ -57,7 +59,8 @@ const initialFormData = {
         root: false
     },
     integrations: {
-        root: false
+        root: false,
+        apiKeys: false
     }
 };
 
@@ -97,13 +100,15 @@ export const ResourcesFriendly = {
     subscriber: { singular: 'Subscriber', plural: 'Subscribers' },
     message: { singular: 'Message', plural: 'Messages' },
     'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
-    platform: { singular: 'Platform', plural: 'Platforms' }
+    platform: { singular: 'Platform', plural: 'Platforms' },
+    'api-key': { singular: 'API Key', plural: 'API Keys' }
 };
 
 export const providerResources: ProviderResourceMap = {
     appwrite: [
         ...Object.values(AppwriteMigrationResource),
-        MigrationResources.Platform as AppwriteMigrationResource
+        MigrationResources.Platform as AppwriteMigrationResource,
+        MigrationResources.ApiKey as AppwriteMigrationResource
     ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
@@ -169,6 +174,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
+        if (formData.integrations.apiKeys) {
+            addResource(MigrationResources.ApiKey);
+        }
     }
 
     return resources as ProviderResourceMap[P];
@@ -251,6 +259,10 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;
+    }
+    if (resources.includes(MigrationResources.ApiKey)) {
+        formData.integrations.root = true;
+        formData.integrations.apiKeys = true;
     }
 
     return formData;

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -120,7 +120,10 @@
         }
 
         if (groupKey === 'integrations') {
-            return resources.includes(MigrationResources.Platform);
+            return (
+                resources.includes(MigrationResources.Platform) ||
+                resources.includes(MigrationResources.ApiKey)
+            );
         }
 
         const groupToResource: Record<string, MigrationResource> = {

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -38,7 +38,8 @@
             root: 'Backup policies'
         },
         integrations: {
-            root: 'Platforms'
+            root: 'Platforms',
+            apiKeys: 'Include API keys'
         }
     };
 
@@ -67,7 +68,8 @@
             root: 'Import all backup policies'
         },
         integrations: {
-            root: 'Import all platforms (web, Flutter, iOS, Android, etc.)'
+            root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',
+            apiKeys: 'Import all API keys with their scopes and expiration'
         }
     };
 


### PR DESCRIPTION
## Summary

Stacks on #3043. Adds api-key as its own top-level resource group in the migration wizard, parallel to platforms.

Backend uses the kebab-case `'api-key'` resource id (matches `Resource::TYPE_API_KEY` in utopia-php/migration). The form field name `apiKeys` stays camelCase as it's a local property.

## Cross-repo

- utopia-php/migration#183
- appwrite/appwrite#12308
- appwrite-labs/cloud#4032