### PR TITLE
Add Custom Domains + SMTP migration wizard support

### DIFF
--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -14,17 +14,19 @@ export type MigrationResource =
     | SupabaseMigrationResource
     | 'platform'
     | 'api-key'
-    | 'project-variable';
+    | 'project-variable'
+    | 'webhook';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform, ApiKey and ProjectVariable are augmented locally until @appwrite.io/console
-// SDK is regenerated against the new spec.
+// Platform, ApiKey, ProjectVariable and Webhook are augmented locally until
+// @appwrite.io/console SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
     ApiKey: 'api-key',
-    ProjectVariable: 'project-variable'
+    ProjectVariable: 'project-variable',
+    Webhook: 'webhook'
 } as const;
 
 type ProviderResourceMap = {
@@ -66,7 +68,8 @@ const initialFormData = {
         apiKeys: false
     },
     settings: {
-        root: false
+        root: false,
+        webhooks: false
     }
 };
 
@@ -108,7 +111,8 @@ export const ResourcesFriendly = {
     'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
     platform: { singular: 'Platform', plural: 'Platforms' },
     'api-key': { singular: 'API Key', plural: 'API Keys' },
-    'project-variable': { singular: 'Project Variable', plural: 'Project Variables' }
+    'project-variable': { singular: 'Project Variable', plural: 'Project Variables' },
+    webhook: { singular: 'Webhook', plural: 'Webhooks' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -116,7 +120,8 @@ export const providerResources: ProviderResourceMap = {
         ...Object.values(AppwriteMigrationResource),
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
-        MigrationResources.ProjectVariable as AppwriteMigrationResource
+        MigrationResources.ProjectVariable as AppwriteMigrationResource,
+        MigrationResources.Webhook as AppwriteMigrationResource
     ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
@@ -188,6 +193,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.settings.root) {
         addResource(MigrationResources.ProjectVariable);
+        if (formData.settings.webhooks) {
+            addResource(MigrationResources.Webhook);
+        }
     }
 
     return resources as ProviderResourceMap[P];
@@ -277,6 +285,10 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.ProjectVariable)) {
         formData.settings.root = true;
+    }
+    if (resources.includes(MigrationResources.Webhook)) {
+        formData.settings.root = true;
+        formData.settings.webhooks = true;
     }
 
     return formData;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -17,12 +17,14 @@ export type MigrationResource =
     | 'project-variable'
     | 'webhook'
     | 'auth-methods'
-    | 'protocols';
+    | 'protocols'
+    | 'labels';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform, ApiKey, ProjectVariable, Webhook, AuthMethods and Protocols are
-// augmented locally until @appwrite.io/console SDK is regenerated.
+// Project-level singleton resources (Platform, ApiKey, ProjectVariable,
+// Webhook, AuthMethods, Protocols, Labels) are augmented locally until
+// @appwrite.io/console SDK is regenerated.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
@@ -30,7 +32,8 @@ export const MigrationResources = {
     ProjectVariable: 'project-variable',
     Webhook: 'webhook',
     AuthMethods: 'auth-methods',
-    Protocols: 'protocols'
+    Protocols: 'protocols',
+    Labels: 'labels'
 } as const;
 
 type ProviderResourceMap = {
@@ -71,6 +74,9 @@ const initialFormData = {
         root: false
     },
     protocols: {
+        root: false
+    },
+    labels: {
         root: false
     },
     integrations: {
@@ -124,7 +130,8 @@ export const ResourcesFriendly = {
     'project-variable': { singular: 'Project Variable', plural: 'Project Variables' },
     webhook: { singular: 'Webhook', plural: 'Webhooks' },
     'auth-methods': { singular: 'Auth method config', plural: 'Auth method config' },
-    protocols: { singular: 'Protocol config', plural: 'Protocol config' }
+    protocols: { singular: 'Protocol config', plural: 'Protocol config' },
+    labels: { singular: 'Project labels', plural: 'Project labels' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -132,6 +139,7 @@ export const providerResources: ProviderResourceMap = {
         ...Object.values(AppwriteMigrationResource),
         MigrationResources.AuthMethods as AppwriteMigrationResource,
         MigrationResources.Protocols as AppwriteMigrationResource,
+        MigrationResources.Labels as AppwriteMigrationResource,
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
         MigrationResources.ProjectVariable as AppwriteMigrationResource,
@@ -204,6 +212,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.protocols.root) {
         addResource(MigrationResources.Protocols);
+    }
+    if (formData.labels.root) {
+        addResource(MigrationResources.Labels);
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
@@ -301,6 +312,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Protocols)) {
         formData.protocols.root = true;
+    }
+    if (resources.includes(MigrationResources.Labels)) {
+        formData.labels.root = true;
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -18,13 +18,14 @@ export type MigrationResource =
     | 'webhook'
     | 'auth-methods'
     | 'protocols'
-    | 'labels';
+    | 'labels'
+    | 'services';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
 // Project-level singleton resources (Platform, ApiKey, ProjectVariable,
-// Webhook, AuthMethods, Protocols, Labels) are augmented locally until
-// @appwrite.io/console SDK is regenerated.
+// Webhook, AuthMethods, Protocols, Labels, Services) are augmented locally
+// until @appwrite.io/console SDK is regenerated.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
@@ -33,7 +34,8 @@ export const MigrationResources = {
     Webhook: 'webhook',
     AuthMethods: 'auth-methods',
     Protocols: 'protocols',
-    Labels: 'labels'
+    Labels: 'labels',
+    Services: 'services'
 } as const;
 
 type ProviderResourceMap = {
@@ -77,6 +79,9 @@ const initialFormData = {
         root: false
     },
     labels: {
+        root: false
+    },
+    services: {
         root: false
     },
     integrations: {
@@ -131,7 +136,8 @@ export const ResourcesFriendly = {
     webhook: { singular: 'Webhook', plural: 'Webhooks' },
     'auth-methods': { singular: 'Auth method config', plural: 'Auth method config' },
     protocols: { singular: 'Protocol config', plural: 'Protocol config' },
-    labels: { singular: 'Project labels', plural: 'Project labels' }
+    labels: { singular: 'Project labels', plural: 'Project labels' },
+    services: { singular: 'Services config', plural: 'Services config' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -140,6 +146,7 @@ export const providerResources: ProviderResourceMap = {
         MigrationResources.AuthMethods as AppwriteMigrationResource,
         MigrationResources.Protocols as AppwriteMigrationResource,
         MigrationResources.Labels as AppwriteMigrationResource,
+        MigrationResources.Services as AppwriteMigrationResource,
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
         MigrationResources.ProjectVariable as AppwriteMigrationResource,
@@ -215,6 +222,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.labels.root) {
         addResource(MigrationResources.Labels);
+    }
+    if (formData.services.root) {
+        addResource(MigrationResources.Services);
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
@@ -315,6 +325,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Labels)) {
         formData.labels.root = true;
+    }
+    if (resources.includes(MigrationResources.Services)) {
+        formData.services.root = true;
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -12,14 +12,16 @@ export type MigrationResource =
     | FirebaseMigrationResource
     | NHostMigrationResource
     | SupabaseMigrationResource
-    | 'platform';
+    | 'platform'
+    | 'api-key';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform is augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
+// Platform and ApiKey are augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
-    Platform: 'platform'
+    Platform: 'platform',
+    ApiKey: 'api-key'
 } as const;
 
 type ProviderResourceMap = {
@@ -57,7 +59,8 @@ const initialFormData = {
         root: false
     },
     integrations: {
-        root: false
+        root: false,
+        apiKeys: false
     }
 };
 
@@ -97,13 +100,15 @@ export const ResourcesFriendly = {
     subscriber: { singular: 'Subscriber', plural: 'Subscribers' },
     message: { singular: 'Message', plural: 'Messages' },
     'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
-    platform: { singular: 'Platform', plural: 'Platforms' }
+    platform: { singular: 'Platform', plural: 'Platforms' },
+    'api-key': { singular: 'API Key', plural: 'API Keys' }
 };
 
 export const providerResources: ProviderResourceMap = {
     appwrite: [
         ...Object.values(AppwriteMigrationResource),
-        MigrationResources.Platform as AppwriteMigrationResource
+        MigrationResources.Platform as AppwriteMigrationResource,
+        MigrationResources.ApiKey as AppwriteMigrationResource
     ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
@@ -169,6 +174,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
+        if (formData.integrations.apiKeys) {
+            addResource(MigrationResources.ApiKey);
+        }
     }
 
     return resources as ProviderResourceMap[P];
@@ -251,6 +259,10 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;
+    }
+    if (resources.includes(MigrationResources.ApiKey)) {
+        formData.integrations.root = true;
+        formData.integrations.apiKeys = true;
     }
 
     return formData;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -16,19 +16,21 @@ export type MigrationResource =
     | 'api-key'
     | 'project-variable'
     | 'webhook'
-    | 'auth-methods';
+    | 'auth-methods'
+    | 'protocols';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform, ApiKey, ProjectVariable, Webhook and AuthMethods are augmented
-// locally until @appwrite.io/console SDK is regenerated against the new spec.
+// Platform, ApiKey, ProjectVariable, Webhook, AuthMethods and Protocols are
+// augmented locally until @appwrite.io/console SDK is regenerated.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
     ApiKey: 'api-key',
     ProjectVariable: 'project-variable',
     Webhook: 'webhook',
-    AuthMethods: 'auth-methods'
+    AuthMethods: 'auth-methods',
+    Protocols: 'protocols'
 } as const;
 
 type ProviderResourceMap = {
@@ -66,6 +68,9 @@ const initialFormData = {
         root: false
     },
     authMethods: {
+        root: false
+    },
+    protocols: {
         root: false
     },
     integrations: {
@@ -118,13 +123,15 @@ export const ResourcesFriendly = {
     'api-key': { singular: 'API Key', plural: 'API Keys' },
     'project-variable': { singular: 'Project Variable', plural: 'Project Variables' },
     webhook: { singular: 'Webhook', plural: 'Webhooks' },
-    'auth-methods': { singular: 'Auth method config', plural: 'Auth method config' }
+    'auth-methods': { singular: 'Auth method config', plural: 'Auth method config' },
+    protocols: { singular: 'Protocol config', plural: 'Protocol config' }
 };
 
 export const providerResources: ProviderResourceMap = {
     appwrite: [
         ...Object.values(AppwriteMigrationResource),
         MigrationResources.AuthMethods as AppwriteMigrationResource,
+        MigrationResources.Protocols as AppwriteMigrationResource,
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
         MigrationResources.ProjectVariable as AppwriteMigrationResource,
@@ -194,6 +201,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.authMethods.root) {
         addResource(MigrationResources.AuthMethods);
+    }
+    if (formData.protocols.root) {
+        addResource(MigrationResources.Protocols);
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
@@ -288,6 +298,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.AuthMethods)) {
         formData.authMethods.root = true;
+    }
+    if (resources.includes(MigrationResources.Protocols)) {
+        formData.protocols.root = true;
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -20,7 +20,9 @@ export type MigrationResource =
     | 'protocols'
     | 'labels'
     | 'services'
-    | 'policies';
+    | 'policies'
+    | 'smtp'
+    | 'rule';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
@@ -37,7 +39,9 @@ export const MigrationResources = {
     Protocols: 'protocols',
     Labels: 'labels',
     Services: 'services',
-    Policies: 'policies'
+    Policies: 'policies',
+    SMTP: 'smtp',
+    Rule: 'rule'
 } as const;
 
 type ProviderResourceMap = {
@@ -87,6 +91,12 @@ const initialFormData = {
         root: false
     },
     policies: {
+        root: false
+    },
+    smtp: {
+        root: false
+    },
+    customDomains: {
         root: false
     },
     integrations: {
@@ -143,7 +153,9 @@ export const ResourcesFriendly = {
     protocols: { singular: 'Protocol config', plural: 'Protocol config' },
     labels: { singular: 'Project labels', plural: 'Project labels' },
     services: { singular: 'Services config', plural: 'Services config' },
-    policies: { singular: 'Policies config', plural: 'Policies config' }
+    policies: { singular: 'Policies config', plural: 'Policies config' },
+    smtp: { singular: 'SMTP config', plural: 'SMTP config' },
+    rule: { singular: 'Custom domain', plural: 'Custom domains' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -154,6 +166,8 @@ export const providerResources: ProviderResourceMap = {
         MigrationResources.Labels as AppwriteMigrationResource,
         MigrationResources.Services as AppwriteMigrationResource,
         MigrationResources.Policies as AppwriteMigrationResource,
+        MigrationResources.SMTP as AppwriteMigrationResource,
+        MigrationResources.Rule as AppwriteMigrationResource,
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
         MigrationResources.ProjectVariable as AppwriteMigrationResource,
@@ -235,6 +249,12 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.policies.root) {
         addResource(MigrationResources.Policies);
+    }
+    if (formData.smtp.root) {
+        addResource(MigrationResources.SMTP);
+    }
+    if (formData.customDomains.root) {
+        addResource(MigrationResources.Rule);
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
@@ -341,6 +361,12 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Policies)) {
         formData.policies.root = true;
+    }
+    if (resources.includes(MigrationResources.SMTP)) {
+        formData.smtp.root = true;
+    }
+    if (resources.includes(MigrationResources.Rule)) {
+        formData.customDomains.root = true;
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -13,15 +13,18 @@ export type MigrationResource =
     | NHostMigrationResource
     | SupabaseMigrationResource
     | 'platform'
-    | 'api-key';
+    | 'api-key'
+    | 'project-variable';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform and ApiKey are augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
+// Platform, ApiKey and ProjectVariable are augmented locally until @appwrite.io/console
+// SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
-    ApiKey: 'api-key'
+    ApiKey: 'api-key',
+    ProjectVariable: 'project-variable'
 } as const;
 
 type ProviderResourceMap = {
@@ -61,6 +64,9 @@ const initialFormData = {
     integrations: {
         root: false,
         apiKeys: false
+    },
+    settings: {
+        root: false
     }
 };
 
@@ -101,14 +107,16 @@ export const ResourcesFriendly = {
     message: { singular: 'Message', plural: 'Messages' },
     'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
     platform: { singular: 'Platform', plural: 'Platforms' },
-    'api-key': { singular: 'API Key', plural: 'API Keys' }
+    'api-key': { singular: 'API Key', plural: 'API Keys' },
+    'project-variable': { singular: 'Project Variable', plural: 'Project Variables' }
 };
 
 export const providerResources: ProviderResourceMap = {
     appwrite: [
         ...Object.values(AppwriteMigrationResource),
         MigrationResources.Platform as AppwriteMigrationResource,
-        MigrationResources.ApiKey as AppwriteMigrationResource
+        MigrationResources.ApiKey as AppwriteMigrationResource,
+        MigrationResources.ProjectVariable as AppwriteMigrationResource
     ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
@@ -177,6 +185,9 @@ export const migrationFormToResources = <P extends Provider>(
         if (formData.integrations.apiKeys) {
             addResource(MigrationResources.ApiKey);
         }
+    }
+    if (formData.settings.root) {
+        addResource(MigrationResources.ProjectVariable);
     }
 
     return resources as ProviderResourceMap[P];
@@ -263,6 +274,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     if (resources.includes(MigrationResources.ApiKey)) {
         formData.integrations.root = true;
         formData.integrations.apiKeys = true;
+    }
+    if (resources.includes(MigrationResources.ProjectVariable)) {
+        formData.settings.root = true;
     }
 
     return formData;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -11,11 +11,16 @@ export type MigrationResource =
     | AppwriteMigrationResource
     | FirebaseMigrationResource
     | NHostMigrationResource
-    | SupabaseMigrationResource;
+    | SupabaseMigrationResource
+    | 'platform';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-export const MigrationResources = AppwriteMigrationResource;
+// Platform is augmented locally until @appwrite.io/console SDK is regenerated against the new spec.
+export const MigrationResources = {
+    ...AppwriteMigrationResource,
+    Platform: 'platform'
+} as const;
 
 type ProviderResourceMap = {
     appwrite: AppwriteMigrationResource[];
@@ -49,6 +54,9 @@ const initialFormData = {
         messages: false
     },
     backups: {
+        root: false
+    },
+    integrations: {
         root: false
     }
 };
@@ -88,11 +96,15 @@ export const ResourcesFriendly = {
     topic: { singular: 'Topic', plural: 'Topics' },
     subscriber: { singular: 'Subscriber', plural: 'Subscribers' },
     message: { singular: 'Message', plural: 'Messages' },
-    'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' }
+    'backup-policy': { singular: 'Backup Policy', plural: 'Backup Policies' },
+    platform: { singular: 'Platform', plural: 'Platforms' }
 };
 
 export const providerResources: ProviderResourceMap = {
-    appwrite: Object.values(AppwriteMigrationResource),
+    appwrite: [
+        ...Object.values(AppwriteMigrationResource),
+        MigrationResources.Platform as AppwriteMigrationResource
+    ],
     supabase: Object.values(SupabaseMigrationResource),
     nhost: Object.values(NHostMigrationResource),
     firebase: Object.values(FirebaseMigrationResource)
@@ -154,6 +166,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.backups.root) {
         addResource(MigrationResources.Backuppolicy);
+    }
+    if (formData.integrations.root) {
+        addResource(MigrationResources.Platform);
     }
 
     return resources as ProviderResourceMap[P];
@@ -233,6 +248,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Backuppolicy)) {
         formData.backups.root = true;
+    }
+    if (resources.includes(MigrationResources.Platform)) {
+        formData.integrations.root = true;
     }
 
     return formData;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -15,18 +15,20 @@ export type MigrationResource =
     | 'platform'
     | 'api-key'
     | 'project-variable'
-    | 'webhook';
+    | 'webhook'
+    | 'auth-methods';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
-// Platform, ApiKey, ProjectVariable and Webhook are augmented locally until
-// @appwrite.io/console SDK is regenerated against the new spec.
+// Platform, ApiKey, ProjectVariable, Webhook and AuthMethods are augmented
+// locally until @appwrite.io/console SDK is regenerated against the new spec.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
     ApiKey: 'api-key',
     ProjectVariable: 'project-variable',
-    Webhook: 'webhook'
+    Webhook: 'webhook',
+    AuthMethods: 'auth-methods'
 } as const;
 
 type ProviderResourceMap = {
@@ -61,6 +63,9 @@ const initialFormData = {
         messages: false
     },
     backups: {
+        root: false
+    },
+    authMethods: {
         root: false
     },
     integrations: {
@@ -112,12 +117,14 @@ export const ResourcesFriendly = {
     platform: { singular: 'Platform', plural: 'Platforms' },
     'api-key': { singular: 'API Key', plural: 'API Keys' },
     'project-variable': { singular: 'Project Variable', plural: 'Project Variables' },
-    webhook: { singular: 'Webhook', plural: 'Webhooks' }
+    webhook: { singular: 'Webhook', plural: 'Webhooks' },
+    'auth-methods': { singular: 'Auth method config', plural: 'Auth method config' }
 };
 
 export const providerResources: ProviderResourceMap = {
     appwrite: [
         ...Object.values(AppwriteMigrationResource),
+        MigrationResources.AuthMethods as AppwriteMigrationResource,
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
         MigrationResources.ProjectVariable as AppwriteMigrationResource,
@@ -184,6 +191,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.backups.root) {
         addResource(MigrationResources.Backuppolicy);
+    }
+    if (formData.authMethods.root) {
+        addResource(MigrationResources.AuthMethods);
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
@@ -275,6 +285,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Backuppolicy)) {
         formData.backups.root = true;
+    }
+    if (resources.includes(MigrationResources.AuthMethods)) {
+        formData.authMethods.root = true;
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;

--- a/src/lib/stores/migration.ts
+++ b/src/lib/stores/migration.ts
@@ -19,13 +19,14 @@ export type MigrationResource =
     | 'auth-methods'
     | 'protocols'
     | 'labels'
-    | 'services';
+    | 'services'
+    | 'policies';
 
 // Appwrite enum is the superset of all provider resources — used as a
 // provider-agnostic reference. The addResource guard filters by provider.
 // Project-level singleton resources (Platform, ApiKey, ProjectVariable,
-// Webhook, AuthMethods, Protocols, Labels, Services) are augmented locally
-// until @appwrite.io/console SDK is regenerated.
+// Webhook, AuthMethods, Protocols, Labels, Services, Policies) are augmented
+// locally until @appwrite.io/console SDK is regenerated.
 export const MigrationResources = {
     ...AppwriteMigrationResource,
     Platform: 'platform',
@@ -35,7 +36,8 @@ export const MigrationResources = {
     AuthMethods: 'auth-methods',
     Protocols: 'protocols',
     Labels: 'labels',
-    Services: 'services'
+    Services: 'services',
+    Policies: 'policies'
 } as const;
 
 type ProviderResourceMap = {
@@ -82,6 +84,9 @@ const initialFormData = {
         root: false
     },
     services: {
+        root: false
+    },
+    policies: {
         root: false
     },
     integrations: {
@@ -137,7 +142,8 @@ export const ResourcesFriendly = {
     'auth-methods': { singular: 'Auth method config', plural: 'Auth method config' },
     protocols: { singular: 'Protocol config', plural: 'Protocol config' },
     labels: { singular: 'Project labels', plural: 'Project labels' },
-    services: { singular: 'Services config', plural: 'Services config' }
+    services: { singular: 'Services config', plural: 'Services config' },
+    policies: { singular: 'Policies config', plural: 'Policies config' }
 };
 
 export const providerResources: ProviderResourceMap = {
@@ -147,6 +153,7 @@ export const providerResources: ProviderResourceMap = {
         MigrationResources.Protocols as AppwriteMigrationResource,
         MigrationResources.Labels as AppwriteMigrationResource,
         MigrationResources.Services as AppwriteMigrationResource,
+        MigrationResources.Policies as AppwriteMigrationResource,
         MigrationResources.Platform as AppwriteMigrationResource,
         MigrationResources.ApiKey as AppwriteMigrationResource,
         MigrationResources.ProjectVariable as AppwriteMigrationResource,
@@ -225,6 +232,9 @@ export const migrationFormToResources = <P extends Provider>(
     }
     if (formData.services.root) {
         addResource(MigrationResources.Services);
+    }
+    if (formData.policies.root) {
+        addResource(MigrationResources.Policies);
     }
     if (formData.integrations.root) {
         addResource(MigrationResources.Platform);
@@ -328,6 +338,9 @@ export const resourcesToMigrationForm = (resources: MigrationResource[]): Migrat
     }
     if (resources.includes(MigrationResources.Services)) {
         formData.services.root = true;
+    }
+    if (resources.includes(MigrationResources.Policies)) {
+        formData.policies.root = true;
     }
     if (resources.includes(MigrationResources.Platform)) {
         formData.integrations.root = true;

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -126,6 +126,10 @@
             );
         }
 
+        if (groupKey === 'settings') {
+            return resources.includes(MigrationResources.ProjectVariable);
+        }
+
         const groupToResource: Record<string, MigrationResource> = {
             users: MigrationResources.User,
             databases: MigrationResources.Database
@@ -148,7 +152,8 @@
             sites: 'site',
             messaging: 'provider',
             backups: 'backup-policy',
-            integrations: 'platform'
+            integrations: 'platform',
+            settings: 'project-variable'
         };
         return map[groupKey] || groupKey;
     };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -135,6 +135,10 @@
             return resources.includes(MigrationResources.Services);
         }
 
+        if (groupKey === 'policies') {
+            return resources.includes(MigrationResources.Policies);
+        }
+
         if (groupKey === 'integrations') {
             return (
                 resources.includes(MigrationResources.Platform) ||
@@ -175,6 +179,7 @@
             protocols: 'protocols',
             labels: 'labels',
             services: 'services',
+            policies: 'policies',
             integrations: 'platform',
             settings: 'project-variable'
         };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -127,7 +127,10 @@
         }
 
         if (groupKey === 'settings') {
-            return resources.includes(MigrationResources.ProjectVariable);
+            return (
+                resources.includes(MigrationResources.ProjectVariable) ||
+                resources.includes(MigrationResources.Webhook)
+            );
         }
 
         const groupToResource: Record<string, MigrationResource> = {

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -119,6 +119,10 @@
             return resources.includes(MigrationResources.Backuppolicy);
         }
 
+        if (groupKey === 'authMethods') {
+            return resources.includes(MigrationResources.AuthMethods);
+        }
+
         if (groupKey === 'integrations') {
             return (
                 resources.includes(MigrationResources.Platform) ||
@@ -155,6 +159,7 @@
             sites: 'site',
             messaging: 'provider',
             backups: 'backup-policy',
+            authMethods: 'auth-methods',
             integrations: 'platform',
             settings: 'project-variable'
         };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -127,6 +127,10 @@
             return resources.includes(MigrationResources.Protocols);
         }
 
+        if (groupKey === 'labels') {
+            return resources.includes(MigrationResources.Labels);
+        }
+
         if (groupKey === 'integrations') {
             return (
                 resources.includes(MigrationResources.Platform) ||
@@ -165,6 +169,7 @@
             backups: 'backup-policy',
             authMethods: 'auth-methods',
             protocols: 'protocols',
+            labels: 'labels',
             integrations: 'platform',
             settings: 'project-variable'
         };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -119,6 +119,10 @@
             return resources.includes(MigrationResources.Backuppolicy);
         }
 
+        if (groupKey === 'integrations') {
+            return resources.includes(MigrationResources.Platform);
+        }
+
         const groupToResource: Record<string, MigrationResource> = {
             users: MigrationResources.User,
             databases: MigrationResources.Database
@@ -140,7 +144,8 @@
             storage: 'bucket',
             sites: 'site',
             messaging: 'provider',
-            backups: 'backup-policy'
+            backups: 'backup-policy',
+            integrations: 'platform'
         };
         return map[groupKey] || groupKey;
     };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -131,6 +131,10 @@
             return resources.includes(MigrationResources.Labels);
         }
 
+        if (groupKey === 'services') {
+            return resources.includes(MigrationResources.Services);
+        }
+
         if (groupKey === 'integrations') {
             return (
                 resources.includes(MigrationResources.Platform) ||
@@ -170,6 +174,7 @@
             authMethods: 'auth-methods',
             protocols: 'protocols',
             labels: 'labels',
+            services: 'services',
             integrations: 'platform',
             settings: 'project-variable'
         };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -139,6 +139,14 @@
             return resources.includes(MigrationResources.Policies);
         }
 
+        if (groupKey === 'smtp') {
+            return resources.includes(MigrationResources.SMTP);
+        }
+
+        if (groupKey === 'customDomains') {
+            return resources.includes(MigrationResources.Rule);
+        }
+
         if (groupKey === 'integrations') {
             return (
                 resources.includes(MigrationResources.Platform) ||
@@ -180,6 +188,8 @@
             labels: 'labels',
             services: 'services',
             policies: 'policies',
+            smtp: 'smtp',
+            customDomains: 'rule',
             integrations: 'platform',
             settings: 'project-variable'
         };

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -120,7 +120,10 @@
         }
 
         if (groupKey === 'integrations') {
-            return resources.includes(MigrationResources.Platform);
+            return (
+                resources.includes(MigrationResources.Platform) ||
+                resources.includes(MigrationResources.ApiKey)
+            );
         }
 
         const groupToResource: Record<string, MigrationResource> = {

--- a/src/routes/(console)/(migration-wizard)/resource-form.svelte
+++ b/src/routes/(console)/(migration-wizard)/resource-form.svelte
@@ -123,6 +123,10 @@
             return resources.includes(MigrationResources.AuthMethods);
         }
 
+        if (groupKey === 'protocols') {
+            return resources.includes(MigrationResources.Protocols);
+        }
+
         if (groupKey === 'integrations') {
             return (
                 resources.includes(MigrationResources.Platform) ||
@@ -160,6 +164,7 @@
             messaging: 'provider',
             backups: 'backup-policy',
             authMethods: 'auth-methods',
+            protocols: 'protocols',
             integrations: 'platform',
             settings: 'project-variable'
         };

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -40,6 +40,9 @@
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
+        },
+        settings: {
+            root: 'Project variables'
         }
     };
 
@@ -70,6 +73,9 @@
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',
             apiKeys: 'Import all API keys with their scopes and expiration'
+        },
+        settings: {
+            root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)'
         }
     };
 

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -38,7 +38,8 @@
             root: 'Backup policies'
         },
         integrations: {
-            root: 'Platforms'
+            root: 'Platforms',
+            apiKeys: 'Include API keys'
         }
     };
 
@@ -67,7 +68,8 @@
             root: 'Import all backup policies'
         },
         integrations: {
-            root: 'Import all platforms (web, Flutter, iOS, Android, etc.)'
+            root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',
+            apiKeys: 'Import all API keys with their scopes and expiration'
         }
     };
 

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -49,6 +49,9 @@
         services: {
             root: 'Services'
         },
+        policies: {
+            root: 'Security policies'
+        },
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
@@ -94,6 +97,9 @@
         },
         services: {
             root: 'Import the project service enable/disable flags (Account, Databases, Functions, GraphQL, etc.)'
+        },
+        policies: {
+            root: 'Import the project security policies (password rules, session behavior, user limits, membership privacy)'
         },
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -52,6 +52,12 @@
         policies: {
             root: 'Security policies'
         },
+        smtp: {
+            root: 'Custom SMTP'
+        },
+        customDomains: {
+            root: 'Custom domains'
+        },
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
@@ -100,6 +106,12 @@
         },
         policies: {
             root: 'Import the project security policies (password rules, session behavior, user limits, membership privacy)'
+        },
+        smtp: {
+            root: 'Import the project custom SMTP configuration (the password is not exposed by the SDK and stays on the destination)'
+        },
+        customDomains: {
+            root: 'Import manually-added custom-domain proxy rules (API, function, site, redirect). Auto-generated `.appwrite.network` rules are skipped — they are recreated by parent Function/Site migration.'
         },
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -36,6 +36,9 @@
         },
         backups: {
             root: 'Backup policies'
+        },
+        integrations: {
+            root: 'Platforms'
         }
     };
 
@@ -62,6 +65,9 @@
         },
         backups: {
             root: 'Import all backup policies'
+        },
+        integrations: {
+            root: 'Import all platforms (web, Flutter, iOS, Android, etc.)'
         }
     };
 

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -37,6 +37,9 @@
         backups: {
             root: 'Backup policies'
         },
+        authMethods: {
+            root: 'Auth methods'
+        },
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
@@ -71,13 +74,17 @@
         backups: {
             root: 'Import all backup policies'
         },
+        authMethods: {
+            root: 'Import the project auth method flags (email/password, magic URL, JWT, phone, etc.)'
+        },
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',
             apiKeys: 'Import all API keys with their scopes and expiration'
         },
         settings: {
             root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)',
-            webhooks: 'Import all webhooks (signing secrets are not exposed by the SDK; the destination regenerates a fresh signature key for each)'
+            webhooks:
+                'Import all webhooks (signing secrets are not exposed by the SDK; the destination regenerates a fresh signature key for each)'
         }
     };
 

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -46,6 +46,9 @@
         labels: {
             root: 'Project labels'
         },
+        services: {
+            root: 'Services'
+        },
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
@@ -88,6 +91,9 @@
         },
         labels: {
             root: 'Import the project-level RBAC label array'
+        },
+        services: {
+            root: 'Import the project service enable/disable flags (Account, Databases, Functions, GraphQL, etc.)'
         },
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -43,6 +43,9 @@
         protocols: {
             root: 'Protocols'
         },
+        labels: {
+            root: 'Project labels'
+        },
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
@@ -82,6 +85,9 @@
         },
         protocols: {
             root: 'Import the project protocol flags (REST / GraphQL / WebSocket)'
+        },
+        labels: {
+            root: 'Import the project-level RBAC label array'
         },
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -40,6 +40,9 @@
         authMethods: {
             root: 'Auth methods'
         },
+        protocols: {
+            root: 'Protocols'
+        },
         integrations: {
             root: 'Platforms',
             apiKeys: 'Include API keys'
@@ -76,6 +79,9 @@
         },
         authMethods: {
             root: 'Import the project auth method flags (email/password, magic URL, JWT, phone, etc.)'
+        },
+        protocols: {
+            root: 'Import the project protocol flags (REST / GraphQL / WebSocket)'
         },
         integrations: {
             root: 'Import all platforms (web, Flutter, iOS, Android, etc.)',

--- a/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/migrations/(import)/importReport.svelte
@@ -42,7 +42,8 @@
             apiKeys: 'Include API keys'
         },
         settings: {
-            root: 'Project variables'
+            root: 'Project variables',
+            webhooks: 'Include webhooks'
         }
     };
 
@@ -75,7 +76,8 @@
             apiKeys: 'Import all API keys with their scopes and expiration'
         },
         settings: {
-            root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)'
+            root: 'Import all project-level variables (secret values are not exposed by the SDK and will be migrated empty)',
+            webhooks: 'Import all webhooks (signing secrets are not exposed by the SDK; the destination regenerates a fresh signature key for each)'
         }
     };
 


### PR DESCRIPTION
## Summary
- Adds `Custom domains` and `Custom SMTP` rows to the migration wizard's resource picker.
- Custom domains migrates manually-added proxy rules (API, function, site, redirect). Auto-generated \`.appwrite.network\` rules are skipped — they're recreated by parent Function/Site migration.
- SMTP migrates the project's custom SMTP configuration. The password is not exposed by the SDK; the destination keeps its existing password.

Pairs with:
- https://github.com/utopia-php/migration/pull/188
- https://github.com/appwrite/appwrite/pull/12368
- https://github.com/appwrite-labs/cloud/pull/4095

## Test plan
- [ ] Wizard renders both new rows for the Appwrite source provider
- [ ] Selecting either checkbox sends the correct resource(s) to the migration endpoint
- [ ] Migration report shows the per-resource count