### PR TITLE
fix: send null for unlimited user limit

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
@@ -31,7 +31,7 @@
     async function updateLimit() {
         try {
             await sdk.forProject(project.region, project.$id).project.updateUserLimitPolicy({
-                total: isLimited ? newLimit : 0
+                total: isLimited ? newLimit : (null as unknown as number)
             });
             await invalidate(Dependencies.PROJECT);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
@@ -31,7 +31,7 @@
     async function updateLimit() {
         try {
             await sdk.forProject(project.region, project.$id).project.updateUserLimitPolicy({
-                total: isLimited ? newLimit : (null as unknown as number)
+                total: isLimited ? newLimit : null
             });
             await invalidate(Dependencies.PROJECT);
             addNotification({

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/+page.svelte
@@ -109,7 +109,8 @@
                             href="https://appwrite.io/docs/products/databases/databases"
                             text
                             event="empty_documentation"
-                            ariaLabel="read {entityLower.singular} documentation">Documentation</Button>
+                            ariaLabel="read {entityLower.singular} documentation"
+                            >Documentation</Button>
 
                         {#if $canWriteTables}
                             <Button secondary on:click={() => ($showCreateEntity = true)}>


### PR DESCRIPTION
## What
- Send null instead of 0 when updating the project user limit to unlimited.

## Why
- The API expects null to disable the user limit.

## Testing
- bun run check