### PR TITLE
fix(auth/security): harden against missing or null policy entries (#3076)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/security/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/+page.ts
@@ -27,7 +27,9 @@ export const load: PageLoad = async ({ depends, params }) => {
 
     const { policies } = await sdk.forProject(params.region, params.project).project.listPolicies();
     const policiesById = Object.fromEntries(
-        (policies as ProjectPolicy[]).map((policy) => [policy.$id, policy])
+        (policies as ProjectPolicy[])
+            .filter((policy) => policy != null && policy.$id != null)
+            .map((policy) => [policy.$id, policy])
     ) as Partial<Record<ProjectPolicyId | EmailPolicyId, ProjectPolicy>>;
 
     return {

--- a/src/routes/(console)/project-[region]-[project]/auth/security/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/+page.ts
@@ -33,27 +33,33 @@ export const load: PageLoad = async ({ depends, params }) => {
     ) as Partial<Record<ProjectPolicyId | EmailPolicyId, ProjectPolicy>>;
 
     return {
-        membershipPrivacyPolicy: policiesById[
-            ProjectPolicyId.Membershipprivacy
-        ] as Models.PolicyMembershipPrivacy,
-        passwordDictionaryPolicy: policiesById[
-            ProjectPolicyId.Passworddictionary
-        ] as Models.PolicyPasswordDictionary,
-        passwordHistoryPolicy: policiesById[
-            ProjectPolicyId.Passwordhistory
-        ] as Models.PolicyPasswordHistory,
-        passwordPersonalDataPolicy: policiesById[
-            ProjectPolicyId.Passwordpersonaldata
-        ] as Models.PolicyPasswordPersonalData,
-        sessionAlertPolicy: policiesById[ProjectPolicyId.Sessionalert] as Models.PolicySessionAlert,
-        sessionDurationPolicy: policiesById[
-            ProjectPolicyId.Sessionduration
-        ] as Models.PolicySessionDuration,
-        sessionInvalidationPolicy: policiesById[
-            ProjectPolicyId.Sessioninvalidation
-        ] as Models.PolicySessionInvalidation,
-        sessionLimitPolicy: policiesById[ProjectPolicyId.Sessionlimit] as Models.PolicySessionLimit,
-        userLimitPolicy: policiesById[ProjectPolicyId.Userlimit] as Models.PolicyUserLimit,
+        membershipPrivacyPolicy: policiesById[ProjectPolicyId.Membershipprivacy] as
+            | Models.PolicyMembershipPrivacy
+            | undefined,
+        passwordDictionaryPolicy: policiesById[ProjectPolicyId.Passworddictionary] as
+            | Models.PolicyPasswordDictionary
+            | undefined,
+        passwordHistoryPolicy: policiesById[ProjectPolicyId.Passwordhistory] as
+            | Models.PolicyPasswordHistory
+            | undefined,
+        passwordPersonalDataPolicy: policiesById[ProjectPolicyId.Passwordpersonaldata] as
+            | Models.PolicyPasswordPersonalData
+            | undefined,
+        sessionAlertPolicy: policiesById[ProjectPolicyId.Sessionalert] as
+            | Models.PolicySessionAlert
+            | undefined,
+        sessionDurationPolicy: policiesById[ProjectPolicyId.Sessionduration] as
+            | Models.PolicySessionDuration
+            | undefined,
+        sessionInvalidationPolicy: policiesById[ProjectPolicyId.Sessioninvalidation] as
+            | Models.PolicySessionInvalidation
+            | undefined,
+        sessionLimitPolicy: policiesById[ProjectPolicyId.Sessionlimit] as
+            | Models.PolicySessionLimit
+            | undefined,
+        userLimitPolicy: policiesById[ProjectPolicyId.Userlimit] as
+            | Models.PolicyUserLimit
+            | undefined,
         denyAliasedEmailPolicy:
             (policiesById[ProjectEmailPolicyId.DenyAliasedEmail] as EnabledPolicy) ??
             getDefaultEnabledPolicy(ProjectEmailPolicyId.DenyAliasedEmail),

--- a/src/routes/(console)/project-[region]-[project]/auth/security/passwordPolicies.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/passwordPolicies.svelte
@@ -17,9 +17,9 @@
         personalDataPolicy
     }: {
         project: Models.Project;
-        dictionaryPolicy: Models.PolicyPasswordDictionary;
-        historyPolicy: Models.PolicyPasswordHistory;
-        personalDataPolicy: Models.PolicyPasswordPersonalData;
+        dictionaryPolicy: Models.PolicyPasswordDictionary | undefined;
+        historyPolicy: Models.PolicyPasswordHistory | undefined;
+        personalDataPolicy: Models.PolicyPasswordPersonalData | undefined;
     } = $props();
 
     let lastValidLimit = $state(5);
@@ -30,15 +30,15 @@
 
     onMount(() => {
         // update initial states here in onMount.
-        const historyValue = historyPolicy.total;
+        const historyValue = historyPolicy?.total;
         if (historyValue && historyValue > 0) {
             passwordHistory = historyValue;
             lastValidLimit = historyValue;
         }
 
         passwordHistoryEnabled = (historyValue ?? 0) !== 0;
-        passwordDictionary = dictionaryPolicy.enabled;
-        authPersonalDataCheck = personalDataPolicy.enabled;
+        passwordDictionary = dictionaryPolicy?.enabled ?? false;
+        authPersonalDataCheck = personalDataPolicy?.enabled ?? false;
     });
 
     $effect(() => {
@@ -49,11 +49,11 @@
     });
 
     const hasChanges = $derived.by(() => {
-        const dictChanged = passwordDictionary !== dictionaryPolicy.enabled;
-        const dataCheckChanged = authPersonalDataCheck !== personalDataPolicy.enabled;
-        const historyChanged = passwordHistoryEnabled !== (historyPolicy.total !== 0);
+        const dictChanged = passwordDictionary !== (dictionaryPolicy?.enabled ?? false);
+        const dataCheckChanged = authPersonalDataCheck !== (personalDataPolicy?.enabled ?? false);
+        const historyChanged = passwordHistoryEnabled !== ((historyPolicy?.total ?? 0) !== 0);
         const limitChanged =
-            passwordHistoryEnabled && Number(passwordHistory) !== historyPolicy.total;
+            passwordHistoryEnabled && Number(passwordHistory) !== (historyPolicy?.total ?? 0);
 
         return historyChanged || dictChanged || dataCheckChanged || limitChanged;
     });

--- a/src/routes/(console)/project-[region]-[project]/auth/security/sessionSecurity.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/sessionSecurity.svelte
@@ -16,21 +16,22 @@
         sessionInvalidationPolicy
     }: {
         project: Models.Project;
-        sessionAlertPolicy: Models.PolicySessionAlert;
-        sessionInvalidationPolicy: Models.PolicySessionInvalidation;
+        sessionAlertPolicy: Models.PolicySessionAlert | undefined;
+        sessionInvalidationPolicy: Models.PolicySessionInvalidation | undefined;
     } = $props();
 
     let authSessionAlerts = $state(false);
     let sessionInvalidation = $state(false);
 
     onMount(() => {
-        authSessionAlerts = sessionAlertPolicy.enabled;
-        sessionInvalidation = sessionInvalidationPolicy.enabled;
+        authSessionAlerts = sessionAlertPolicy?.enabled ?? false;
+        sessionInvalidation = sessionInvalidationPolicy?.enabled ?? false;
     });
 
     const hasChanges = $derived.by(() => {
-        const alertsChanged = authSessionAlerts !== sessionAlertPolicy.enabled;
-        const invalidationChanged = sessionInvalidation !== sessionInvalidationPolicy.enabled;
+        const alertsChanged = authSessionAlerts !== (sessionAlertPolicy?.enabled ?? false);
+        const invalidationChanged =
+            sessionInvalidation !== (sessionInvalidationPolicy?.enabled ?? false);
         return alertsChanged || invalidationChanged;
     });
 

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateMembershipPrivacy.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateMembershipPrivacy.svelte
@@ -14,21 +14,21 @@
         policy
     }: {
         project: Models.Project;
-        policy: Models.PolicyMembershipPrivacy;
+        policy: Models.PolicyMembershipPrivacy | undefined;
     } = $props();
 
-    let authMembershipsMfa = $state(policy.userMFA);
-    let authMembershipsUserId = $state(policy.userId);
-    let authMembershipsUserName = $state(policy.userName);
-    let authMembershipsUserEmail = $state(policy.userEmail);
-    let authMembershipsUserPhone = $state(policy.userPhone);
+    let authMembershipsMfa = $state(policy?.userMFA ?? false);
+    let authMembershipsUserId = $state(policy?.userId ?? false);
+    let authMembershipsUserName = $state(policy?.userName ?? false);
+    let authMembershipsUserEmail = $state(policy?.userEmail ?? false);
+    let authMembershipsUserPhone = $state(policy?.userPhone ?? false);
 
     const isSubmitDisabled = $derived(
-        authMembershipsUserId === policy.userId &&
-            authMembershipsUserName === policy.userName &&
-            authMembershipsUserEmail === policy.userEmail &&
-            authMembershipsUserPhone === policy.userPhone &&
-            authMembershipsMfa === policy.userMFA
+        authMembershipsUserId === (policy?.userId ?? false) &&
+            authMembershipsUserName === (policy?.userName ?? false) &&
+            authMembershipsUserEmail === (policy?.userEmail ?? false) &&
+            authMembershipsUserPhone === (policy?.userPhone ?? false) &&
+            authMembershipsMfa === (policy?.userMFA ?? false)
     );
 
     async function updateMembershipsPrivacy() {

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateSessionLength.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateSessionLength.svelte
@@ -15,10 +15,11 @@
         policy
     }: {
         project: Models.Project;
-        policy: Models.PolicySessionDuration;
+        policy: Models.PolicySessionDuration | undefined;
     } = $props();
 
-    const { value, unit, baseValue, units } = $derived(createTimeUnitPair(policy.duration));
+    const policyDuration = $derived(policy?.duration ?? 0);
+    const { value, unit, baseValue, units } = $derived(createTimeUnitPair(policyDuration));
     const options = $derived(units.map((v) => ({ label: v.name, value: v.name })));
 
     async function updateSessionLength() {
@@ -53,7 +54,7 @@
         </Layout.Stack>
     </svelte:fragment>
     <svelte:fragment slot="actions">
-        <Button disabled={$baseValue === policy.duration} on:click={updateSessionLength}>
+        <Button disabled={$baseValue === policyDuration} on:click={updateSessionLength}>
             Update
         </Button>
     </svelte:fragment>

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateSessionsLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateSessionsLimit.svelte
@@ -14,10 +14,11 @@
         policy
     }: {
         project: Models.Project;
-        policy: Models.PolicySessionLimit;
+        policy: Models.PolicySessionLimit | undefined;
     } = $props();
 
-    let maxSessions = $state(policy.total);
+    const policyTotal = $derived(policy?.total ?? 0);
+    let maxSessions = $state(policyTotal);
 
     async function updateSessionsLimit() {
         try {
@@ -56,7 +57,7 @@
                 bind:value={maxSessions} />
         </svelte:fragment>
         <svelte:fragment slot="actions">
-            <Button disabled={maxSessions === policy.total} submit>Update</Button>
+            <Button disabled={maxSessions === policyTotal} submit>Update</Button>
         </svelte:fragment>
     </CardGrid>
 </Form>

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
@@ -15,17 +15,18 @@
         policy
     }: {
         project: Models.Project;
-        policy: Models.PolicyUserLimit;
+        policy: Models.PolicyUserLimit | undefined;
     } = $props();
 
     let maxUsersInputField: HTMLInputElement | null = $state(null);
 
-    let value = $state(policy.total !== 0 ? 'limited' : 'unlimited');
-    let newLimit = $state(policy.total !== 0 ? policy.total : 100);
+    const policyTotal = $derived(policy?.total ?? 0);
+    let value = $state(policyTotal !== 0 ? 'limited' : 'unlimited');
+    let newLimit = $state(policyTotal !== 0 ? policyTotal : 100);
 
     const isLimited = $derived(value === 'limited');
     const btnDisabled = $derived.by(() => {
-        return (!isLimited && policy.total === 0) || (isLimited && policy.total === newLimit);
+        return (!isLimited && policyTotal === 0) || (isLimited && policyTotal === newLimit);
     });
 
     async function updateLimit() {


### PR DESCRIPTION
## What

Hardens the load function and `passwordPolicies` component for the `/auth/security` route against `null` or missing policy entries returned by `project.listPolicies()`.

## Why

After upgrading a self-hosted instance from `1.8.1` to `1.9.0`, opening **Auth → Security** crashes with:

```
Uncaught TypeError: Cannot read properties of null (reading 'group')
    at Array.filter (<anonymous>)
```

— reported in #3076.

The current code makes two unsafe assumptions:

1. `src/routes/.../auth/security/+page.ts` calls `.map((policy) => [policy.$id, policy])` on the `policies` array, so a single `null` entry throws before the page can render.
2. `passwordPolicies.svelte` accesses `historyPolicy.total`, `dictionaryPolicy.enabled`, and `personalDataPolicy.enabled` directly, but `+page.ts` already casts the lookup result as the policy type without verifying it is defined. After a migration from `1.8.1` → `1.9.0` it is possible for some policies not to be present yet, in which case those reads throw too.

## What changed

- `+page.ts` — `.filter((policy) => policy != null && policy.$id != null)` before `.map`.
- `passwordPolicies.svelte` — typed the three policy props as `… | undefined` (to match the runtime reality), used optional chaining + nullish-coalescing defaults in `onMount` and in the `hasChanges` derived.

## Verification

- `bun run check` — 0 errors, no new warnings.
- `bun run lint` — 0 errors.
- `bun run test:unit` — 235/235 pass.
- Dev server (`bun run dev`) loads with no regression.

## Caveats

The original stack trace in #3076 (`null.group` inside `Array.filter`) does not directly map to either site changed here — it points into minified JS without source maps. None of the policy models in `@appwrite.io/console` expose a `group` field, so the exact failing call site is somewhere I could not identify from the source alone (likely a code path I missed, or inside a dependency).

This PR fixes a **same-class** null-safety bug in the same load path that is reachable from the same user action. It is defensive hardening rather than a confirmed root-cause fix. If maintainers can share an unminified stack from a reproducing environment, I'm happy to follow up with a targeted patch for the precise failing site.

Related to: #3076
