### PR TITLE
Fix nameserver verification SDK calls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@d7ff250",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@d7ff250", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@88cc66d",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@d7ff250",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@88cc66d", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@d7ff250", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@d7ff250",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@88cc66d",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@d7ff250",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/lib/components/domains/viewLogsModal.svelte
+++ b/src/lib/components/domains/viewLogsModal.svelte
@@ -32,7 +32,7 @@
             const apexDomain = getApexDomain(selectedProxyRule.domain);
             const domain = domainsList?.domains.find((d) => d.domain === apexDomain);
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }

--- a/src/routes/(console)/organization-[organization]/domains/recordsCard.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/recordsCard.svelte
@@ -34,7 +34,7 @@
 
     async function verifyStatus() {
         try {
-            domain = await sdk.forConsole.domains.updateNameservers({ domainId: domain.$id });
+            domain = await sdk.forConsole.domains.verifyNameservers({ domainId: domain.$id });
             verified = domain.nameservers.toLowerCase() === 'appwrite';
             if (verified) {
                 addNotification({

--- a/src/routes/(console)/organization-[organization]/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/organization-[organization]/domains/retryDomainModal.svelte
@@ -29,7 +29,7 @@
     async function retryDomain() {
         try {
             error = null;
-            const domain = await sdk.forConsole.domains.updateNameservers({
+            const domain = await sdk.forConsole.domains.verifyNameservers({
                 domainId: selectedDomain.$id
             });
 

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/add-domain/verify-[domain]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/add-domain/verify-[domain]/+page.svelte
@@ -62,7 +62,7 @@
             const domain = data.domainsList.domains.find((d) => d.domain === apexDomain);
 
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/domains/retryDomainModal.svelte
@@ -57,7 +57,7 @@
             const apexDomain = getApexDomain(selectedProxyRule.domain);
             const domain = domainsList?.domains.find((d) => d.domain === apexDomain);
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }

--- a/src/routes/(console)/project-[region]-[project]/settings/domains/add-domain/verify-[domain]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/domains/add-domain/verify-[domain]/+page.svelte
@@ -61,7 +61,7 @@
             const apexDomain = getApexDomain(proxyRule.domain);
             const domain = data.domainsList.domains.find((d) => d.domain === apexDomain);
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }

--- a/src/routes/(console)/project-[region]-[project]/settings/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/domains/retryDomainModal.svelte
@@ -57,7 +57,7 @@
             const apexDomain = getApexDomain(selectedProxyRule.domain);
             const domain = domainsList?.domains.find((d) => d.domain === apexDomain);
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/domains/add-domain/verify-[domain]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/domains/add-domain/verify-[domain]/+page.svelte
@@ -61,7 +61,7 @@
             const apexDomain = getApexDomain(proxyRule.domain);
             const domain = data.domainsList.domains.find((d) => d.domain === apexDomain);
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/domains/retryDomainModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/domains/retryDomainModal.svelte
@@ -57,7 +57,7 @@
             const apexDomain = getApexDomain(selectedProxyRule.domain);
             const domain = domainsList?.domains.find((d) => d.domain === apexDomain);
             if (isCloud && domain) {
-                await sdk.forConsole.domains.updateNameservers({
+                await sdk.forConsole.domains.verifyNameservers({
                     domainId: domain.$id
                 });
             }


### PR DESCRIPTION
## What does this PR do?

Updates the console to match the nameserver API split from appwrite-labs/cloud#4515.

- Pins `@appwrite.io/console` to the preview SDK generated from cloud commit `d7ff250`
- Replaces domain retry/check flows that previously called `domains.updateNameservers()` with `domains.verifyNameservers()`
- Leaves `updateNameservers()` reserved for the new explicit registrar delegation update behavior

## Test Plan

- `git diff --check`
- `bun run check` *(fails on an existing/preview SDK OAuth typing mismatch: `oauth2.approve()` no longer types the `scope` parameter used by `src/routes/(public)/oauth2/consent-card.svelte`; nameserver call sites type against the preview SDK)*

## Related PR

- appwrite-labs/cloud#4515
