### PR TITLE
refactor: streamline OAuth2 consent screens

### DIFF
--- a/src/lib/helpers/oauth2-scopes.ts
+++ b/src/lib/helpers/oauth2-scopes.ts
@@ -72,9 +72,11 @@ export function describeScopes(scopes: string[]): ScopeDescriptor[] {
 const CONSENT_IDENTITY_SCOPES = ['profile', 'email'] as const;
 
 /**
- * Build the permission list for the OAuth2 consent screen. Full account access
- * is shown only when the app explicitly requests `account.admin`; OIDC identity
- * scopes are shown as secondary detail when present.
+ * Build the permission list for the console OAuth2 consent screen. The server
+ * enforces scope-based access, so this maps 1:1 to the issued token: full access
+ * only for `account.admin`, then identity scopes, then any granular scopes.
+ * Falls back to the lone `openid` "Verify your identity" row so a minimal OIDC
+ * request is never empty.
  */
 export function describeConsentScopes(scopes: string[]): ScopeDescriptor[] {
     const requested = new Set(scopes);
@@ -89,5 +91,10 @@ export function describeConsentScopes(scopes: string[]): ScopeDescriptor[] {
             !(CONSENT_IDENTITY_SCOPES as readonly string[]).includes(scope)
     );
 
-    return [...admin, ...identity, ...remaining.map(describeScope)];
+    const described = [...admin, ...identity, ...remaining.map(describeScope)];
+    if (described.length === 0 && requested.has('openid')) {
+        return [describeScope('openid')];
+    }
+
+    return described;
 }

--- a/src/lib/helpers/oauth2-scopes.ts
+++ b/src/lib/helpers/oauth2-scopes.ts
@@ -14,17 +14,10 @@ export interface ScopeDescriptor {
     icon: ComponentType;
 }
 
-/**
- * This consent screen always authorizes against the Appwrite **console**
- * project. On the server, any OAuth2 access token issued for the console
- * project is granted the full `users` (member) role — the same access a
- * signed-in console session has — regardless of the OIDC scopes requested.
- * The `openid`/`profile`/`email` scopes only shape the OIDC identity claims;
- * they do NOT limit what the application can do. So the consent screen must
- * lead with the full-access reality rather than implying read-only access.
- */
-export const FULL_ACCESS_SCOPE: ScopeDescriptor = {
-    id: '__full_access__',
+export const ACCOUNT_ADMIN_SCOPE = 'account.admin';
+
+export const ACCOUNT_ADMIN_DESCRIPTOR: ScopeDescriptor = {
+    id: ACCOUNT_ADMIN_SCOPE,
     title: 'Full access to your account',
     description: 'Manage your organizations, projects, and all their resources on your behalf.',
     icon: IconShieldCheck
@@ -45,6 +38,11 @@ const BUILTIN_SCOPES: Record<string, Omit<ScopeDescriptor, 'id'>> = {
         title: 'View your email address',
         description: 'Read the email address associated with your account.',
         icon: IconMail
+    },
+    [ACCOUNT_ADMIN_SCOPE]: {
+        title: ACCOUNT_ADMIN_DESCRIPTOR.title,
+        description: ACCOUNT_ADMIN_DESCRIPTOR.description,
+        icon: ACCOUNT_ADMIN_DESCRIPTOR.icon
     }
 };
 
@@ -71,20 +69,25 @@ export function describeScopes(scopes: string[]): ScopeDescriptor[] {
     return scopes.map(describeScope);
 }
 
-// Identity scopes shown (in this order) as secondary detail beneath the
-// full-access item. `openid` is intentionally omitted — identity verification
-// is implied by full account access, so listing it separately is redundant.
 const CONSENT_IDENTITY_SCOPES = ['profile', 'email'] as const;
 
 /**
- * Build the permission list for the console OAuth2 consent screen. Always leads
- * with the full-access item (the true effect of authorizing), followed by the
- * identity scopes the application actually reads (profile, email) when present.
+ * Build the permission list for the OAuth2 consent screen. Full account access
+ * is shown only when the app explicitly requests `account.admin`; OIDC identity
+ * scopes are shown as secondary detail when present.
  */
 export function describeConsentScopes(scopes: string[]): ScopeDescriptor[] {
     const requested = new Set(scopes);
+    const admin = requested.has(ACCOUNT_ADMIN_SCOPE) ? [ACCOUNT_ADMIN_DESCRIPTOR] : [];
     const identity = CONSENT_IDENTITY_SCOPES.filter((scope) => requested.has(scope)).map(
         describeScope
     );
-    return [FULL_ACCESS_SCOPE, ...identity];
+    const remaining = scopes.filter(
+        (scope) =>
+            scope !== 'openid' &&
+            scope !== ACCOUNT_ADMIN_SCOPE &&
+            !(CONSENT_IDENTITY_SCOPES as readonly string[]).includes(scope)
+    );
+
+    return [...admin, ...identity, ...remaining.map(describeScope)];
 }

--- a/src/routes/(console)/account/applications/+page.svelte
+++ b/src/routes/(console)/account/applications/+page.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+    import { invalidate } from '$app/navigation';
+    import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
+    import { Dependencies } from '$lib/constants';
+    import { Button } from '$lib/elements/forms';
+    import { Container } from '$lib/layout';
+    import { toLocaleDate } from '$lib/helpers/date';
+    import { addNotification } from '$lib/stores/notifications';
+    import { sdk } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
+    import { Badge, Card, Empty, Icon, Layout, Table, Typography } from '@appwrite.io/pink-svelte';
+    import { IconTerminal } from '@appwrite.io/pink-icons-svelte';
+    import type { PageData } from './$types';
+
+    export let data: PageData;
+
+    function displayName(appId: string, app: Models.App | null): string {
+        return app?.name || appId;
+    }
+
+    async function revoke(identity: Models.Identity, appId: string, app: Models.App | null) {
+        try {
+            await sdk.forConsole.account.deleteIdentity({ identityId: identity.$id });
+            await invalidate(Dependencies.IDENTITIES);
+            trackEvent(Submit.AccountDeleteIdentity);
+            addNotification({
+                type: 'success',
+                message: `Access for ${displayName(appId, app)} has been revoked`
+            });
+        } catch (error) {
+            addNotification({ type: 'error', message: error.message });
+            trackError(error, Submit.AccountDeleteIdentity);
+        }
+    }
+</script>
+
+<Container>
+    <Layout.Stack gap="xxs">
+        <Typography.Title>Applications</Typography.Title>
+        <Typography.Text variant="m-400" color="--fgcolor-neutral-secondary">
+            Applications you've authorized to access your Appwrite account.
+        </Typography.Text>
+    </Layout.Stack>
+
+    {#if data.connectedApps.length === 0}
+        <Card.Base padding="none">
+            <Empty type="secondary" title="No applications connected" />
+        </Card.Base>
+    {:else}
+        <Table.Root
+            class="responsive-table"
+            let:root
+            columns={[
+                { id: 'app', width: { min: 450 } },
+                { id: 'authorized', width: { min: 160 } },
+                { id: 'actions', width: 100 }
+            ]}>
+            <svelte:fragment slot="header" let:root>
+                <Table.Header.Cell column="app" {root}>Application</Table.Header.Cell>
+                <Table.Header.Cell column="authorized" {root}>Authorized</Table.Header.Cell>
+                <Table.Header.Cell column="actions" {root} />
+            </svelte:fragment>
+            {#each data.connectedApps as { identity, appId, app } (identity.$id)}
+                <Table.Row.Base {root}>
+                    <Table.Cell column="app" {root}>
+                        <Layout.Stack direction="row" alignItems="center" gap="m">
+                            <div class="avatar is-size-small">
+                                {#if app?.logoUri}
+                                    <img height="24" width="24" src={app.logoUri} alt={app.name} />
+                                {:else}
+                                    <Icon icon={IconTerminal} size="s" />
+                                {/if}
+                            </div>
+                            <Layout.Stack gap="none">
+                                <Layout.Stack direction="row" alignItems="center" gap="s">
+                                    <Typography.Text
+                                        variant="m-500"
+                                        color="--fgcolor-neutral-primary">
+                                        {displayName(appId, app)}
+                                    </Typography.Text>
+                                    {#if app?.deviceFlow}
+                                        <Badge
+                                            variant="secondary"
+                                            content="Device flow"
+                                            size="xs" />
+                                    {/if}
+                                </Layout.Stack>
+                                {#if app?.tagline || app?.description}
+                                    <Typography.Caption
+                                        variant="400"
+                                        color="--fgcolor-neutral-secondary"
+                                        truncate>
+                                        {app.tagline || app.description}
+                                    </Typography.Caption>
+                                {/if}
+                            </Layout.Stack>
+                        </Layout.Stack>
+                    </Table.Cell>
+                    <Table.Cell column="authorized" {root}>
+                        {toLocaleDate(identity.$createdAt)}
+                    </Table.Cell>
+                    <Table.Cell column="actions" {root}>
+                        <Button size="xs" secondary on:click={() => revoke(identity, appId, app)}>
+                            Revoke
+                        </Button>
+                    </Table.Cell>
+                </Table.Row.Base>
+            {/each}
+        </Table.Root>
+    {/if}
+</Container>

--- a/src/routes/(console)/account/applications/+page.ts
+++ b/src/routes/(console)/account/applications/+page.ts
@@ -1,0 +1,28 @@
+import { Dependencies } from '$lib/constants';
+import { sdk } from '$lib/stores/sdk';
+import type { Models } from '@appwrite.io/console';
+import type { PageLoad } from './$types';
+
+const OAUTH2_PREFIX = 'oauth2:';
+
+export const load: PageLoad = async ({ depends, parent }) => {
+    depends(Dependencies.IDENTITIES);
+
+    // Apps authorized through the console OAuth2 server (e.g. the Appwrite CLI via
+    // the device flow) are stored as `oauth2:<appId>` identities by the parent
+    // layout load. Resolve each to its app metadata for richer rendering.
+    const { identities } = await parent();
+    const grants = (identities.identities as Models.Identity[]).filter((identity) =>
+        identity.provider?.startsWith(OAUTH2_PREFIX)
+    );
+
+    const connectedApps = await Promise.all(
+        grants.map(async (identity) => {
+            const appId = identity.provider.slice(OAUTH2_PREFIX.length);
+            const app = await sdk.forConsole.apps.get({ appId }).catch(() => null);
+            return { identity, appId, app };
+        })
+    );
+
+    return { connectedApps };
+};

--- a/src/routes/(console)/account/header.svelte
+++ b/src/routes/(console)/account/header.svelte
@@ -23,6 +23,11 @@
             event: 'sessions'
         },
         {
+            href: `${path}/applications`,
+            title: 'Applications',
+            event: 'applications'
+        },
+        {
             href: `${path}/activity`,
             title: 'Activity',
             event: 'activity',

--- a/src/routes/(console)/account/identities.svelte
+++ b/src/routes/(console)/account/identities.svelte
@@ -12,6 +12,12 @@
     import { IconTrash } from '@appwrite.io/pink-icons-svelte';
     import DualTimeView from '$lib/components/dualTimeView.svelte';
 
+    // Apps authorized through the OAuth2 server use an `oauth2:<appId>` provider
+    // and are managed on the Applications tab; this list is sign-in identities only.
+    $: signInIdentities = $identities.filter(
+        (identity) => !identity.provider?.startsWith('oauth2:')
+    );
+
     async function deleteIdentity(id: string) {
         try {
             await sdk.forConsole.account.deleteIdentity({ identityId: id });
@@ -36,7 +42,7 @@
     Identities are your connected GitHub accounts. You can sign in using these accounts.
 
     <svelte:fragment slot="aside">
-        {#if $identities.length === 0}
+        {#if signInIdentities.length === 0}
             <Card.Base padding="none">
                 <Empty
                     type="secondary"
@@ -61,7 +67,7 @@
                     <Table.Header.Cell column="expiryDate" {root}>Expiry Date</Table.Header.Cell>
                     <Table.Header.Cell column="actions" {root} />
                 </svelte:fragment>
-                {#each $identities as identity (identity.$id)}
+                {#each signInIdentities as identity (identity.$id)}
                     {@const provider = oAuthProviders[identity.provider]}
                     <Table.Row.Base {root}>
                         <Table.Cell column="provider" {root}>

--- a/src/routes/(console)/account/sessions/+page.svelte
+++ b/src/routes/(console)/account/sessions/+page.svelte
@@ -21,37 +21,15 @@
         Icon,
         InteractiveText
     } from '@appwrite.io/pink-svelte';
-    import { IconGlobeAlt, IconTerminal } from '@appwrite.io/pink-icons-svelte';
-    import { toLocaleDate } from '$lib/helpers/date';
+    import { IconGlobeAlt } from '@appwrite.io/pink-icons-svelte';
 
     export let data: PageData;
 
-    // Apps the user authorized through the console OAuth2 server (e.g. the
-    // Appwrite CLI via the device flow) are stored as identities with an
-    // `oauth2:<appId>` provider, separately from browser sessions.
-    $: connectedApps = data.identities.identities.filter((identity) =>
-        identity.provider?.startsWith('oauth2:')
+    // OAuth2 app authorizations (e.g. the Appwrite CLI) are surfaced on the
+    // Applications tab, so keep them out of the browser-session list here.
+    $: visibleSessions = data.sessions.sessions.filter(
+        (session) => !session.provider?.startsWith('oauth2')
     );
-
-    // The built-in CLI client only supports the device flow, so we can label it
-    // precisely; other OAuth2 clients just show "OAuth".
-    const OAUTH2_PREFIX = 'oauth2:';
-    const KNOWN_APP_NAMES: Record<string, string> = {
-        'appwrite-cli': 'Appwrite CLI'
-    };
-
-    function appIdOf(provider: string): string {
-        return provider.slice(OAUTH2_PREFIX.length);
-    }
-
-    function appName(provider: string): string {
-        const appId = appIdOf(provider);
-        return KNOWN_APP_NAMES[appId] ?? appId;
-    }
-
-    function connectionLabel(provider: string): string {
-        return appIdOf(provider) === 'appwrite-cli' ? 'OAuth · device flow' : 'OAuth';
-    }
 
     function getBrowser(clientCode: string) {
         const code = clientCode.toLowerCase();
@@ -103,20 +81,6 @@
         await goto(`${base}/login`);
     }
 
-    async function revokeApp(identity: Models.Identity) {
-        try {
-            await sdk.forConsole.account.deleteIdentity({ identityId: identity.$id });
-            await invalidate(Dependencies.ACCOUNT_SESSIONS);
-            trackEvent(Submit.AccountDeleteIdentity);
-            addNotification({
-                type: 'success',
-                message: `Access for ${appName(identity.provider)} has been revoked`
-            });
-        } catch (e) {
-            addNotification({ type: 'error', message: e.message });
-        }
-    }
-
     onMount(() => {
         return pageStore.subscribe(($page) => {
             const url = new URL($page.url);
@@ -153,7 +117,7 @@
             <Table.Header.Cell column="ip" {root}>IP</Table.Header.Cell>
             <Table.Header.Cell column="actions" {root} />
         </svelte:fragment>
-        {#each data.sessions.sessions as session}
+        {#each visibleSessions as session}
             {@const browser = getBrowser(session.clientCode)}
             <Table.Row.Base {root}>
                 <Table.Cell column="client" {root}>
@@ -204,51 +168,4 @@
             </Table.Row.Base>
         {/each}
     </Table.Root>
-
-    {#if connectedApps.length > 0}
-        <Layout.Stack gap="xxs">
-            <Typography.Title size="s">Connected applications</Typography.Title>
-            <Typography.Text variant="m-400" color="--fgcolor-neutral-secondary">
-                Applications you've authorized to access your account.
-            </Typography.Text>
-        </Layout.Stack>
-
-        <Table.Root
-            class="responsive-table"
-            let:root
-            columns={[
-                { id: 'app', width: { min: 450 } },
-                { id: 'authorized', width: { min: 200 } },
-                { id: 'actions', width: 100 }
-            ]}>
-            <svelte:fragment slot="header" let:root>
-                <Table.Header.Cell column="app" {root}>Application</Table.Header.Cell>
-                <Table.Header.Cell column="authorized" {root}>Authorized</Table.Header.Cell>
-                <Table.Header.Cell column="actions" {root} />
-            </svelte:fragment>
-            {#each connectedApps as identity (identity.$id)}
-                <Table.Row.Base {root}>
-                    <Table.Cell column="app" {root}>
-                        <Layout.Stack direction="row" alignItems="center">
-                            <div class="avatar is-size-small">
-                                <Icon icon={IconTerminal} size="s" />
-                            </div>
-                            <Trim>{appName(identity.provider)}</Trim>
-                            <Badge
-                                variant="secondary"
-                                content={connectionLabel(identity.provider)} />
-                        </Layout.Stack>
-                    </Table.Cell>
-                    <Table.Cell column="authorized" {root}>
-                        {toLocaleDate(identity.$createdAt)}
-                    </Table.Cell>
-                    <Table.Cell column="actions" {root}>
-                        <Button size="xs" secondary on:click={() => revokeApp(identity)}>
-                            Revoke
-                        </Button>
-                    </Table.Cell>
-                </Table.Row.Base>
-            {/each}
-        </Table.Root>
-    {/if}
 </Container>

--- a/src/routes/(console)/account/sessions/+page.svelte
+++ b/src/routes/(console)/account/sessions/+page.svelte
@@ -21,9 +21,37 @@
         Icon,
         InteractiveText
     } from '@appwrite.io/pink-svelte';
-    import { IconGlobeAlt } from '@appwrite.io/pink-icons-svelte';
+    import { IconGlobeAlt, IconTerminal } from '@appwrite.io/pink-icons-svelte';
+    import { toLocaleDate } from '$lib/helpers/date';
 
     export let data: PageData;
+
+    // Apps the user authorized through the console OAuth2 server (e.g. the
+    // Appwrite CLI via the device flow) are stored as identities with an
+    // `oauth2:<appId>` provider, separately from browser sessions.
+    $: connectedApps = data.identities.identities.filter((identity) =>
+        identity.provider?.startsWith('oauth2:')
+    );
+
+    // The built-in CLI client only supports the device flow, so we can label it
+    // precisely; other OAuth2 clients just show "OAuth".
+    const OAUTH2_PREFIX = 'oauth2:';
+    const KNOWN_APP_NAMES: Record<string, string> = {
+        'appwrite-cli': 'Appwrite CLI'
+    };
+
+    function appIdOf(provider: string): string {
+        return provider.slice(OAUTH2_PREFIX.length);
+    }
+
+    function appName(provider: string): string {
+        const appId = appIdOf(provider);
+        return KNOWN_APP_NAMES[appId] ?? appId;
+    }
+
+    function connectionLabel(provider: string): string {
+        return appIdOf(provider) === 'appwrite-cli' ? 'OAuth · device flow' : 'OAuth';
+    }
 
     function getBrowser(clientCode: string) {
         const code = clientCode.toLowerCase();
@@ -73,6 +101,20 @@
         await invalidate(Dependencies.ACCOUNT_SESSIONS);
         trackEvent(Submit.AccountDeleteAllSessions);
         await goto(`${base}/login`);
+    }
+
+    async function revokeApp(identity: Models.Identity) {
+        try {
+            await sdk.forConsole.account.deleteIdentity({ identityId: identity.$id });
+            await invalidate(Dependencies.ACCOUNT_SESSIONS);
+            trackEvent(Submit.AccountDeleteIdentity);
+            addNotification({
+                type: 'success',
+                message: `Access for ${appName(identity.provider)} has been revoked`
+            });
+        } catch (e) {
+            addNotification({ type: 'error', message: e.message });
+        }
     }
 
     onMount(() => {
@@ -162,4 +204,51 @@
             </Table.Row.Base>
         {/each}
     </Table.Root>
+
+    {#if connectedApps.length > 0}
+        <Layout.Stack gap="xxs">
+            <Typography.Title size="s">Connected applications</Typography.Title>
+            <Typography.Text variant="m-400" color="--fgcolor-neutral-secondary">
+                Applications you've authorized to access your account.
+            </Typography.Text>
+        </Layout.Stack>
+
+        <Table.Root
+            class="responsive-table"
+            let:root
+            columns={[
+                { id: 'app', width: { min: 450 } },
+                { id: 'authorized', width: { min: 200 } },
+                { id: 'actions', width: 100 }
+            ]}>
+            <svelte:fragment slot="header" let:root>
+                <Table.Header.Cell column="app" {root}>Application</Table.Header.Cell>
+                <Table.Header.Cell column="authorized" {root}>Authorized</Table.Header.Cell>
+                <Table.Header.Cell column="actions" {root} />
+            </svelte:fragment>
+            {#each connectedApps as identity (identity.$id)}
+                <Table.Row.Base {root}>
+                    <Table.Cell column="app" {root}>
+                        <Layout.Stack direction="row" alignItems="center">
+                            <div class="avatar is-size-small">
+                                <Icon icon={IconTerminal} size="s" />
+                            </div>
+                            <Trim>{appName(identity.provider)}</Trim>
+                            <Badge
+                                variant="secondary"
+                                content={connectionLabel(identity.provider)} />
+                        </Layout.Stack>
+                    </Table.Cell>
+                    <Table.Cell column="authorized" {root}>
+                        {toLocaleDate(identity.$createdAt)}
+                    </Table.Cell>
+                    <Table.Cell column="actions" {root}>
+                        <Button size="xs" secondary on:click={() => revokeApp(identity)}>
+                            Revoke
+                        </Button>
+                    </Table.Cell>
+                </Table.Row.Base>
+            {/each}
+        </Table.Root>
+    {/if}
 </Container>

--- a/src/routes/(console)/account/sessions/+page.ts
+++ b/src/routes/(console)/account/sessions/+page.ts
@@ -5,10 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ depends }) => {
     depends(Dependencies.ACCOUNT_SESSIONS);
 
-    const [sessions, identities] = await Promise.all([
-        sdk.forConsole.account.listSessions(),
-        sdk.forConsole.account.listIdentities()
-    ]);
-
-    return { sessions, identities };
+    return {
+        sessions: await sdk.forConsole.account.listSessions()
+    };
 };

--- a/src/routes/(console)/account/sessions/+page.ts
+++ b/src/routes/(console)/account/sessions/+page.ts
@@ -5,7 +5,10 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ depends }) => {
     depends(Dependencies.ACCOUNT_SESSIONS);
 
-    return {
-        sessions: await sdk.forConsole.account.listSessions()
-    };
+    const [sessions, identities] = await Promise.all([
+        sdk.forConsole.account.listSessions(),
+        sdk.forConsole.account.listIdentities()
+    ]);
+
+    return { sessions, identities };
 };

--- a/src/routes/(public)/oauth2/consent-card.svelte
+++ b/src/routes/(public)/oauth2/consent-card.svelte
@@ -157,21 +157,23 @@
             {/if}
         </Layout.Stack>
 
-        <ul class="scope-list">
-            {#each scopes as scope (scope.id)}
-                <li class="scope-item" class:lead={scope.id === ACCOUNT_ADMIN_SCOPE}>
-                    <span class="scope-icon">
-                        <Icon icon={scope.icon} size="s" />
-                    </span>
-                    <span class="scope-text">
-                        <span class="scope-title">{scope.title}</span>
-                        {#if showDescription(scope.id)}
-                            <span class="scope-desc">{scope.description}</span>
-                        {/if}
-                    </span>
-                </li>
-            {/each}
-        </ul>
+        {#if scopes.length > 0}
+            <ul class="scope-list">
+                {#each scopes as scope (scope.id)}
+                    <li class="scope-item" class:lead={scope.id === ACCOUNT_ADMIN_SCOPE}>
+                        <span class="scope-icon">
+                            <Icon icon={scope.icon} size="s" />
+                        </span>
+                        <span class="scope-text">
+                            <span class="scope-title">{scope.title}</span>
+                            {#if showDescription(scope.id)}
+                                <span class="scope-desc">{scope.description}</span>
+                            {/if}
+                        </span>
+                    </li>
+                {/each}
+            </ul>
+        {/if}
 
         {#if details.length > 0}
             <Layout.Stack gap="s">

--- a/src/routes/(public)/oauth2/consent-card.svelte
+++ b/src/routes/(public)/oauth2/consent-card.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
     import type { Models } from '@appwrite.io/console';
     import { Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
-    import {
-        IconCheck,
-        IconExclamation,
-        IconShieldCheck,
-        IconExternalLink
-    } from '@appwrite.io/pink-icons-svelte';
+    import { IconCheck, IconExclamation } from '@appwrite.io/pink-icons-svelte';
     import { Button, Form } from '$lib/elements/forms';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
-    import { describeConsentScopes } from '$lib/helpers/oauth2-scopes';
+    import { ACCOUNT_ADMIN_SCOPE, describeConsentScopes } from '$lib/helpers/oauth2-scopes';
 
     export type OAuth2Flow = 'authorization' | 'device';
+
+    // Identity scopes are self-explanatory from their title, so we render them as
+    // single lines. Everything else (full account access, custom scopes) keeps its
+    // description so the user understands what they're granting.
+    const CONCISE_SCOPES = new Set(['openid', 'profile', 'email']);
 
     interface AuthorizationDetail {
         type: string;
@@ -58,6 +58,11 @@
     const redirectHost = $derived(hostnameOf(grant.redirectUri));
 
     const appInitial = $derived((app.name || '?').charAt(0).toUpperCase());
+    const accountInitial = $derived((accountLabel || '?').charAt(0).toUpperCase());
+
+    function showDescription(scopeId: string): boolean {
+        return scopeId === ACCOUNT_ADMIN_SCOPE || !CONCISE_SCOPES.has(scopeId);
+    }
 
     async function approve() {
         if (busy) return;
@@ -139,47 +144,45 @@
                 <Typography.Title size="m" align="center">
                     Authorize {app.name}
                 </Typography.Title>
-                <Typography.Text variant="m-400" align="center">
-                    {app.tagline || `${app.name} wants to access your Appwrite account.`}
+                <Typography.Text variant="m-400" align="center" color="--fgcolor-neutral-secondary">
+                    {app.tagline || `${app.name} is requesting access to your Appwrite account.`}
                 </Typography.Text>
             </Layout.Stack>
+
+            {#if accountLabel}
+                <div class="account-chip">
+                    <span class="account-avatar">{accountInitial}</span>
+                    <span class="account-label">{accountLabel}</span>
+                </div>
+            {/if}
         </Layout.Stack>
 
-        <Layout.Stack gap="m">
-            <Typography.Eyebrow color="--fgcolor-neutral-secondary">
-                This will allow {app.name} to
-            </Typography.Eyebrow>
-            <ul class="scope-list">
-                {#each scopes as scope (scope.id)}
-                    <li class="scope-item">
-                        <span class="scope-icon">
-                            <Icon icon={scope.icon} size="s" />
-                        </span>
-                        <span class="scope-text">
-                            <span class="scope-title">{scope.title}</span>
+        <ul class="scope-list">
+            {#each scopes as scope (scope.id)}
+                <li class="scope-item" class:lead={scope.id === ACCOUNT_ADMIN_SCOPE}>
+                    <span class="scope-icon">
+                        <Icon icon={scope.icon} size="s" />
+                    </span>
+                    <span class="scope-text">
+                        <span class="scope-title">{scope.title}</span>
+                        {#if showDescription(scope.id)}
                             <span class="scope-desc">{scope.description}</span>
-                        </span>
-                    </li>
-                {/each}
-            </ul>
-        </Layout.Stack>
+                        {/if}
+                    </span>
+                </li>
+            {/each}
+        </ul>
 
         {#if details.length > 0}
             <Layout.Stack gap="s">
-                <Typography.Eyebrow color="--fgcolor-neutral-secondary">
-                    Requested resources
-                </Typography.Eyebrow>
-                <ul class="detail-list">
+                <Typography.Text variant="m-500" color="--fgcolor-neutral-secondary">
+                    Also requested
+                </Typography.Text>
+                <div class="detail-list">
                     {#each details as detail, i (`${detail.type}-${i}`)}
-                        <li class="detail-item">
-                            <Icon
-                                icon={IconShieldCheck}
-                                size="s"
-                                color="--fgcolor-neutral-secondary" />
-                            <span class="detail-type">{detail.type}</span>
-                        </li>
+                        <span class="detail-tag">{detail.type}</span>
                     {/each}
-                </ul>
+                </div>
             </Layout.Stack>
         {/if}
 
@@ -208,41 +211,24 @@
             </Layout.Stack>
         </Form>
 
-        <Typography.Text variant="m-400" align="center" color="--fgcolor-neutral-secondary">
-            {#if accountLabel}
-                Signed in as <span class="bold">{accountLabel}</span>.{' '}
-            {/if}
+        <p class="footnote">
             {#if flow === 'authorization' && redirectHost}
-                You'll be redirected to {redirectHost}.
+                <span>You'll be returned to {redirectHost}</span>
             {/if}
             {#if flow === 'device'}
-                After authorizing, return to your device.
+                <span>After authorizing, return to your device</span>
             {/if}
-        </Typography.Text>
-
-        {#if app.privacyPolicyUrl || app.termsUrl}
-            <Typography.Text variant="m-400" align="center" color="--fgcolor-neutral-secondary">
-                {#if app.privacyPolicyUrl}
-                    <a
-                        href={app.privacyPolicyUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        class="footer-link">
-                        Privacy Policy
-                        <Icon icon={IconExternalLink} size="xs" />
-                    </a>
-                {/if}
-                {#if app.privacyPolicyUrl && app.termsUrl}
-                    {' · '}
-                {/if}
-                {#if app.termsUrl}
-                    <a href={app.termsUrl} target="_blank" rel="noreferrer" class="footer-link">
-                        Terms of Service
-                        <Icon icon={IconExternalLink} size="xs" />
-                    </a>
-                {/if}
-            </Typography.Text>
-        {/if}
+            {#if app.privacyPolicyUrl}
+                <a href={app.privacyPolicyUrl} target="_blank" rel="noreferrer" class="footer-link">
+                    Privacy
+                </a>
+            {/if}
+            {#if app.termsUrl}
+                <a href={app.termsUrl} target="_blank" rel="noreferrer" class="footer-link">
+                    Terms
+                </a>
+            {/if}
+        </p>
     </Layout.Stack>
 </Card.Base>
 
@@ -250,18 +236,18 @@
     .app-logo {
         width: 3.5rem;
         height: 3.5rem;
-        border-radius: 0.75rem;
+        border-radius: 0.85rem;
         object-fit: cover;
-        border: 1px solid var(--border-color-neutral-strong, #e2e2e2);
+        border: 1px solid var(--border-neutral-strong);
     }
 
     .app-logo-placeholder {
         width: 3.5rem;
         height: 3.5rem;
-        border-radius: 0.75rem;
-        border: 1px solid var(--border-color-neutral-strong, #e2e2e2);
-        background: var(--bgcolor-neutral-secondary, #f4f4f4);
-        color: var(--fgcolor-neutral-secondary, #6b7280);
+        border-radius: 0.85rem;
+        border: 1px solid var(--border-neutral-strong);
+        background: var(--bgcolor-neutral-secondary);
+        color: var(--fgcolor-neutral-secondary);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -269,93 +255,146 @@
         font-weight: 600;
     }
 
+    /* Account context, shown right under the heading like Google/GitHub consent. */
+    .account-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        max-width: 100%;
+        padding: 0.3rem 0.75rem 0.3rem 0.35rem;
+        border: 1px solid var(--border-neutral-strong);
+        border-radius: 2rem;
+        font-size: 0.8125rem;
+        color: var(--fgcolor-neutral-secondary);
+    }
+
+    .account-avatar {
+        flex-shrink: 0;
+        width: 1.4rem;
+        height: 1.4rem;
+        border-radius: 50%;
+        background: var(--bgcolor-neutral-invert);
+        color: var(--fgcolor-neutral-on-invert, var(--bgcolor-neutral-primary));
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.7rem;
+        font-weight: 600;
+    }
+
+    .account-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--fgcolor-neutral-primary);
+    }
+
+    /* Single grouped container — rows split by hairlines instead of N tiles. */
     .scope-list {
         list-style: none;
         margin: 0;
         padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
+        border: 1px solid var(--border-neutral);
+        border-radius: 0.75rem;
+        background: var(--bgcolor-neutral-default);
+        overflow: hidden;
     }
 
     .scope-item {
         display: flex;
         align-items: flex-start;
         gap: 0.75rem;
+        padding: 0.85rem 0.9rem;
+    }
+
+    .scope-item + .scope-item {
+        border-top: 1px solid var(--border-neutral);
     }
 
     .scope-icon {
         flex-shrink: 0;
-        width: 2rem;
-        height: 2rem;
-        border-radius: 0.5rem;
-        background: var(--bgcolor-neutral-secondary, #f4f4f4);
-        color: var(--fgcolor-neutral-secondary, #6b7280);
         display: flex;
         align-items: center;
         justify-content: center;
-        margin-top: 0.125rem;
+        margin-top: 0.05rem;
+        color: var(--fgcolor-neutral-tertiary);
+    }
+
+    .scope-item.lead .scope-icon {
+        color: var(--fgcolor-neutral-secondary);
     }
 
     .scope-text {
         display: flex;
         flex-direction: column;
-        gap: 0.125rem;
+        gap: 0.15rem;
+        min-width: 0;
     }
 
     .scope-title {
         font-size: 0.875rem;
         font-weight: 500;
-        color: var(--fgcolor-neutral-primary, #1f2937);
+        line-height: 1.3;
+        color: var(--fgcolor-neutral-primary);
+    }
+
+    .scope-item.lead .scope-title {
+        font-weight: 600;
     }
 
     .scope-desc {
-        font-size: 0.75rem;
-        color: var(--fgcolor-neutral-secondary, #6b7280);
+        font-size: 0.78rem;
+        line-height: 1.4;
+        color: var(--fgcolor-neutral-secondary);
     }
 
+    /* Rich authorization details — de-emphasized, compact tags. */
     .detail-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
         display: flex;
-        flex-direction: column;
-        gap: 0.375rem;
+        flex-wrap: wrap;
+        gap: 0.4rem;
     }
 
-    .detail-item {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        background: var(--bgcolor-neutral-secondary, #f4f4f4);
-        border-radius: 0.5rem;
-        padding: 0.5rem 0.75rem;
-        font-size: 0.875rem;
-        font-weight: 500;
-    }
-
-    .detail-type {
-        color: var(--fgcolor-neutral-primary, #1f2937);
+    .detail-tag {
+        font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+        font-size: 0.74rem;
+        color: var(--fgcolor-neutral-secondary);
+        border: 1px solid var(--border-neutral-strong);
+        border-radius: 0.4rem;
+        padding: 0.2rem 0.5rem;
+        background: var(--bgcolor-neutral-default);
     }
 
     .error-box {
         display: flex;
         align-items: flex-start;
         gap: 0.5rem;
-        border: 1px solid var(--border-color-danger, rgba(220, 38, 38, 0.2));
+        border: 1px solid var(--border-danger, rgba(220, 38, 38, 0.2));
         background: var(--bgcolor-danger-secondary, rgba(220, 38, 38, 0.1));
-        border-radius: 0.375rem;
+        border-radius: 0.5rem;
         padding: 0.75rem;
     }
 
-    .bold {
-        font-weight: 500;
+    /* One quiet line: contextual note + legal links, dot-separated. */
+    .footnote {
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        font-size: 0.78rem;
+        color: var(--fgcolor-neutral-tertiary);
+        text-align: center;
+    }
+
+    .footnote > :global(* + *)::before {
+        content: '·';
+        margin-inline-end: 0.5rem;
+        color: var(--fgcolor-neutral-tertiary);
     }
 
     .footer-link {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
         color: inherit;
         text-decoration: none;
     }


### PR DESCRIPTION
## What

Redesigns the OAuth2 consent screen (shared by both the **authorization** and **device** flows) to be cleaner and more in line with familiar consent UIs, without dropping any information the user needs to make a decision.

Also includes a small correctness fix: the **Full access to your account** item now appears only when the app actually requests the `account.admin` scope, instead of always being shown.

## Why

The previous screen felt busy: every scope sat in its own tinted icon tile (a noisy grid), each row repeated a description, rich authorization details were a second boxed list, and the footer stacked two-to-three separate lines. It was also full of hardcoded color fallbacks that didn't track the theme.

## Changes

- **Grouped permission list** — one bordered container with hairline dividers and small inline icons, instead of separate tinted tiles. The `account.admin` row leads and is emphasized.
- **Descriptions only where they help** — kept on full-access / custom scopes; dropped from the self-explanatory `profile`/`email` one-liners.
- **Account chip** under the heading (avatar + email), replacing the "Signed in as…" footer line.
- **Authorization details** rendered as compact tags ("Also requested") rather than a boxed list with a repeated icon.
- **Footer collapsed** to a single line (redirect / device note · Privacy · Terms).
- **Design tokens** used throughout — removed ~30 hardcoded hex fallbacks.

## Authorization flow

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/appwrite/console/pr-assets/oauth2-consent-redesign/screenshots/before-dark-auth.png" width="380"> | <img src="https://raw.githubusercontent.com/appwrite/console/pr-assets/oauth2-consent-redesign/screenshots/after-dark-auth.png" width="380"> |

## Device flow

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/appwrite/console/pr-assets/oauth2-consent-redesign/screenshots/before-dark-device.png" width="380"> | <img src="https://raw.githubusercontent.com/appwrite/console/pr-assets/oauth2-consent-redesign/screenshots/after-dark-device.png" width="380"> |

## Adapts to requested scopes

When an app doesn't request `account.admin`, the full-access row is omitted entirely:

<img src="https://raw.githubusercontent.com/appwrite/console/pr-assets/oauth2-consent-redesign/screenshots/after-dark-identity.png" width="380">

## Testing

- `bun run format` · `bun run check` (0 errors) · `bun run lint` (0 errors)
- Rendered both flows against mock grants in all scope combinations (full access + identity, identity only, with/without authorization details, with/without privacy/terms links).

<sub>Screenshots are hosted on the throwaway `pr-assets/oauth2-consent-redesign` branch; safe to delete after merge.</sub>

---

## Account → Applications tab

The Appwrite CLI (and any app authorized through the console OAuth2 server) signs in via the device flow, stored as an `oauth2:<appId>` **identity grant** — not a session, and with no session↔app link. Rather than mixing it into **Sessions**, this adds a dedicated **Account → Applications** tab that resolves each grant to its app metadata via `apps.get()` (name, logo, tagline, device-flow badge) with a **Revoke** action.

To keep each surface single-purpose, `oauth2` grants are also filtered out of the **Sessions** tab and the Overview **Identities** list.

<img src="https://raw.githubusercontent.com/appwrite/console/pr-assets/oauth2-consent-redesign/screenshots/account-applications-tab.png" width="720">
