### PR TITLE
feat: add dedicated 402 budget limit error page

### DIFF
--- a/src/routes/(console)/+error.svelte
+++ b/src/routes/(console)/+error.svelte
@@ -24,10 +24,10 @@
     <section class="budget-error">
         <div class="budget-error__content">
             <Layout.Stack gap="s" alignItems="center">
-                <Badge type="error" variant="secondary" content="Budget limit reached" />
+                <Badge type="error" variant="secondary" content="Billing limit reached" />
                 <Layout.Stack gap="xs" alignItems="center">
                     <Typography.Title size="l" align="center">
-                        Your organization has reached its budget limit
+                        Your organization has reached a billing limit
                     </Typography.Title>
                     <Typography.Text align="center">
                         Access to resources has been blocked. Update your billing settings to

--- a/src/routes/(console)/+error.svelte
+++ b/src/routes/(console)/+error.svelte
@@ -5,7 +5,12 @@
     import { Button } from '$lib/elements/forms';
     import { isVerifyEmailRedirectError } from '$lib/helpers/emailVerification';
     import { Container } from '$lib/layout';
-    import { Typography } from '@appwrite.io/pink-svelte';
+    import { Badge, Layout, Typography } from '@appwrite.io/pink-svelte';
+
+    const isPaymentError = $derived(page.status === 402);
+    const billingUrl = $derived(
+        page.params.organization ? `${base}/organization-${page.params.organization}/billing` : null
+    );
 
     $effect(() => {
         const verifyEmailPath = resolve('/verify-email');
@@ -15,15 +20,59 @@
     });
 </script>
 
-<Container>
-    <div>
-        <Typography.Title size="xl"
-            >{'status' in page.error
-                ? page.error.status || 'Invalid Argument'
-                : 'Invalid Argument'}</Typography.Title>
-        <Typography.Title>{page.error.message}</Typography.Title>
-    </div>
-    <div>
-        <Button href={base}>Back to the console</Button>
-    </div>
-</Container>
+{#if isPaymentError}
+    <section class="budget-error">
+        <div class="budget-error__content">
+            <Layout.Stack gap="s" alignItems="center">
+                <Badge type="error" variant="secondary" content="Budget limit reached" />
+                <Layout.Stack gap="xs" alignItems="center">
+                    <Typography.Title size="l" align="center">
+                        Your organization has reached its budget limit
+                    </Typography.Title>
+                    <Typography.Text align="center">
+                        Access to resources has been blocked. Update your billing settings to
+                        restore access.
+                    </Typography.Text>
+                </Layout.Stack>
+                <div class="u-margin-block-start-16">
+                    <Layout.Stack direction="row" gap="s" justifyContent="center">
+                        {#if billingUrl}
+                            <Button href={billingUrl}>Go to billing</Button>
+                        {/if}
+                        <Button secondary href="{base}/account/organizations"
+                            >Change organization</Button>
+                    </Layout.Stack>
+                </div>
+            </Layout.Stack>
+        </div>
+    </section>
+{:else}
+    <Container>
+        <div>
+            <Typography.Title size="xl"
+                >{'status' in page.error
+                    ? page.error.status || 'Invalid Argument'
+                    : 'Invalid Argument'}</Typography.Title>
+            <Typography.Title>{page.error.message}</Typography.Title>
+        </div>
+        <div>
+            <Button href={base}>Back to the console</Button>
+        </div>
+    </Container>
+{/if}
+
+<style>
+    .budget-error {
+        min-height: calc(100vh - 48px - 2rem);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 4rem 1.5rem;
+        text-align: center;
+    }
+
+    .budget-error__content {
+        width: min(100%, 33rem);
+        max-width: 33rem;
+    }
+</style>

--- a/src/routes/(console)/+error.svelte
+++ b/src/routes/(console)/+error.svelte
@@ -29,10 +29,7 @@
                     <Typography.Title size="l" align="center">
                         Your organization has reached a billing limit
                     </Typography.Title>
-                    <Typography.Text align="center">
-                        Access to resources has been blocked. Update your billing settings to
-                        restore access.
-                    </Typography.Text>
+                    <Typography.Text align="center">{page.error.message}</Typography.Text>
                 </Layout.Stack>
                 <div class="u-margin-block-start-16">
                     <Layout.Stack direction="row" gap="s" justifyContent="center">

--- a/src/routes/(console)/project-[region]-[project]/+error.svelte
+++ b/src/routes/(console)/project-[region]-[project]/+error.svelte
@@ -31,10 +31,7 @@
                     <Typography.Title size="l" align="center">
                         Your organization has reached a billing limit
                     </Typography.Title>
-                    <Typography.Text align="center">
-                        Access to this resource has been blocked. Update your billing settings to
-                        restore access.
-                    </Typography.Text>
+                    <Typography.Text align="center">{page.error.message}</Typography.Text>
                 </Layout.Stack>
                 <div class="u-margin-block-start-16">
                     <Layout.Stack direction="row" gap="s" justifyContent="center">

--- a/src/routes/(console)/project-[region]-[project]/+error.svelte
+++ b/src/routes/(console)/project-[region]-[project]/+error.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+    import { base } from '$app/paths';
     import { page } from '$app/state';
     import { Button } from '$lib/elements/forms';
-    import { currentPlan, organizationList } from '$lib/stores/organization';
+    import { currentPlan, organization, organizationList } from '$lib/stores/organization';
     import SupportWizard from '$routes/(console)/supportWizard.svelte';
     import { wizard } from '$lib/stores/wizard';
     import { Badge, Layout, Typography } from '@appwrite.io/pink-svelte';
     import type { Models } from '@appwrite.io/console';
-
     function contactSupport() {
         wizard.start(SupportWizard);
     }
@@ -16,9 +16,39 @@
     );
 
     $: hasPremiumSupport = $currentPlan?.premiumSupport ?? allOrgsHavePremiumSupport ?? false;
+
+    $: orgId = $organization?.$id;
+    $: billingUrl = orgId ? `${base}/organization-${orgId}/billing` : null;
+    $: isPaymentError = page.status === 402;
 </script>
 
-{#if page.error.type === 'general_resource_blocked'}
+{#if isPaymentError}
+    <section class="resource-blocked">
+        <div class="resource-blocked__content">
+            <Layout.Stack gap="s" alignItems="center">
+                <Badge type="error" variant="secondary" content="Budget limit reached" />
+                <Layout.Stack gap="xs" alignItems="center">
+                    <Typography.Title size="l" align="center">
+                        Your organization has reached its budget limit
+                    </Typography.Title>
+                    <Typography.Text align="center">
+                        Access to this resource has been blocked. Update your billing settings to
+                        restore access.
+                    </Typography.Text>
+                </Layout.Stack>
+                <div class="u-margin-block-start-16">
+                    <Layout.Stack direction="row" gap="s" justifyContent="center">
+                        {#if billingUrl}
+                            <Button href={billingUrl}>Go to billing</Button>
+                        {/if}
+                        <Button secondary href="{base}/account/organizations"
+                            >Change organization</Button>
+                    </Layout.Stack>
+                </div>
+            </Layout.Stack>
+        </div>
+    </section>
+{:else if page.error.type === 'general_resource_blocked'}
     <section class="resource-blocked">
         <div class="resource-blocked__content">
             <Layout.Stack gap="s" alignItems="center">

--- a/src/routes/(console)/project-[region]-[project]/+error.svelte
+++ b/src/routes/(console)/project-[region]-[project]/+error.svelte
@@ -26,10 +26,10 @@
     <section class="resource-blocked">
         <div class="resource-blocked__content">
             <Layout.Stack gap="s" alignItems="center">
-                <Badge type="error" variant="secondary" content="Budget limit reached" />
+                <Badge type="error" variant="secondary" content="Billing limit reached" />
                 <Layout.Stack gap="xs" alignItems="center">
                     <Typography.Title size="l" align="center">
-                        Your organization has reached its budget limit
+                        Your organization has reached a billing limit
                     </Typography.Title>
                     <Typography.Text align="center">
                         Access to this resource has been blocked. Update your billing settings to


### PR DESCRIPTION
Replace generic error display for 402 responses with a dedicated budget limit error page. Includes a 'Go to billing' CTA when an organization is in context, and a 'Change organization' secondary action on both console-level and project-level error pages.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

<img width="2820" height="1370" alt="image" src="https://github.com/user-attachments/assets/1a8d18dd-a40d-4e85-bc1f-f682555753a4" />
<img width="2800" height="1372" alt="image" src="https://github.com/user-attachments/assets/d5e1b3a0-912a-4247-8814-af60d2e6da6b" />


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)