### PR TITLE
feat: notify self-hosted users that execution/site logs are unavailable

### DIFF
--- a/src/lib/components/logs/logsResponse.svelte
+++ b/src/lib/components/logs/logsResponse.svelte
@@ -14,7 +14,9 @@
         Typography
     } from '@appwrite.io/pink-svelte';
     import { onMount } from 'svelte';
+    import { isSelfHosted } from '$lib/system';
     import LoggingAlert from './loggingAlert.svelte';
+    import SelfHostedLogsAlert from './selfHostedLogsAlert.svelte';
 
     let {
         selectedLog,
@@ -83,6 +85,8 @@
     {#if responseTab === 'logs'}
         {#if selectedLog.logs}
             <Logs logs={selectedLog.logs} />
+        {:else if isSelfHosted}
+            <SelfHostedLogsAlert {product} />
         {:else if !logging}
             <LoggingAlert {product} />
         {:else}
@@ -93,6 +97,8 @@
     {:else if responseTab === 'errors'}
         {#if selectedLog.errors}
             <Logs logs={selectedLog.errors} />
+        {:else if isSelfHosted}
+            <SelfHostedLogsAlert {product} />
         {:else if !logging}
             <LoggingAlert {product} />
         {:else}

--- a/src/lib/components/logs/selfHostedLogsAlert.svelte
+++ b/src/lib/components/logs/selfHostedLogsAlert.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import { Alert } from '@appwrite.io/pink-svelte';
+
+    let { product }: { product: 'site' | 'function' } = $props();
+</script>
+
+{#if product === 'site'}
+    <Alert.Inline status="info" title="Logs are unavailable on self-hosted Appwrite">
+        To reduce storage overhead, self-hosted Appwrite no longer stores logs or error output. As a
+        result, this section may be empty. You can still view log status, duration, and response
+        code. Full logs remain available on Appwrite Cloud.
+    </Alert.Inline>
+{:else}
+    <Alert.Inline status="info" title="Execution logs are unavailable on self-hosted Appwrite">
+        To reduce storage overhead, self-hosted Appwrite no longer stores function logs or error
+        output. As a result, this section may be empty. You can still view execution status,
+        duration, and response code. Full execution logs remain available on Appwrite Cloud.
+    </Alert.Inline>
+{/if}


### PR DESCRIPTION
## What

Self-hosted open-source Appwrite no longer stores function/site execution log and error output. This adds an informational notice in the console so users understand why the **Logs** and **Errors** sections may appear empty, instead of just seeing "No logs found."

## How

- **New component** `src/lib/components/logs/selfHostedLogsAlert.svelte` — a `product`-aware (`site` | `function`) `Alert.Inline status="info"`, mirroring the existing `loggingAlert.svelte` pattern.
- **Updated** `src/lib/components/logs/logsResponse.svelte` — the shared component that renders the Logs/Errors tabs for **both functions and sites**. Imports `isSelfHosted` from `$lib/system` and renders the new alert in the Logs and Errors branches when on self-hosted and no output is present (taking precedence over the old `LoggingAlert` / "No logs found." fallbacks).

Because the Logs/Errors rendering is shared, this single change covers both function executions (`functions/.../executions/sheet.svelte`) and site logs (`sites/.../logs/sheet.svelte`).

## Behavior

- Shown **only** on self-hosted builds (`isCloud` users are unaffected).
- Always shown on self-hosted when there's no log/error output, regardless of the logging toggle, since logs are never persisted there.
- Copy is state-neutral ("...so this section may be empty") so it reads correctly for older executions that legitimately had empty logs, without implying their data was deleted.

### Copy

**Function:**
> **Execution logs are unavailable on self-hosted Appwrite**
> To reduce storage overhead, self-hosted Appwrite no longer stores function logs or error output. As a result, this section may be empty. You can still view execution status, duration, and response code. Full execution logs remain available on Appwrite Cloud.

**Site:**
> **Logs are unavailable on self-hosted Appwrite**
> To reduce storage overhead, self-hosted Appwrite no longer stores logs or error output. As a result, this section may be empty. You can still view log status, duration, and response code. Full logs remain available on Appwrite Cloud.

## Testing

- `bun run format` — clean
- `bun run lint` (eslint on touched files) — clean
- `bun run check` — no new errors from touched files (pre-existing `@appwrite.io/console` module-resolution errors are environment-only, SDK not installed locally)