### PR TITLE
Fix site specification SDK package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@1a5604f",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@8c37253",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@1a5604f", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@8c37253", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-tk/tQgC20lA8p7RnL2uu22X+OYqPh2HDVGqBLNU/h3Wks66fQUu2Y6OarAAcoMyhfxelP/k0fa9jDaRvclC0jw=="],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@2e31ae6",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@16caf4e",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@2e31ae6", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-DtlsXzS8hzz1R0FCC9FXPrabmZUs9qbkC4ogNU0POeKvcplviPe5Pcn0tzZotjYrPfAEdbpS2sJc62ZOdkAp5Q=="],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@16caf4e", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-JqzVnaRKHCEZzmcKze8Lal8X2NsZ9UUZcYH8Dqk8kXM2+3CQ/7edShjJCzsClIfP82PPA7jnN61lye/E/RAPww=="],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@8c37253",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@2e31ae6",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@8c37253", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-tk/tQgC20lA8p7RnL2uu22X+OYqPh2HDVGqBLNU/h3Wks66fQUu2Y6OarAAcoMyhfxelP/k0fa9jDaRvclC0jw=="],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@2e31ae6", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-DtlsXzS8hzz1R0FCC9FXPrabmZUs9qbkC4ogNU0POeKvcplviPe5Pcn0tzZotjYrPfAEdbpS2sJc62ZOdkAp5Q=="],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@8c37253",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@2e31ae6",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@1a5604f",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@8c37253",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@2e31ae6",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@16caf4e",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/routes/(console)/project-[region]-[project]/functions/+layout.ts
+++ b/src/routes/(console)/project-[region]-[project]/functions/+layout.ts
@@ -9,21 +9,30 @@ import type { LayoutLoad } from './$types';
 export const load: LayoutLoad = async ({ depends, params }) => {
     depends(Dependencies.FUNCTION_INSTALLATIONS);
 
-    const [runtimesList, installations, specificationsList] = await Promise.all([
-        sdk.forProject(params.region, params.project).functions.listRuntimes(),
-        sdk
-            .forProject(params.region, params.project)
-            .vcs.listInstallations({ queries: [Query.limit(100)] }),
-        isCloud
-            ? sdk.forProject(params.region, params.project).functions.listSpecifications()
-            : Promise.resolve({ specifications: [], total: 0 })
-    ]);
+    const [runtimesList, installations, buildSpecificationsList, runtimeSpecificationsList] =
+        await Promise.all([
+            sdk.forProject(params.region, params.project).functions.listRuntimes(),
+            sdk
+                .forProject(params.region, params.project)
+                .vcs.listInstallations({ queries: [Query.limit(100)] }),
+            isCloud
+                ? sdk
+                      .forProject(params.region, params.project)
+                      .functions.listSpecifications({ type: 'builds' })
+                : Promise.resolve({ specifications: [], total: 0 }),
+            isCloud
+                ? sdk
+                      .forProject(params.region, params.project)
+                      .functions.listSpecifications({ type: 'runtimes' })
+                : Promise.resolve({ specifications: [], total: 0 })
+        ]);
 
     return {
         header: Header,
         breadcrumbs: Breadcrumbs,
         runtimesList,
         installations,
-        specificationsList
+        specificationsList: buildSpecificationsList,
+        runtimeSpecificationsList
     };
 };

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/+page.svelte
@@ -128,7 +128,10 @@
 
     <UpdatePermissions />
     {#if isCloud}
-        <UpdateResourceLimits func={data.function} specs={data.specificationsList} />
+        <UpdateResourceLimits
+            func={data.function}
+            buildSpecs={data.specificationsList}
+            runtimeSpecs={data.runtimeSpecificationsList} />
     {/if}
     <UpdateEvents />
     <UpdateSchedule />

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/+page.ts
@@ -11,14 +11,21 @@ export const load = async ({ params, depends, parent }) => {
     const limit = PAGE_LIMIT;
     const variablesOffset = 0;
 
-    const { runtimesList, specificationsList, function: fn } = await parent();
+    const {
+        runtimesList,
+        specificationsList,
+        runtimeSpecificationsList,
+        function: fn
+    } = await parent();
 
-    const enabledSpecs = specificationsList?.specifications?.filter((s) => s.enabled) ?? [];
-    if (!enabledSpecs.some((s) => s.slug === fn.buildSpecification)) {
-        fn.buildSpecification = enabledSpecs[0]?.slug;
+    const buildEnabledSpecs = specificationsList?.specifications?.filter((s) => s.enabled) ?? [];
+    const runtimeEnabledSpecs =
+        runtimeSpecificationsList?.specifications?.filter((s) => s.enabled) ?? [];
+    if (!buildEnabledSpecs.some((s) => s.slug === fn.buildSpecification)) {
+        fn.buildSpecification = buildEnabledSpecs[0]?.slug;
     }
-    if (!enabledSpecs.some((s) => s.slug === fn.runtimeSpecification)) {
-        fn.runtimeSpecification = enabledSpecs[0]?.slug;
+    if (!runtimeEnabledSpecs.some((s) => s.slug === fn.runtimeSpecification)) {
+        fn.runtimeSpecification = runtimeEnabledSpecs[0]?.slug;
     }
 
     const [globalVariables, variables] = await Promise.all([
@@ -56,6 +63,7 @@ export const load = async ({ params, depends, parent }) => {
         variablesOffset,
         runtimesList,
         specificationsList,
+        runtimeSpecificationsList,
         function: fn
     };
 };

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateResourceLimits.svelte
@@ -17,7 +17,8 @@
     import { page } from '$app/state';
 
     export let func: Models.Function;
-    export let specs: Models.SpecificationList;
+    export let buildSpecs: Models.SpecificationList;
+    export let runtimeSpecs: Models.SpecificationList;
 
     let buildSpecification = func.buildSpecification;
     let runtimeSpecification = func.runtimeSpecification;
@@ -79,7 +80,12 @@
         }
     }
 
-    const options = (specs?.specifications ?? []).map((spec) => ({
+    const buildOptions = buildSpecs.specifications.map((spec) => ({
+        label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
+        value: spec.slug,
+        disabled: !spec.enabled
+    }));
+    const runtimeOptions = runtimeSpecs.specifications.map((spec) => ({
         label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
         value: spec.slug,
         disabled: !spec.enabled
@@ -100,9 +106,9 @@
                 label="Build specification"
                 id="build-specification"
                 required
-                disabled={options.length < 1}
+                disabled={buildOptions.length < 1}
                 bind:value={buildSpecification}
-                {options}>
+                options={buildOptions}>
                 <Tooltip slot="info">
                     <Icon icon={IconInfo} size="s" />
                     <span slot="tooltip">
@@ -114,9 +120,9 @@
                 label="Runtime specification"
                 id="runtime-specification"
                 required
-                disabled={options.length < 1}
+                disabled={runtimeOptions.length < 1}
                 bind:value={runtimeSpecification}
-                {options}>
+                options={runtimeOptions}>
                 <Tooltip slot="info">
                     <Icon icon={IconInfo} size="s" />
                     <span slot="tooltip">

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.svelte
@@ -77,7 +77,8 @@
     <UpdateBuildSettings
         site={data.site}
         frameworks={data.frameworks.frameworks}
-        specs={data.specificationsList} />
+        buildSpecs={data.buildSpecificationsList}
+        runtimeSpecs={data.runtimeSpecificationsList} />
     <UpdateRuntimeSettings site={data.site} frameworks={data.frameworks.frameworks} />
     <UpdateVariables
         {sdkCreateVariable}
@@ -95,7 +96,10 @@
         product="site"
         analyticsSource="site_settings" />
     {#if isCloud}
-        <UpdateResourceLimits site={data.site} specs={data.specificationsList} />
+        <UpdateResourceLimits
+            site={data.site}
+            buildSpecs={data.buildSpecificationsList}
+            runtimeSpecs={data.runtimeSpecificationsList} />
     {/if}
     <UpdateDeploymentRetention site={data.site} />
     <UpdateTimeout site={data.site} />

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
@@ -1,9 +1,10 @@
 import { sdk } from '$lib/stores/sdk';
 import { Dependencies, PAGE_LIMIT } from '$lib/constants';
 import { isCloud } from '$lib/system';
-import { Query } from '@appwrite.io/console';
+import { Query, type Models } from '@appwrite.io/console';
 
 const VARIABLES_LIMIT = 100;
+type SiteSpecification = Models.Specification & { buildEnabled: boolean; runtimeEnabled: boolean };
 
 export const load = async ({ params, depends, parent }) => {
     depends(Dependencies.VARIABLES);
@@ -46,12 +47,20 @@ export const load = async ({ params, depends, parent }) => {
         }
     });
 
-    const enabledSpecs = specificationsList?.specifications?.filter((s) => s.enabled) ?? [];
-    if (!enabledSpecs.some((s) => s.slug === site.buildSpecification)) {
-        site.buildSpecification = enabledSpecs[0]?.slug;
+    const specifications = (specificationsList?.specifications ?? []) as SiteSpecification[];
+    const buildEnabledSpecs = specifications.filter((s) => s.buildEnabled);
+    const runtimeEnabledSpecs = specifications.filter((s) => s.runtimeEnabled);
+    if (
+        buildEnabledSpecs.length &&
+        !buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
+    ) {
+        site.buildSpecification = buildEnabledSpecs[0]?.slug;
     }
-    if (!enabledSpecs.some((s) => s.slug === site.runtimeSpecification)) {
-        site.runtimeSpecification = enabledSpecs[0]?.slug;
+    if (
+        runtimeEnabledSpecs.length &&
+        !runtimeEnabledSpecs.some((s) => s.slug === site.runtimeSpecification)
+    ) {
+        site.runtimeSpecification = runtimeEnabledSpecs[0]?.slug;
     }
 
     return {

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
@@ -12,21 +12,34 @@ export const load = async ({ params, depends, parent }) => {
     const variablesOffset = 0;
     const { site } = await parent();
 
-    const [globalVariables, variables, frameworks, installations, specificationsList] =
-        await Promise.all([
-            sdk.forProject(params.region, params.project).projectApi.listVariables({
-                queries: [Query.limit(VARIABLES_LIMIT)]
-            }),
-            sdk.forProject(params.region, params.project).sites.listVariables({
-                siteId: params.site,
-                queries: [Query.limit(limit), Query.offset(variablesOffset)]
-            }),
-            sdk.forProject(params.region, params.project).sites.listFrameworks(),
-            sdk.forProject(params.region, params.project).vcs.listInstallations(),
-            isCloud
-                ? sdk.forProject(params.region, params.project).sites.listSpecifications()
-                : Promise.resolve({ specifications: [], total: 0 })
-        ]);
+    const [
+        globalVariables,
+        variables,
+        frameworks,
+        installations,
+        buildSpecificationsList,
+        runtimeSpecificationsList
+    ] = await Promise.all([
+        sdk.forProject(params.region, params.project).projectApi.listVariables({
+            queries: [Query.limit(VARIABLES_LIMIT)]
+        }),
+        sdk.forProject(params.region, params.project).sites.listVariables({
+            siteId: params.site,
+            queries: [Query.limit(limit), Query.offset(variablesOffset)]
+        }),
+        sdk.forProject(params.region, params.project).sites.listFrameworks(),
+        sdk.forProject(params.region, params.project).vcs.listInstallations(),
+        isCloud
+            ? sdk
+                  .forProject(params.region, params.project)
+                  .sites.listSpecifications({ type: 'builds' })
+            : Promise.resolve({ specifications: [], total: 0 }),
+        isCloud
+            ? sdk
+                  .forProject(params.region, params.project)
+                  .sites.listSpecifications({ type: 'runtimes' })
+            : Promise.resolve({ specifications: [], total: 0 })
+    ]);
 
     // Conflicting variables first
     variables.variables = variables.variables.sort((var1, var2) => {
@@ -46,9 +59,8 @@ export const load = async ({ params, depends, parent }) => {
         }
     });
 
-    const specifications = specificationsList?.specifications ?? [];
-    const buildEnabledSpecs = specifications.filter((s) => s.enabledForBuilds);
-    const runtimeEnabledSpecs = specifications.filter((s) => s.enabled);
+    const buildEnabledSpecs = buildSpecificationsList.specifications.filter((s) => s.enabled);
+    const runtimeEnabledSpecs = runtimeSpecificationsList.specifications.filter((s) => s.enabled);
     if (
         buildEnabledSpecs.length &&
         !buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
@@ -70,6 +82,7 @@ export const load = async ({ params, depends, parent }) => {
         limit,
         variablesOffset,
         installations,
-        specificationsList
+        buildSpecificationsList,
+        runtimeSpecificationsList
     };
 };

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/+page.ts
@@ -1,10 +1,9 @@
 import { sdk } from '$lib/stores/sdk';
 import { Dependencies, PAGE_LIMIT } from '$lib/constants';
 import { isCloud } from '$lib/system';
-import { Query, type Models } from '@appwrite.io/console';
+import { Query } from '@appwrite.io/console';
 
 const VARIABLES_LIMIT = 100;
-type SiteSpecification = Models.Specification & { buildEnabled: boolean; runtimeEnabled: boolean };
 
 export const load = async ({ params, depends, parent }) => {
     depends(Dependencies.VARIABLES);
@@ -47,9 +46,9 @@ export const load = async ({ params, depends, parent }) => {
         }
     });
 
-    const specifications = (specificationsList?.specifications ?? []) as SiteSpecification[];
-    const buildEnabledSpecs = specifications.filter((s) => s.buildEnabled);
-    const runtimeEnabledSpecs = specifications.filter((s) => s.runtimeEnabled);
+    const specifications = specificationsList?.specifications ?? [];
+    const buildEnabledSpecs = specifications.filter((s) => s.enabledForBuilds);
+    const runtimeEnabledSpecs = specifications.filter((s) => s.enabled);
     if (
         buildEnabledSpecs.length &&
         !buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -18,11 +18,13 @@
     let {
         site,
         frameworks,
-        specs
+        buildSpecs,
+        runtimeSpecs
     }: {
         site: Models.Site;
         frameworks: Models.Framework[];
-        specs: Models.SpecificationList;
+        buildSpecs: Models.SpecificationList;
+        runtimeSpecs: Models.SpecificationList;
     } = $props();
 
     let frameworkKey = $state(site.framework);
@@ -124,9 +126,9 @@
                 adapter = selectedFramework.adapters[0].key as Adapter;
                 site.adapter = adapter;
             }
-            if (specs && specs.specifications?.length) {
-                const buildEnabledSpecs = specs.specifications.filter((s) => s.enabledForBuilds);
-                const runtimeEnabledSpecs = specs.specifications.filter((s) => s.enabled);
+            if (buildSpecs.specifications.length || runtimeSpecs.specifications.length) {
+                const buildEnabledSpecs = buildSpecs.specifications.filter((s) => s.enabled);
+                const runtimeEnabledSpecs = runtimeSpecs.specifications.filter((s) => s.enabled);
                 if (
                     buildEnabledSpecs.length &&
                     !buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
@@ -150,9 +152,8 @@
             adptr = selectedFramework.adapters[0];
             site.adapter = adapter;
         }
-        const specifications = specs?.specifications ?? [];
-        const buildEnabledSpecs = specifications.filter((s) => s.enabledForBuilds);
-        const runtimeEnabledSpecs = specifications.filter((s) => s.enabled);
+        const buildEnabledSpecs = buildSpecs.specifications.filter((s) => s.enabled);
+        const runtimeEnabledSpecs = runtimeSpecs.specifications.filter((s) => s.enabled);
         const specToSend = buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
             ? site.buildSpecification
             : (buildEnabledSpecs[0]?.slug ?? site.buildSpecification);

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -25,11 +25,6 @@
         specs: Models.SpecificationList;
     } = $props();
 
-    type SiteSpecification = Models.Specification & {
-        buildEnabled: boolean;
-        runtimeEnabled: boolean;
-    };
-
     let frameworkKey = $state(site.framework);
     let installCommand = $state(site?.installCommand);
     let buildCommand = $state(site?.buildCommand);
@@ -130,9 +125,8 @@
                 site.adapter = adapter;
             }
             if (specs && specs.specifications?.length) {
-                const specifications = specs.specifications as SiteSpecification[];
-                const buildEnabledSpecs = specifications.filter((s) => s.buildEnabled);
-                const runtimeEnabledSpecs = specifications.filter((s) => s.runtimeEnabled);
+                const buildEnabledSpecs = specs.specifications.filter((s) => s.enabledForBuilds);
+                const runtimeEnabledSpecs = specs.specifications.filter((s) => s.enabled);
                 if (
                     buildEnabledSpecs.length &&
                     !buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
@@ -156,9 +150,9 @@
             adptr = selectedFramework.adapters[0];
             site.adapter = adapter;
         }
-        const specifications = (specs?.specifications ?? []) as SiteSpecification[];
-        const buildEnabledSpecs = specifications.filter((s) => s.buildEnabled);
-        const runtimeEnabledSpecs = specifications.filter((s) => s.runtimeEnabled);
+        const specifications = specs?.specifications ?? [];
+        const buildEnabledSpecs = specifications.filter((s) => s.enabledForBuilds);
+        const runtimeEnabledSpecs = specifications.filter((s) => s.enabled);
         const specToSend = buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
             ? site.buildSpecification
             : (buildEnabledSpecs[0]?.slug ?? site.buildSpecification);

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -25,6 +25,11 @@
         specs: Models.SpecificationList;
     } = $props();
 
+    type SiteSpecification = Models.Specification & {
+        buildEnabled: boolean;
+        runtimeEnabled: boolean;
+    };
+
     let frameworkKey = $state(site.framework);
     let installCommand = $state(site?.installCommand);
     let buildCommand = $state(site?.buildCommand);
@@ -125,13 +130,20 @@
                 site.adapter = adapter;
             }
             if (specs && specs.specifications?.length) {
-                const enabledSpecs = specs.specifications.filter((s) => s.enabled);
-                const fallbackSlug = enabledSpecs[0]?.slug ?? specs.specifications[0]?.slug;
-                if (!enabledSpecs.some((s) => s.slug === site.buildSpecification)) {
-                    site.buildSpecification = fallbackSlug;
+                const specifications = specs.specifications as SiteSpecification[];
+                const buildEnabledSpecs = specifications.filter((s) => s.buildEnabled);
+                const runtimeEnabledSpecs = specifications.filter((s) => s.runtimeEnabled);
+                if (
+                    buildEnabledSpecs.length &&
+                    !buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
+                ) {
+                    site.buildSpecification = buildEnabledSpecs[0]?.slug;
                 }
-                if (!enabledSpecs.some((s) => s.slug === site.runtimeSpecification)) {
-                    site.runtimeSpecification = fallbackSlug;
+                if (
+                    runtimeEnabledSpecs.length &&
+                    !runtimeEnabledSpecs.some((s) => s.slug === site.runtimeSpecification)
+                ) {
+                    site.runtimeSpecification = runtimeEnabledSpecs[0]?.slug;
                 }
             }
         }
@@ -144,14 +156,17 @@
             adptr = selectedFramework.adapters[0];
             site.adapter = adapter;
         }
-        // only allow enabled specsification for it
-        const enabledSpecs = specs?.specifications?.filter((s) => s.enabled) ?? [];
-        const specToSend = enabledSpecs.some((s) => s.slug === site.buildSpecification)
+        const specifications = (specs?.specifications ?? []) as SiteSpecification[];
+        const buildEnabledSpecs = specifications.filter((s) => s.buildEnabled);
+        const runtimeEnabledSpecs = specifications.filter((s) => s.runtimeEnabled);
+        const specToSend = buildEnabledSpecs.some((s) => s.slug === site.buildSpecification)
             ? site.buildSpecification
-            : enabledSpecs[0]?.slug;
-        const runtimeSpecToSend = enabledSpecs.some((s) => s.slug === site.runtimeSpecification)
+            : (buildEnabledSpecs[0]?.slug ?? site.buildSpecification);
+        const runtimeSpecToSend = runtimeEnabledSpecs.some(
+            (s) => s.slug === site.runtimeSpecification
+        )
             ? site.runtimeSpecification
-            : enabledSpecs[0]?.slug;
+            : (runtimeEnabledSpecs[0]?.slug ?? site.runtimeSpecification);
         try {
             await sdk.forProject(page.params.region, page.params.project).sites.update({
                 siteId: site.$id,

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -18,6 +18,11 @@
     export let site: Models.Site;
     export let specs: Models.SpecificationList;
 
+    type SiteSpecification = Models.Specification & {
+        buildEnabled: boolean;
+        runtimeEnabled: boolean;
+    };
+
     let buildSpecification = site.buildSpecification;
     let runtimeSpecification = site.runtimeSpecification;
     let originalBuild = site.buildSpecification;
@@ -75,10 +80,18 @@
         }
     }
 
-    const options = (specs?.specifications ?? []).map((spec) => ({
+    const specifications = (specs?.specifications ?? []) as SiteSpecification[];
+    const buildEnabledSpecs = specifications.filter((spec) => spec.buildEnabled);
+    const runtimeEnabledSpecs = specifications.filter((spec) => spec.runtimeEnabled);
+    const buildOptions = specifications.map((spec) => ({
         label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
         value: spec.slug,
-        disabled: !spec.enabled
+        disabled: !spec.buildEnabled
+    }));
+    const runtimeOptions = specifications.map((spec) => ({
+        label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
+        value: spec.slug,
+        disabled: !spec.runtimeEnabled
     }));
 </script>
 
@@ -94,9 +107,9 @@
                 label="Build specification"
                 id="build-specification"
                 required
-                disabled={options.length < 1}
+                disabled={buildEnabledSpecs.length < 1}
                 bind:value={buildSpecification}
-                {options}>
+                options={buildOptions}>
                 <Tooltip slot="info">
                     <Icon icon={IconInfo} size="s" />
                     <span slot="tooltip">
@@ -109,9 +122,9 @@
                 label="Runtime specification"
                 id="runtime-specification"
                 required
-                disabled={options.length < 1}
+                disabled={runtimeEnabledSpecs.length < 1}
                 bind:value={runtimeSpecification}
-                {options}>
+                options={runtimeOptions}>
                 <Tooltip slot="info">
                     <Icon icon={IconInfo} size="s" />
                     <span slot="tooltip">

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -18,11 +18,6 @@
     export let site: Models.Site;
     export let specs: Models.SpecificationList;
 
-    type SiteSpecification = Models.Specification & {
-        buildEnabled: boolean;
-        runtimeEnabled: boolean;
-    };
-
     let buildSpecification = site.buildSpecification;
     let runtimeSpecification = site.runtimeSpecification;
     let originalBuild = site.buildSpecification;
@@ -80,18 +75,18 @@
         }
     }
 
-    const specifications = (specs?.specifications ?? []) as SiteSpecification[];
-    const buildEnabledSpecs = specifications.filter((spec) => spec.buildEnabled);
-    const runtimeEnabledSpecs = specifications.filter((spec) => spec.runtimeEnabled);
+    const specifications = specs?.specifications ?? [];
+    const buildEnabledSpecs = specifications.filter((spec) => spec.enabledForBuilds);
+    const runtimeEnabledSpecs = specifications.filter((spec) => spec.enabled);
     const buildOptions = specifications.map((spec) => ({
         label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
         value: spec.slug,
-        disabled: !spec.buildEnabled
+        disabled: !spec.enabledForBuilds
     }));
     const runtimeOptions = specifications.map((spec) => ({
         label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
         value: spec.slug,
-        disabled: !spec.runtimeEnabled
+        disabled: !spec.enabled
     }));
 </script>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateResourceLimits.svelte
@@ -16,7 +16,8 @@
     import { page } from '$app/state';
 
     export let site: Models.Site;
-    export let specs: Models.SpecificationList;
+    export let buildSpecs: Models.SpecificationList;
+    export let runtimeSpecs: Models.SpecificationList;
 
     let buildSpecification = site.buildSpecification;
     let runtimeSpecification = site.runtimeSpecification;
@@ -75,15 +76,14 @@
         }
     }
 
-    const specifications = specs?.specifications ?? [];
-    const buildEnabledSpecs = specifications.filter((spec) => spec.enabledForBuilds);
-    const runtimeEnabledSpecs = specifications.filter((spec) => spec.enabled);
-    const buildOptions = specifications.map((spec) => ({
+    const buildEnabledSpecs = buildSpecs.specifications.filter((spec) => spec.enabled);
+    const runtimeEnabledSpecs = runtimeSpecs.specifications.filter((spec) => spec.enabled);
+    const buildOptions = buildSpecs.specifications.map((spec) => ({
         label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
         value: spec.slug,
-        disabled: !spec.enabledForBuilds
+        disabled: !spec.enabled
     }));
-    const runtimeOptions = specifications.map((spec) => ({
+    const runtimeOptions = runtimeSpecs.specifications.map((spec) => ({
         label: `${spec.cpus} CPU, ${spec.memory} MB RAM`,
         value: spec.slug,
         disabled: !spec.enabled


### PR DESCRIPTION
## What
- Updates `@appwrite.io/console` to the SDK artifact from `4851d03`
- Calls `listSpecifications({ type: "builds" })` for build specification options
- Calls `listSpecifications({ type: "runtimes" })` for runtime specification options
- Keeps build and runtime specification fallbacks separate for sites and functions
- Removes reliance on `enabledForBuilds`; `enabled` now applies to the requested specification type
- Syncs with latest `main`

## Testing
- `bun run check`
- `bun run lint`