### PR TITLE
feat: gate project-specific roles on supportsProjectSpecificRoles plag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@5c7f8e5",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@82069e6",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -125,7 +125,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@5c7f8e5", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@82069e6", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@5c7f8e5",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@82069e6",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -20,6 +20,5 @@ function isFlagEnabled(name: string) {
 
 export const flags = {
     multiDb: isFlagEnabled('multi-db'),
-    granularProjectAccess: isFlagEnabled('granular-project-access'),
     oauth2Server: isFlagEnabled('oauth2-server')
 };

--- a/src/routes/(console)/organization-[organization]/createMember.svelte
+++ b/src/routes/(console)/organization-[organization]/createMember.svelte
@@ -26,9 +26,7 @@
         oncreated?: (team: Models.Membership) => void;
     } = $props();
 
-    const supportsProjectRoles = $derived(
-        isCloud && !!$currentPlan?.supportsProjectSpecificRoles
-    );
+    const supportsProjectRoles = $derived(isCloud && !!$currentPlan?.supportsProjectSpecificRoles);
 
     let email = $state('');
     let name = $state('');

--- a/src/routes/(console)/organization-[organization]/createMember.svelte
+++ b/src/routes/(console)/organization-[organization]/createMember.svelte
@@ -11,8 +11,6 @@
     import { Submit, trackEvent, trackError } from '$lib/actions/analytics';
     import { isCloud, isSelfHosted } from '$lib/system';
     import { roles, buildProjectRole } from '$lib/stores/billing';
-    import { flags } from '$lib/flags';
-    import { user } from '$lib/stores/user';
     import InputSelect from '$lib/elements/forms/inputSelect.svelte';
     import Roles from '$lib/components/roles/roles.svelte';
     import { Icon, Popover, Layout } from '@appwrite.io/pink-svelte';
@@ -29,9 +27,7 @@
     } = $props();
 
     const supportsProjectRoles = $derived(
-        isCloud &&
-            flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-            !!$currentPlan?.supportsProjectSpecificRoles
+        isCloud && !!$currentPlan?.supportsProjectSpecificRoles
     );
 
     let email = $state('');

--- a/src/routes/(console)/organization-[organization]/createMember.svelte
+++ b/src/routes/(console)/organization-[organization]/createMember.svelte
@@ -31,7 +31,7 @@
     const supportsProjectRoles = $derived(
         isCloud &&
             flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-            !!$currentPlan?.supportsOrganizationRoles
+            !!$currentPlan?.supportsProjectSpecificRoles
     );
 
     let email = $state('');

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -219,7 +219,7 @@
                         </Button.Button>
                         <div style:min-width="232px" slot="tooltip">
                             <ActionMenu.Root>
-                                {#if supportsOrgRoles}
+                                {#if supportsOrgRoles || supportsProjectRoles}
                                     <ActionMenu.Item.Button
                                         trailingIcon={IconPencil}
                                         on:click={() => {

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -62,8 +62,7 @@
     $: isLimited = limit !== 0 && limit < Infinity;
     $: isButtonDisabled =
         isCloud && (($readOnly && !GRACE_PERIOD_OVERRIDE) || (isLimited && memberCount >= limit));
-    $: supportsOrgRoles =
-        isCloud && !!$currentPlan?.supportsOrganizationRoles;
+    $: supportsOrgRoles = isCloud && !!$currentPlan?.supportsOrganizationRoles;
     $: supportsProjectRoles =
         isCloud &&
         flags.granularProjectAccess({ account: $user, organization: $organization }) &&

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -62,10 +62,12 @@
     $: isLimited = limit !== 0 && limit < Infinity;
     $: isButtonDisabled =
         isCloud && (($readOnly && !GRACE_PERIOD_OVERRIDE) || (isLimited && memberCount >= limit));
+    $: supportsOrgRoles =
+        isCloud && !!$currentPlan?.supportsOrganizationRoles;
     $: supportsProjectRoles =
         isCloud &&
         flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-        $currentPlan?.supportsProjectSpecificRoles;
+        !!$currentPlan?.supportsProjectSpecificRoles;
 
     const resend = async (member: Models.Membership) => {
         try {
@@ -223,7 +225,7 @@
                         </Button.Button>
                         <div style:min-width="232px" slot="tooltip">
                             <ActionMenu.Root>
-                                {#if supportsProjectRoles}
+                                {#if supportsOrgRoles}
                                     <ActionMenu.Item.Button
                                         trailingIcon={IconPencil}
                                         on:click={() => {

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -65,7 +65,7 @@
     $: supportsProjectRoles =
         isCloud &&
         flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-        $currentPlan?.supportsOrganizationRoles;
+        $currentPlan?.supportsProjectSpecificRoles;
 
     const resend = async (member: Models.Membership) => {
         try {

--- a/src/routes/(console)/organization-[organization]/members/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/members/+page.svelte
@@ -20,10 +20,8 @@
     } from '$lib/helpers/tooltipContent';
     import { addNotification } from '$lib/stores/notifications';
     import { currentPlan, newMemberModal, organization } from '$lib/stores/organization';
-    import { flags } from '$lib/flags';
     import { isOwner } from '$lib/stores/roles';
     import { sdk } from '$lib/stores/sdk';
-    import { user } from '$lib/stores/user';
     import type { Models } from '@appwrite.io/console';
     import Delete from '../deleteMember.svelte';
     import Edit from './edit.svelte';
@@ -63,10 +61,7 @@
     $: isButtonDisabled =
         isCloud && (($readOnly && !GRACE_PERIOD_OVERRIDE) || (isLimited && memberCount >= limit));
     $: supportsOrgRoles = isCloud && !!$currentPlan?.supportsOrganizationRoles;
-    $: supportsProjectRoles =
-        isCloud &&
-        flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-        !!$currentPlan?.supportsProjectSpecificRoles;
+    $: supportsProjectRoles = isCloud && !!$currentPlan?.supportsProjectSpecificRoles;
 
     const resend = async (member: Models.Membership) => {
         try {

--- a/src/routes/(console)/organization-[organization]/members/+page.ts
+++ b/src/routes/(console)/organization-[organization]/members/+page.ts
@@ -1,12 +1,11 @@
 import { Dependencies, PAGE_LIMIT } from '$lib/constants';
-import { flags } from '$lib/flags';
 import { getLimit, getPage, getSearch, pageToOffset } from '$lib/helpers/load';
 import { sdk } from '$lib/stores/sdk';
 import { Query } from '@appwrite.io/console';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url, params, route, depends, parent }) => {
-    const { account, organization } = await parent();
+    await parent();
     depends(Dependencies.ORGANIZATION);
     depends(Dependencies.MEMBERS);
 
@@ -15,22 +14,18 @@ export const load: PageLoad = async ({ url, params, route, depends, parent }) =>
     const limit = getLimit(url, route, PAGE_LIMIT);
     const offset = pageToOffset(page, limit);
 
-    const supportsProjectRoles = flags.granularProjectAccess({ account, organization });
-
     const [organizationMembers, orgProjects] = await Promise.all([
         sdk.forConsole.teams.listMemberships({
             teamId: params.organization,
             queries: [Query.limit(limit), Query.offset(offset)],
             search
         }),
-        supportsProjectRoles
-            ? sdk.forConsole
-                  .organization(params.organization)
-                  .listProjects({
-                      queries: [Query.limit(100), Query.equal('teamId', params.organization)]
-                  })
-                  .catch(() => null)
-            : null
+        sdk.forConsole
+            .organization(params.organization)
+            .listProjects({
+                queries: [Query.limit(100), Query.equal('teamId', params.organization)]
+            })
+            .catch(() => null)
     ]);
 
     return {

--- a/src/routes/(console)/organization-[organization]/members/edit.svelte
+++ b/src/routes/(console)/organization-[organization]/members/edit.svelte
@@ -36,7 +36,7 @@
     const supportsProjectRoles = $derived(
         isCloud &&
             flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-            !!$currentPlan?.supportsOrganizationRoles
+            !!$currentPlan?.supportsProjectSpecificRoles
     );
     const defaultRole = isSelfHosted ? 'owner' : 'developer';
 

--- a/src/routes/(console)/organization-[organization]/members/edit.svelte
+++ b/src/routes/(console)/organization-[organization]/members/edit.svelte
@@ -19,8 +19,6 @@
         buildProjectRole
     } from '$lib/stores/billing';
     import { isCloud, isSelfHosted } from '$lib/system';
-    import { flags } from '$lib/flags';
-    import { user } from '$lib/stores/user';
     import ProjectAccessSelector from '../projectAccessSelector.svelte';
 
     let {
@@ -34,9 +32,7 @@
     } = $props();
 
     const supportsProjectRoles = $derived(
-        isCloud &&
-            flags.granularProjectAccess({ account: $user, organization: $organization }) &&
-            !!$currentPlan?.supportsProjectSpecificRoles
+        isCloud && !!$currentPlan?.supportsProjectSpecificRoles
     );
     const defaultRole = isSelfHosted ? 'owner' : 'developer';
 

--- a/src/routes/(console)/organization-[organization]/members/edit.svelte
+++ b/src/routes/(console)/organization-[organization]/members/edit.svelte
@@ -31,9 +31,7 @@
         onupdated?: (membership: Models.Membership) => void;
     } = $props();
 
-    const supportsProjectRoles = $derived(
-        isCloud && !!$currentPlan?.supportsProjectSpecificRoles
-    );
+    const supportsProjectRoles = $derived(isCloud && !!$currentPlan?.supportsProjectSpecificRoles);
     const defaultRole = isSelfHosted ? 'owner' : 'developer';
 
     let error = $state<string>(null);


### PR DESCRIPTION


Update SDK to @appwrite.io/console@82069e6 which exposes the new flag. Replace supportsOrganizationRoles with supportsProjectSpecificRoles in createMember, edit, and members page — org roles and project-specific roles are now independently gated by their own plan flags.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)