### PR TITLE
fix(billing): use addon name from API instead of hardcoded label map

### DIFF
--- a/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/planSummary.svelte
@@ -295,7 +295,10 @@
         };
 
         // addons (additional members, projects, etc.)
-        const billingAddonNames: Record<string, string> = {
+        // Fallback labels for older cloud builds that don't yet send `addon.name`
+        // on the resource entry. Once the cloud rollout is complete this map can
+        // be removed entirely.
+        const billingAddonNamesFallback: Record<string, string> = {
             addon_baa: 'HIPAA BAA'
         };
 
@@ -315,8 +318,9 @@
                             ? 'Additional members'
                             : addon.resourceId === 'projects'
                               ? 'Additional projects'
-                              : (billingAddonNames[addon.resourceId] ??
-                                `${addon.resourceId} overage (${formatNum(addon.value)})`),
+                              : addon.name ||
+                                billingAddonNamesFallback[addon.resourceId] ||
+                                addon.resourceId,
                     usage: '',
                     price: formatCurrency(addon.amount)
                 },


### PR DESCRIPTION
## Summary

The plan summary table on the billing page used a hardcoded `addon_<key> → label` map to render addon line items, with a fallback that labelled every unknown addon as an "overage" — e.g. `addon_baa overage (1)` for any addon not in the map, which was both wrong terminology (addons are not overages) and missing the friendly name.

Switch to reading `addon.name` from the API response. The aggregation endpoint now populates this field from the cloud's addon catalog, so the console no longer needs to maintain a parallel name registry.

The hardcoded map is kept as a fallback for older cloud builds during the rollout window; a plain `resourceId` is the final fallback in place of the misleading `overage (N)` string.

## Related cloud change

The companion cloud change populates `name`, `rate`, `desc` on each `addon_*` entry in the aggregation `resources` map. This console PR should ship after that cloud change reaches production; before then, the fallback map keeps the existing addons rendering correctly.

## Test plan

- [ ] BAA addon still labelled "HIPAA BAA" on the billing summary (regression — via fallback before cloud rollout, via API afterwards)
- [ ] Any new addon (e.g. `backup_recovery`) renders its catalog name instead of `addon_<key> overage (N)`
- [ ] Unknown addon without a name renders the raw `resourceId` (no "overage")

🤖 Generated with [Claude Code](https://claude.com/claude-code)