### PR TITLE
Group OAuth2 consent scopes into a collapsible section

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@1a5604f",
+        "@appwrite.io/console": "15.1.0",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@1a5604f", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@15.1.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-uQ8can9vDKoP6zxqhp8JzOYma/w40eKuYzZzsI9ATCRHSzRig0WQ6fue8rZEgOuD3eF3S2GbtHZK4drotAT8Ug=="],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@1a5604f",
+        "@appwrite.io/console": "15.1.0",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/lib/helpers/oauth2-scopes.ts
+++ b/src/lib/helpers/oauth2-scopes.ts
@@ -98,3 +98,95 @@ export function describeConsentScopes(scopes: string[]): ScopeDescriptor[] {
 
     return described;
 }
+
+export interface ScopeAction {
+    /** Full scope id, e.g. `teams.write`. */
+    id: string;
+    /** Trailing verb, e.g. `read` / `write`. */
+    action: string;
+    /** Display label for the verb, e.g. `Read` / `Write`. */
+    label: string;
+}
+
+export interface ScopeResourceGroup {
+    /** Resource prefix, e.g. `teams` or `backups.policies`. */
+    resource: string;
+    /** Display title for the resource, e.g. `Teams`. */
+    title: string;
+    icon: ComponentType;
+    actions: ScopeAction[];
+}
+
+export interface GroupedConsentScopes {
+    /** `account.admin` full-access descriptor, when requested. */
+    admin: ScopeDescriptor | null;
+    /** OIDC identity scopes (openid/profile/email), always shown in full. */
+    identity: ScopeDescriptor[];
+    /** Every other granular scope, bucketed by resource for collapsing. */
+    groups: ScopeResourceGroup[];
+    /** Total count of granular scopes across all groups. */
+    granularCount: number;
+}
+
+/**
+ * Split a granular scope into its resource prefix and trailing action verb.
+ * `teams.read` -> { resource: 'teams', action: 'read' }, and
+ * `backups.policies.write` -> { resource: 'backups.policies', action: 'write' }.
+ * Scopes without a `.` fall back to the whole scope as the resource.
+ */
+function splitScope(scope: string): { resource: string; action: string } {
+    const lastDot = scope.lastIndexOf('.');
+    if (lastDot <= 0) {
+        return { resource: scope, action: '' };
+    }
+    return { resource: scope.slice(0, lastDot), action: scope.slice(lastDot + 1) };
+}
+
+/**
+ * Group the consent scopes for the OAuth2 consent screen. `account.admin` and the
+ * OIDC identity scopes stay as full, always-visible rows; everything else is
+ * bucketed by resource (`teams`, `projects`, …) so the granular console scopes can
+ * be tucked into a single collapsible section rather than a long flat list.
+ * Resource and action order follow first appearance in the requested scopes.
+ */
+export function groupConsentScopes(scopes: string[]): GroupedConsentScopes {
+    const requested = new Set(scopes);
+    const admin = requested.has(ACCOUNT_ADMIN_SCOPE) ? ACCOUNT_ADMIN_DESCRIPTOR : null;
+    const identity = CONSENT_IDENTITY_SCOPES.filter((scope) => requested.has(scope)).map(
+        describeScope
+    );
+
+    const remaining = scopes.filter(
+        (scope) =>
+            scope !== 'openid' &&
+            scope !== ACCOUNT_ADMIN_SCOPE &&
+            !(CONSENT_IDENTITY_SCOPES as readonly string[]).includes(scope)
+    );
+
+    const byResource = new Map<string, ScopeResourceGroup>();
+    for (const scope of remaining) {
+        const { resource, action } = splitScope(scope);
+        let group = byResource.get(resource);
+        if (!group) {
+            group = {
+                resource,
+                title: titleizeScope(resource),
+                icon: IconKey,
+                actions: []
+            };
+            byResource.set(resource, group);
+        }
+        if (!group.actions.some((existing) => existing.id === scope)) {
+            group.actions.push({ id: scope, action, label: titleizeScope(action || scope) });
+        }
+    }
+
+    const groups = [...byResource.values()];
+
+    // Keep a non-empty consent screen for a minimal OIDC request.
+    if (!admin && identity.length === 0 && groups.length === 0 && requested.has('openid')) {
+        return { admin: null, identity: [describeScope('openid')], groups: [], granularCount: 0 };
+    }
+
+    return { admin, identity, groups, granularCount: remaining.length };
+}

--- a/src/routes/(public)/oauth2/+layout.svelte
+++ b/src/routes/(public)/oauth2/+layout.svelte
@@ -34,23 +34,22 @@
 <style lang="scss">
     .auth-bg {
         position: fixed;
+        inset: 0;
+        overflow-y: auto;
         background: var(--bgcolor-neutral-primary, #fff);
         background-size: cover;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
         display: flex;
         flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        justify-content: space-between;
         section {
-            flex: 1;
+            /* Grow to fill (keeping the card centered) when the card is short, but
+               never shrink below the card's own height — so a tall card overflows
+               the shell and scrolls instead of being clipped above the fold. */
+            flex: 1 0 auto;
             width: 100%;
             display: flex;
             align-items: center;
             justify-content: center;
+            padding-block: 2rem;
             padding-inline: 1rem;
         }
         .oauth2-shell {
@@ -58,6 +57,7 @@
             max-width: 28rem;
         }
         footer {
+            flex-shrink: 0;
             padding: 2rem 1rem;
             display: flex;
             gap: 0.5rem;

--- a/src/routes/(public)/oauth2/consent-card.svelte
+++ b/src/routes/(public)/oauth2/consent-card.svelte
@@ -1,19 +1,14 @@
 <script lang="ts">
     import type { Models } from '@appwrite.io/console';
-    import { Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
+    import { Accordion, Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
     import { IconCheck, IconExclamation } from '@appwrite.io/pink-icons-svelte';
     import { Button, Form } from '$lib/elements/forms';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
-    import { ACCOUNT_ADMIN_SCOPE, describeConsentScopes } from '$lib/helpers/oauth2-scopes';
+    import { groupConsentScopes } from '$lib/helpers/oauth2-scopes';
 
     export type OAuth2Flow = 'authorization' | 'device';
-
-    // Identity scopes are self-explanatory from their title, so we render them as
-    // single lines. Everything else (full account access, custom scopes) keeps its
-    // description so the user understands what they're granting.
-    const CONCISE_SCOPES = new Set(['openid', 'profile', 'email']);
 
     interface AuthorizationDetail {
         type: string;
@@ -53,16 +48,12 @@
     let rejecting = $state(false);
     let busy = $derived(approving || rejecting);
 
-    const scopes = $derived(describeConsentScopes(grant.scopes ?? []));
+    const scopes = $derived(groupConsentScopes(grant.scopes ?? []));
     const details = $derived(parseAuthorizationDetails(grant.authorizationDetails ?? ''));
     const redirectHost = $derived(hostnameOf(grant.redirectUri));
 
     const appInitial = $derived((app.name || '?').charAt(0).toUpperCase());
     const accountInitial = $derived((accountLabel || '?').charAt(0).toUpperCase());
-
-    function showDescription(scopeId: string): boolean {
-        return scopeId === ACCOUNT_ADMIN_SCOPE || !CONCISE_SCOPES.has(scopeId);
-    }
 
     async function approve() {
         if (busy) return;
@@ -157,22 +148,52 @@
             {/if}
         </Layout.Stack>
 
-        {#if scopes.length > 0}
+        {#if scopes.admin || scopes.identity.length > 0}
             <ul class="scope-list">
-                {#each scopes as scope (scope.id)}
-                    <li class="scope-item" class:lead={scope.id === ACCOUNT_ADMIN_SCOPE}>
+                {#if scopes.admin}
+                    <li class="scope-item lead">
+                        <span class="scope-icon">
+                            <Icon icon={scopes.admin.icon} size="s" />
+                        </span>
+                        <span class="scope-text">
+                            <span class="scope-title">{scopes.admin.title}</span>
+                            <span class="scope-desc">{scopes.admin.description}</span>
+                        </span>
+                    </li>
+                {/if}
+                {#each scopes.identity as scope (scope.id)}
+                    <li class="scope-item">
                         <span class="scope-icon">
                             <Icon icon={scope.icon} size="s" />
                         </span>
                         <span class="scope-text">
                             <span class="scope-title">{scope.title}</span>
-                            {#if showDescription(scope.id)}
-                                <span class="scope-desc">{scope.description}</span>
-                            {/if}
                         </span>
                     </li>
                 {/each}
             </ul>
+        {/if}
+
+        {#if scopes.groups.length > 0}
+            <div class="scope-accordion">
+                <Accordion title="App permissions" badge={String(scopes.granularCount)}>
+                    <ul class="scope-group-list">
+                        {#each scopes.groups as group (group.resource)}
+                            <li class="scope-group">
+                                <span class="scope-icon">
+                                    <Icon icon={group.icon} size="s" />
+                                </span>
+                                <span class="scope-group-title">{group.title}</span>
+                                <span class="scope-group-actions">
+                                    {#each group.actions as action (action.id)}
+                                        <span class="scope-action-tag">{action.label}</span>
+                                    {/each}
+                                </span>
+                            </li>
+                        {/each}
+                    </ul>
+                </Accordion>
+            </div>
         {/if}
 
         {#if details.length > 0}
@@ -348,6 +369,58 @@
         font-size: 0.78rem;
         line-height: 1.4;
         color: var(--fgcolor-neutral-secondary);
+    }
+
+    /* Collapsed bucket of granular console scopes, grouped by resource. */
+    .scope-accordion {
+        border: 1px solid var(--border-neutral);
+        border-radius: 0.75rem;
+        overflow: hidden;
+    }
+
+    .scope-group-list {
+        list-style: none;
+        margin: 0;
+        padding-block-start: 0.25rem;
+        padding-inline-end: 0.25rem;
+    }
+
+    .scope-group {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.8rem 0;
+    }
+
+    .scope-group + .scope-group {
+        border-top: 1px solid var(--border-neutral);
+    }
+
+    .scope-group-title {
+        flex: 1;
+        min-width: 0;
+        font-size: 0.875rem;
+        font-weight: 500;
+        line-height: 1.3;
+        color: var(--fgcolor-neutral-primary);
+    }
+
+    .scope-group-actions {
+        display: flex;
+        flex-shrink: 0;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.3rem;
+    }
+
+    .scope-action-tag {
+        font-size: 0.72rem;
+        line-height: 1.4;
+        color: var(--fgcolor-neutral-secondary);
+        border: 1px solid var(--border-neutral-strong);
+        border-radius: 0.4rem;
+        padding: 0.1rem 0.4rem;
+        background: var(--bgcolor-neutral-default);
     }
 
     /* Rich authorization details — de-emphasized, compact tags. */

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -117,7 +117,8 @@
                         codeChallengeMethod: params.get('code_challenge_method') ?? undefined,
                         prompt: params.get('prompt') ?? undefined,
                         maxAge: parseMaxAge(params.get('max_age')),
-                        authorizationDetails: params.get('authorization_details') ?? undefined
+                        authorizationDetails: params.get('authorization_details') ?? undefined,
+                        resource: params.get('resource[0]') ?? undefined
                     });
                     if (cancelled) return;
                     if (result.redirectUrl) {

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -118,7 +118,7 @@
                         prompt: params.get('prompt') ?? undefined,
                         maxAge: parseMaxAge(params.get('max_age')),
                         authorizationDetails: params.get('authorization_details') ?? undefined,
-                        resource: params.get('resource[0]') ?? undefined
+                        resource: params.get('resource') ?? undefined
                     });
                     if (cancelled) return;
                     if (result.redirectUrl) {


### PR DESCRIPTION
## What

Reworks the console OAuth2 consent screen so a broad scope request renders cleanly instead of as an endless flat list.

Before, every requested scope was a separate row. A request for `account.admin` plus the dozens of granular console scopes (`teams.read`, `teams.write`, `project.read`, …) produced a list that ran far past the fold.

Now:
- **`account.admin`** (full access) and the **OIDC identity scopes** (`openid`/`profile`/`email`) stay as always-visible rows at the top.
- Every other granular scope is **grouped by resource** and tucked into a single collapsible **"App permissions"** accordion (collapsed by default, with a count badge). Each resource shows its requested actions as compact `Read` / `Write` tags.

## Notes

- **Read-only for now.** Letting the user *select* a subset of scopes was considered but the backend `approve` endpoint has no `scopes` parameter — it always issues the token with the scopes frozen at authorize time — so per-scope selection would be cosmetic. Deferred until the server supports downscoping.
- Also bumps `@appwrite.io/console` to the published `15.1.0`, lets the consent layout scroll a tall card instead of clipping it, and forwards the RFC 8707 `resource` indicator through `authorize`.

## Implementation

- `src/lib/helpers/oauth2-scopes.ts` — new `groupConsentScopes()` that splits granular scopes into `{ admin, identity, groups }`, bucketing by resource prefix (handles multi-segment resources like `backups.policies.read`).
- `src/routes/(public)/oauth2/consent-card.svelte` — renders the admin/identity rows plus the grouped accordion.

## Verification

`bun run format`, `bun run check` (0 errors), and `bun run lint` (0 errors) all pass.