### PR TITLE
fix: preserve boolean fields and deploymentRetention across all setti…

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
@@ -83,8 +83,8 @@
                     events: $func.events || undefined,
                     schedule: $func.schedule || undefined,
                     timeout: $func.timeout || undefined,
-                    enabled: $func.enabled || undefined,
-                    logging: $func.logging || undefined,
+                    enabled: $func.enabled ?? undefined,
+                    logging: $func.logging ?? undefined,
                     entrypoint: $func.entrypoint,
                     commands: $func.commands || undefined,
                     scopes: ($func.scopes as Scopes[]) || undefined,
@@ -93,7 +93,8 @@
                     providerBranch: branch || undefined,
                     providerSilentMode: $func.providerSilentMode ?? undefined,
                     providerRootDirectory: $func.providerRootDirectory ?? undefined,
-                    buildSpecification: $func.buildSpecification || undefined
+                    buildSpecification: $func.buildSpecification || undefined,
+                    deploymentRetention: $func.deploymentRetention ?? undefined
                 });
             }
             if (commit) {

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/add-domain/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/add-domain/+page.svelte
@@ -141,14 +141,18 @@
                 events: data.func.events || undefined,
                 schedule: data.func.schedule || undefined,
                 timeout: data.func.timeout || undefined,
-                enabled: data.func.enabled || undefined,
-                logging: data.func.logging || undefined,
+                enabled: data.func.enabled ?? undefined,
+                logging: data.func.logging ?? undefined,
                 entrypoint: data.func.entrypoint,
                 commands: data.func.commands || undefined,
                 scopes: (data.func.scopes as Scopes[]) || undefined,
                 installationId: selectedInstallationId,
                 providerRepositoryId: selectedRepository,
-                providerBranch: 'main'
+                providerBranch: 'main',
+                providerSilentMode: data.func.providerSilentMode ?? undefined,
+                providerRootDirectory: data.func.providerRootDirectory || undefined,
+                buildSpecification: data.func.buildSpecification || undefined,
+                deploymentRetention: data.func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
         } catch {

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/disconnectRepo.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/disconnectRepo.svelte
@@ -31,8 +31,8 @@
                 events: $func.events || undefined,
                 schedule: $func.schedule || undefined,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
@@ -41,7 +41,8 @@
                 providerBranch: '',
                 providerSilentMode: true,
                 providerRootDirectory: '',
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             dispatch('success');

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildCommand.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildCommand.svelte
@@ -26,17 +26,18 @@
                 events: func.events || undefined,
                 schedule: func.schedule || undefined,
                 timeout: func.timeout || undefined,
-                enabled: func.enabled || undefined,
-                logging: func.logging || undefined,
+                enabled: func.enabled ?? undefined,
+                logging: func.logging ?? undefined,
                 entrypoint: func.entrypoint || undefined,
                 commands: buildCommand || undefined,
                 scopes: (func.scopes as Scopes[]) || undefined,
                 installationId: func.installationId || undefined,
                 providerRepositoryId: func.providerRepositoryId || undefined,
                 providerBranch: func.providerBranch || undefined,
-                providerSilentMode: func.providerSilentMode || undefined,
+                providerSilentMode: func.providerSilentMode ?? undefined,
                 providerRootDirectory: func.providerRootDirectory || undefined,
-                buildSpecification: func.buildSpecification || undefined
+                buildSpecification: func.buildSpecification || undefined,
+                deploymentRetention: func.deploymentRetention ?? undefined
             });
 
             await invalidate(Dependencies.FUNCTION);

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildTriggers.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateBuildTriggers.svelte
@@ -56,6 +56,7 @@
                 providerSilentMode: func.providerSilentMode ?? undefined,
                 providerRootDirectory: func.providerRootDirectory ?? undefined,
                 buildSpecification: func.buildSpecification ?? undefined,
+                deploymentRetention: func.deploymentRetention ?? undefined,
                 providerBranches,
                 providerPaths
             });

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateEvents.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateEvents.svelte
@@ -37,17 +37,18 @@
                 events: Array.from($eventSet),
                 schedule: $func.schedule || undefined,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateName.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateName.svelte
@@ -32,17 +32,18 @@
                 events: $func.events || undefined,
                 schedule: $func.schedule || undefined,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updatePermissions.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updatePermissions.svelte
@@ -37,17 +37,18 @@
                 events: $func.events || undefined,
                 schedule: $func.schedule || undefined,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRepository.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRepository.svelte
@@ -82,8 +82,8 @@
                 events: func.events || undefined,
                 schedule: func.schedule || undefined,
                 timeout: func.timeout || undefined,
-                enabled: func.enabled || undefined,
-                logging: func.logging || undefined,
+                enabled: func.enabled ?? undefined,
+                logging: func.logging ?? undefined,
                 entrypoint: func.entrypoint || undefined,
                 commands: func.commands || undefined,
                 scopes: (func.scopes as Scopes[]) || undefined,
@@ -92,7 +92,8 @@
                 providerBranch: selectedBranch,
                 providerSilentMode: silentMode,
                 providerRootDirectory: selectedDir,
-                buildSpecification: func.buildSpecification || undefined
+                buildSpecification: func.buildSpecification || undefined,
+                deploymentRetention: func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({
@@ -156,8 +157,8 @@
                 events: func.events || undefined,
                 schedule: func.schedule || undefined,
                 timeout: func.timeout || undefined,
-                enabled: func.enabled || undefined,
-                logging: func.logging || undefined,
+                enabled: func.enabled ?? undefined,
+                logging: func.logging ?? undefined,
                 entrypoint: func.entrypoint,
                 commands: func.commands || undefined,
                 scopes: (func.scopes as Scopes[]) || undefined,
@@ -166,7 +167,8 @@
                 providerBranch: nextBranch,
                 providerSilentMode: func.providerSilentMode ?? undefined,
                 providerRootDirectory: func.providerRootDirectory ?? undefined,
-                buildSpecification: func.buildSpecification || undefined
+                buildSpecification: func.buildSpecification || undefined,
+                deploymentRetention: func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
         } catch {

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
@@ -48,18 +48,19 @@
                 events: func.events || undefined,
                 schedule: func.schedule || undefined,
                 timeout: func.timeout || undefined,
-                enabled: func.enabled || undefined,
-                logging: func.logging || undefined,
+                enabled: func.enabled ?? undefined,
+                logging: func.logging ?? undefined,
                 entrypoint: func.entrypoint || undefined,
                 commands: func.commands || undefined,
                 scopes: (func.scopes as Scopes[]) || undefined,
                 installationId: func.installationId || undefined,
                 providerRepositoryId: func.providerRepositoryId || undefined,
                 providerBranch: func.providerBranch || undefined,
-                providerSilentMode: func.providerSilentMode || undefined,
+                providerSilentMode: func.providerSilentMode ?? undefined,
                 providerRootDirectory: func.providerRootDirectory || undefined,
                 buildSpecification: buildSpecification || undefined,
-                runtimeSpecification: runtimeSpecification || undefined
+                runtimeSpecification: runtimeSpecification || undefined,
+                deploymentRetention: func.deploymentRetention ?? undefined
             });
 
             await invalidate(Dependencies.FUNCTION);

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRuntime.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRuntime.svelte
@@ -36,17 +36,18 @@
                 events: $func.events || undefined,
                 schedule: $func.schedule || undefined,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateSchedule.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateSchedule.svelte
@@ -37,17 +37,18 @@
                 events: $func.events || undefined,
                 schedule: functionSchedule,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateScopes.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateScopes.svelte
@@ -39,17 +39,18 @@
                 events: $func.events || undefined,
                 schedule: $func.schedule || undefined,
                 timeout: $func.timeout || undefined,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: (functionScopes as unknown as FunctionScopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateTimeout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateTimeout.svelte
@@ -32,17 +32,18 @@
                 events: $func.events || undefined,
                 schedule: $func.schedule || undefined,
                 timeout,
-                enabled: $func.enabled || undefined,
-                logging: $func.logging || undefined,
+                enabled: $func.enabled ?? undefined,
+                logging: $func.logging ?? undefined,
                 entrypoint: $func.entrypoint || undefined,
                 commands: $func.commands || undefined,
                 scopes: ($func.scopes as Scopes[]) || undefined,
                 installationId: $func.installationId || undefined,
                 providerRepositoryId: $func.providerRepositoryId || undefined,
                 providerBranch: $func.providerBranch || undefined,
-                providerSilentMode: $func.providerSilentMode || undefined,
+                providerSilentMode: $func.providerSilentMode ?? undefined,
                 providerRootDirectory: $func.providerRootDirectory || undefined,
-                buildSpecification: $func.buildSpecification || undefined
+                buildSpecification: $func.buildSpecification || undefined,
+                deploymentRetention: $func.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.FUNCTION);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
@@ -85,8 +85,8 @@
                     siteId: site.$id,
                     name: site.name,
                     framework: site.framework as Framework,
-                    enabled: site.enabled || undefined,
-                    logging: site.logging || undefined,
+                    enabled: site.enabled ?? undefined,
+                    logging: site.logging ?? undefined,
                     timeout: site.timeout || undefined,
                     installCommand: site.installCommand || undefined,
                     buildCommand: site.buildCommand || undefined,
@@ -98,8 +98,9 @@
                     installationId: $installation.$id || undefined,
                     providerRepositoryId: selectedRepository || undefined,
                     providerBranch: branch || undefined,
-                    providerSilentMode: site.providerSilentMode || undefined,
-                    providerRootDirectory: site.providerRootDirectory || undefined
+                    providerSilentMode: site.providerSilentMode ?? undefined,
+                    providerRootDirectory: site.providerRootDirectory || undefined,
+                    deploymentRetention: site.deploymentRetention ?? undefined
                 });
             }
             if (commit) {

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/disconnectRepo.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/disconnectRepo.svelte
@@ -22,8 +22,8 @@
                 siteId: site.$id,
                 name: site.name,
                 framework: site.framework as Framework,
-                enabled: site.enabled || undefined,
-                logging: site.logging || undefined,
+                enabled: site.enabled ?? undefined,
+                logging: site.logging ?? undefined,
                 timeout: site.timeout || undefined,
                 installCommand: site.installCommand || undefined,
                 buildCommand: site.buildCommand || undefined,
@@ -35,7 +35,8 @@
                 installationId: '',
                 providerRepositoryId: '',
                 providerBranch: '',
-                providerRootDirectory: ''
+                providerRootDirectory: '',
+                deploymentRetention: site.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.SITE);
             dispatch('success');

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -157,8 +157,8 @@
                 siteId: site.$id,
                 name: site.name,
                 framework: selectedFramework.key as Framework,
-                enabled: site.enabled || undefined,
-                logging: site.logging || undefined,
+                enabled: site.enabled ?? undefined,
+                logging: site.logging ?? undefined,
                 timeout: site.timeout || undefined,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
@@ -170,10 +170,11 @@
                 installationId: site.installationId || undefined,
                 providerRepositoryId: site.providerRepositoryId || undefined,
                 providerBranch: site.providerBranch || undefined,
-                providerSilentMode: site.providerSilentMode || undefined,
+                providerSilentMode: site.providerSilentMode ?? undefined,
                 providerRootDirectory: site.providerRootDirectory || undefined,
                 buildSpecification: specToSend || undefined,
-                runtimeSpecification: runtimeSpecToSend || undefined
+                runtimeSpecification: runtimeSpecToSend || undefined,
+                deploymentRetention: site.deploymentRetention ?? undefined
             });
             site.buildSpecification = specToSend;
             site.runtimeSpecification = runtimeSpecToSend;

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildTriggers.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildTriggers.svelte
@@ -54,6 +54,7 @@
                 providerSilentMode: site.providerSilentMode ?? undefined,
                 providerRootDirectory: site.providerRootDirectory ?? undefined,
                 buildSpecification: site.buildSpecification ?? undefined,
+                deploymentRetention: site.deploymentRetention ?? undefined,
                 providerBranches,
                 providerPaths
             });

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateName.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateName.svelte
@@ -23,8 +23,8 @@
                 siteId: site.$id,
                 name: siteName,
                 framework: site.framework as Framework,
-                enabled: site?.enabled || undefined,
-                logging: site?.logging || undefined,
+                enabled: site?.enabled ?? undefined,
+                logging: site?.logging ?? undefined,
                 timeout: site?.timeout || undefined,
                 installCommand: site?.installCommand || undefined,
                 buildCommand: site?.buildCommand || undefined,
@@ -36,9 +36,10 @@
                 installationId: site?.installationId || undefined,
                 providerRepositoryId: site?.providerRepositoryId || undefined,
                 providerBranch: site?.providerBranch || undefined,
-                providerSilentMode: site?.providerSilentMode || undefined,
+                providerSilentMode: site?.providerSilentMode ?? undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                buildSpecification: site?.buildSpecification || undefined
+                buildSpecification: site?.buildSpecification || undefined,
+                deploymentRetention: site?.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRepository.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRepository.svelte
@@ -72,8 +72,8 @@
                 siteId: site.$id,
                 name: site.name,
                 framework: site?.framework as Framework,
-                enabled: site?.enabled || undefined,
-                logging: site?.logging || undefined,
+                enabled: site?.enabled ?? undefined,
+                logging: site?.logging ?? undefined,
                 timeout: site?.timeout || undefined,
                 installCommand: site?.installCommand || undefined,
                 buildCommand: site?.buildCommand || undefined,
@@ -85,9 +85,10 @@
                 installationId: site?.installationId || undefined,
                 providerRepositoryId: site?.providerRepositoryId || undefined,
                 providerBranch: selectedBranch || undefined,
-                providerSilentMode: silentMode || undefined,
+                providerSilentMode: silentMode,
                 providerRootDirectory: selectedDir || undefined,
-                buildSpecification: site?.buildSpecification || undefined
+                buildSpecification: site?.buildSpecification || undefined,
+                deploymentRetention: site?.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({
@@ -139,8 +140,8 @@
             siteId: site.$id,
             name: site.name,
             framework: site.framework as Framework,
-            enabled: site?.enabled,
-            logging: site?.logging || undefined,
+            enabled: site?.enabled ?? undefined,
+            logging: site?.logging ?? undefined,
             timeout: site?.timeout,
             installCommand: site?.installCommand,
             buildCommand: site?.buildCommand,
@@ -154,7 +155,8 @@
             providerBranch: nextBranch,
             providerSilentMode: site?.providerSilentMode ?? undefined,
             providerRootDirectory: site?.providerRootDirectory ?? undefined,
-            buildSpecification: site?.buildSpecification || undefined
+            buildSpecification: site?.buildSpecification || undefined,
+            deploymentRetention: site?.deploymentRetention ?? undefined
         });
 
         invalidate(Dependencies.SITE);

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -40,8 +40,8 @@
                 siteId: site.$id,
                 name: site.name,
                 framework: site.framework as Framework,
-                enabled: site?.enabled || undefined,
-                logging: site?.logging || undefined,
+                enabled: site?.enabled ?? undefined,
+                logging: site?.logging ?? undefined,
                 timeout: site?.timeout || undefined,
                 installCommand: site?.installCommand || undefined,
                 buildCommand: site?.buildCommand || undefined,
@@ -53,10 +53,11 @@
                 installationId: site?.installationId || undefined,
                 providerRepositoryId: site?.providerRepositoryId || undefined,
                 providerBranch: site?.providerBranch || undefined,
-                providerSilentMode: site?.providerSilentMode || undefined,
+                providerSilentMode: site?.providerSilentMode ?? undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
                 buildSpecification: buildSpecification || undefined,
-                runtimeSpecification: runtimeSpecification || undefined
+                runtimeSpecification: runtimeSpecification || undefined,
+                deploymentRetention: site?.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.SITE);
 

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRuntimeSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRuntimeSettings.svelte
@@ -29,8 +29,8 @@
                 siteId: site.$id,
                 name: site.name,
                 framework: site?.framework as Framework,
-                enabled: site?.enabled || undefined,
-                logging: site?.logging || undefined,
+                enabled: site?.enabled ?? undefined,
+                logging: site?.logging ?? undefined,
                 timeout: site?.timeout || undefined,
                 installCommand: site?.installCommand || undefined,
                 buildCommand: site?.buildCommand || undefined,
@@ -42,9 +42,10 @@
                 installationId: site?.installationId || undefined,
                 providerRepositoryId: site?.providerRepositoryId || undefined,
                 providerBranch: site?.providerBranch || undefined,
-                providerSilentMode: site?.providerSilentMode || undefined,
+                providerSilentMode: site?.providerSilentMode ?? undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                buildSpecification: site?.buildSpecification || undefined
+                buildSpecification: site?.buildSpecification || undefined,
+                deploymentRetention: site?.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateTimeout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateTimeout.svelte
@@ -22,8 +22,8 @@
                 siteId: site.$id,
                 name: site.name,
                 framework: site?.framework as Framework,
-                enabled: site?.enabled || undefined,
-                logging: site?.logging || undefined,
+                enabled: site?.enabled ?? undefined,
+                logging: site?.logging ?? undefined,
                 timeout: timeout || undefined,
                 installCommand: site?.installCommand || undefined,
                 buildCommand: site?.buildCommand || undefined,
@@ -35,9 +35,10 @@
                 installationId: site?.installationId || undefined,
                 providerRepositoryId: site?.providerRepositoryId || undefined,
                 providerBranch: site?.providerBranch || undefined,
-                providerSilentMode: site?.providerSilentMode || undefined,
+                providerSilentMode: site?.providerSilentMode ?? undefined,
                 providerRootDirectory: site?.providerRootDirectory || undefined,
-                buildSpecification: site?.buildSpecification || undefined
+                buildSpecification: site?.buildSpecification || undefined,
+                deploymentRetention: site?.deploymentRetention ?? undefined
             });
             await invalidate(Dependencies.SITE);
             addNotification({


### PR DESCRIPTION
…ngs updates

Extends the fix from #3064 to the remaining 20 settings update components for both functions and sites. Two bugs were present in every file not touched by that PR:

1. `enabled`, `logging`, and `providerSilentMode` were passed through `|| undefined` instead of `?? undefined`, causing `false` values to be silently coerced to `undefined` and reset to their API defaults whenever any other setting was saved.

2. `deploymentRetention` was absent from every partial-update payload, so saving name, timeout, scopes, schedule, runtime, permissions, resource limits, build command, events, build triggers, or repository settings would silently reset the retention value.

Also fixes `providerSilentMode: silentMode || undefined` in sites/ updateRepository.svelte to `silentMode` (matching the functions version), so disabling silent mode is correctly preserved on save.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)