### PR TITLE
fix: restrict granular project roles to Scale plan only

### DIFF
--- a/src/routes/(console)/organization-[organization]/createMember.svelte
+++ b/src/routes/(console)/organization-[organization]/createMember.svelte
@@ -27,7 +27,7 @@
     } = $props();
 
     const supportsProjectRoles = $derived(
-        isCloud && !!$currentPlan?.supportsOrganizationRoles && $currentPlan?.group === 'scale'
+        isCloud && !!$currentPlan?.supportsProjectSpecificRoles
     );
 
     let email = $state('');

--- a/src/routes/(console)/organization-[organization]/createMember.svelte
+++ b/src/routes/(console)/organization-[organization]/createMember.svelte
@@ -26,7 +26,9 @@
         oncreated?: (team: Models.Membership) => void;
     } = $props();
 
-    const supportsProjectRoles = $derived(isCloud && !!$currentPlan?.supportsOrganizationRoles);
+    const supportsProjectRoles = $derived(
+        isCloud && !!$currentPlan?.supportsOrganizationRoles && $currentPlan?.group === 'scale'
+    );
 
     let email = $state('');
     let name = $state('');

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -217,7 +217,7 @@
                         </Button.Button>
                         <div style:min-width="232px" slot="tooltip">
                             <ActionMenu.Root>
-                                {#if isCloud && $currentPlan?.supportsOrganizationRoles}
+                                {#if isCloud && $currentPlan?.supportsOrganizationRoles && $currentPlan?.group === 'scale'}
                                     <ActionMenu.Item.Button
                                         trailingIcon={IconPencil}
                                         on:click={() => {

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -217,7 +217,7 @@
                         </Button.Button>
                         <div style:min-width="232px" slot="tooltip">
                             <ActionMenu.Root>
-                                {#if isCloud && $currentPlan?.supportsOrganizationRoles && $currentPlan?.group === 'scale'}
+                                {#if isCloud && $currentPlan?.supportsProjectSpecificRoles}
                                     <ActionMenu.Item.Button
                                         trailingIcon={IconPencil}
                                         on:click={() => {

--- a/src/routes/(console)/organization-[organization]/members/edit.svelte
+++ b/src/routes/(console)/organization-[organization]/members/edit.svelte
@@ -31,7 +31,9 @@
         onupdated?: (membership: Models.Membership) => void;
     } = $props();
 
-    const supportsProjectRoles = $derived(isCloud && !!$currentPlan?.supportsOrganizationRoles);
+    const supportsProjectRoles = $derived(
+        isCloud && !!$currentPlan?.supportsOrganizationRoles && $currentPlan?.group === 'scale'
+    );
     const defaultRole = isSelfHosted ? 'owner' : 'developer';
 
     let error = $state<string>(null);

--- a/src/routes/(console)/organization-[organization]/members/edit.svelte
+++ b/src/routes/(console)/organization-[organization]/members/edit.svelte
@@ -32,7 +32,7 @@
     } = $props();
 
     const supportsProjectRoles = $derived(
-        isCloud && !!$currentPlan?.supportsOrganizationRoles && $currentPlan?.group === 'scale'
+        isCloud && !!$currentPlan?.supportsProjectSpecificRoles
     );
     const defaultRole = isSelfHosted ? 'owner' : 'developer';
 


### PR DESCRIPTION
The feature was incorrectly available to Pro plan orgs. Added \`\$currentPlan?.group === 'scale'\` guard alongside the existing supportsOrganizationRoles check in all three entry points: createMember, edit modal, and the members table action menu.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)