### PR TITLE
fix(a11y): correct aria-labels for documentation buttons

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/+page.svelte
@@ -109,7 +109,7 @@
                             href="https://appwrite.io/docs/products/databases/databases"
                             text
                             event="empty_documentation"
-                            ariaLabel="create {entityLower.singular}">Documentation</Button>
+                            ariaLabel="read {entityLower.singular} documentation">Documentation</Button>
 
                         {#if $canWriteTables}
                             <Button secondary on:click={() => ($showCreateEntity = true)}>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/executions/+page.svelte
@@ -66,7 +66,7 @@
                     text
                     event="empty_documentation"
                     size="s"
-                    ariaLabel="create execution">Documentation</Button>
+                    ariaLabel="read execution documentation">Documentation</Button>
                 <Tooltip disabled={!!data.func?.deploymentId} maxWidth={BODY_TOOLTIP_MAX_WIDTH}>
                     <div>
                         <Button

--- a/src/routes/(console)/project-[region]-[project]/messaging/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/+page.svelte
@@ -236,7 +236,7 @@
                 <Button
                     external
                     text
-                    ariaLabel="create message"
+                    ariaLabel="read message documentation"
                     event="empty_documentation"
                     href="https://appwrite.io/docs/products/messaging/messages">
                     Documentation


### PR DESCRIPTION
This PR fixes an accessibility bug where the 'Documentation' buttons on empty states incorrectly used the 'create [resource]' ARIA label, which was likely left over from copy-pasting the adjacent 'Create' button.