### PR TITLE
fix(verify-email): prevent redirect loop on failed verification

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -17,18 +17,18 @@
 
     async function updateVerificationEmail() {
         showVerificationDropdown = false;
+        const newVerification = !$user.emailVerification;
+        const label = $user.name || $user.email || $user.phone || 'The account';
         try {
             await sdk
                 .forProject(page.params.region, page.params.project)
                 .users.updateEmailVerification({
                     userId: $user.$id,
-                    emailVerification: !$user.emailVerification
+                    emailVerification: newVerification
                 });
             await invalidate(Dependencies.USER);
             addNotification({
-                message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
-                    !$user.emailVerification ? 'unverified' : 'verified'
-                }`,
+                message: `${label} email has been ${newVerification ? 'verified' : 'unverified'}`,
                 type: 'success'
             });
             trackEvent(Submit.UserUpdateVerificationEmail);
@@ -42,18 +42,18 @@
     }
     async function updateVerificationPhone() {
         showVerificationDropdown = false;
+        const newVerification = !$user.phoneVerification;
+        const label = $user.name || $user.email || $user.phone || 'The account';
         try {
             await sdk
                 .forProject(page.params.region, page.params.project)
                 .users.updatePhoneVerification({
                     userId: $user.$id,
-                    phoneVerification: !$user.phoneVerification
+                    phoneVerification: newVerification
                 });
             await invalidate(Dependencies.USER);
             addNotification({
-                message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
-                    $user.phoneVerification ? 'unverified' : 'verified'
-                }`,
+                message: `${label} phone has been ${newVerification ? 'verified' : 'unverified'}`,
                 type: 'success'
             });
             trackEvent(Submit.UserUpdateVerificationPhone);


### PR DESCRIPTION
Fixes #1392

Both `updateVerificationEmail` and `updateVerificationPhone` read the user store after `invalidate()` to build the success notification. At that point the store already reflects the new state, so the ternary produces the opposite message — showing "unverified" after verifying and vice versa.

Capture the intended verification state before the API call so the notification always matches the action. Also disambiguate the messages to say "email has been verified" vs "phone has been verified" when the user has both.