### PR TITLE
fix: prevent browser password save prompt and fix action menu clipping on env variables

### DIFF
--- a/src/lib/elements/forms/inputPassword.svelte
+++ b/src/lib/elements/forms/inputPassword.svelte
@@ -47,11 +47,7 @@
     {leadingIcon}
     state={error ? 'error' : 'default'}
     autofocus={autofocus || undefined}
-    autocomplete={(typeof autocomplete === 'string'
-        ? autocomplete
-        : autocomplete
-          ? 'on'
-          : 'off') as unknown as AutoFill}
+    autocomplete={typeof autocomplete === 'string' ? (autocomplete as unknown as 'on') : autocomplete ? 'on' : 'off'}
     helper={helper || error}
     on:invalid={handleInvalid}
     bind:value>

--- a/src/lib/elements/forms/inputPassword.svelte
+++ b/src/lib/elements/forms/inputPassword.svelte
@@ -47,7 +47,7 @@
     {leadingIcon}
     state={error ? 'error' : 'default'}
     autofocus={autofocus || undefined}
-    autocomplete={(typeof autocomplete === 'string' ? autocomplete : autocomplete ? 'on' : 'off') as 'on' | 'off'}
+    autocomplete={(typeof autocomplete === 'string' ? autocomplete : autocomplete ? 'on' : 'off') as unknown as AutoFill}
     helper={helper || error}
     on:invalid={handleInvalid}
     bind:value>

--- a/src/lib/elements/forms/inputPassword.svelte
+++ b/src/lib/elements/forms/inputPassword.svelte
@@ -10,7 +10,7 @@
     export let required = false;
     export let disabled = false;
     export let autofocus = false;
-    export let autocomplete = false;
+    export let autocomplete: boolean | string = false;
     export let minlength = 8;
     export let maxlength: number = null;
     export let leadingIcon: ComponentType | undefined = undefined;
@@ -47,7 +47,7 @@
     {leadingIcon}
     state={error ? 'error' : 'default'}
     autofocus={autofocus || undefined}
-    autocomplete={autocomplete ? 'on' : 'off'}
+    autocomplete={(typeof autocomplete === 'string' ? autocomplete : autocomplete ? 'on' : 'off') as 'on' | 'off'}
     helper={helper || error}
     on:invalid={handleInvalid}
     bind:value>

--- a/src/lib/elements/forms/inputPassword.svelte
+++ b/src/lib/elements/forms/inputPassword.svelte
@@ -47,7 +47,11 @@
     {leadingIcon}
     state={error ? 'error' : 'default'}
     autofocus={autofocus || undefined}
-    autocomplete={typeof autocomplete === 'string' ? (autocomplete as unknown as 'on') : autocomplete ? 'on' : 'off'}
+    autocomplete={typeof autocomplete === 'string'
+        ? (autocomplete as unknown as 'on')
+        : autocomplete
+          ? 'on'
+          : 'off'}
     helper={helper || error}
     on:invalid={handleInvalid}
     bind:value>

--- a/src/lib/elements/forms/inputPassword.svelte
+++ b/src/lib/elements/forms/inputPassword.svelte
@@ -47,7 +47,11 @@
     {leadingIcon}
     state={error ? 'error' : 'default'}
     autofocus={autofocus || undefined}
-    autocomplete={(typeof autocomplete === 'string' ? autocomplete : autocomplete ? 'on' : 'off') as unknown as AutoFill}
+    autocomplete={(typeof autocomplete === 'string'
+        ? autocomplete
+        : autocomplete
+          ? 'on'
+          : 'off') as unknown as AutoFill}
     helper={helper || error}
     on:invalid={handleInvalid}
     bind:value>

--- a/src/routes/(console)/project-[region]-[project]/createVariableModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/createVariableModal.svelte
@@ -81,6 +81,7 @@
                         label={`${i === 0 ? 'Value' : ''}`}
                         placeholder="Enter value"
                         bind:value={pair.value}
+                        autocomplete="new-password"
                         minlength={0} />
                     <PinkButton.Button
                         icon

--- a/src/routes/(console)/project-[region]-[project]/updateVariables.svelte
+++ b/src/routes/(console)/project-[region]-[project]/updateVariables.svelte
@@ -525,7 +525,7 @@
                                 {/if}
                             </Table.Cell>
                             <Table.Cell column="actions" {root}>
-                                <Popover placement="bottom-end" let:toggle padding="none">
+                                <Popover placement="bottom-end" let:toggle padding="none" portal>
                                     <Button
                                         text
                                         icon

--- a/src/routes/(console)/project-[region]-[project]/updateVariablesModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/updateVariablesModal.svelte
@@ -72,6 +72,7 @@
             label="Value"
             placeholder="Enter value"
             bind:value={pair.value}
+            autocomplete="new-password"
             minlength={0} />
         <Selector.Checkbox
             id="secret"


### PR DESCRIPTION
## Summary

- **Password save popup**: Environment variable value fields use `<InputPassword>` which renders as `type="password"`. Browsers were matching the Key + Value fields as a username/password login form and showing "Save password?". Fixed by passing `autocomplete="new-password"` on the value field in both create and update variable modals, and extending `InputPassword` to accept a string `autocomplete` value (previously only accepted boolean).
- **Action menu truncation**: The `...` action menu `Popover` was using `position: absolute` inside the table container, causing it to be clipped when opened from the last row. Added `portal` prop so the popover renders in `document.body` instead — the component already uses `flip()` from floating-ui so it will auto-position correctly.

## Files changed

- `src/lib/elements/forms/inputPassword.svelte` — extended `autocomplete` prop to accept `boolean | string`
- `src/routes/(console)/project-[region]-[project]/createVariableModal.svelte` — pass `autocomplete="new-password"` on value field
- `src/routes/(console)/project-[region]-[project]/updateVariablesModal.svelte` — pass `autocomplete="new-password"` on value field
- `src/routes/(console)/project-[region]-[project]/updateVariables.svelte` — add `portal` to action menu Popover

## Test plan

- [ ] Create environment variables — confirm no "Save password?" browser dialog appears
- [ ] Edit an environment variable — confirm no browser password save prompt
- [ ] Open the `...` action menu on the last variable in the list — confirm full menu (Update / Secret / Promote / Delete) is visible without clipping