### PR TITLE
fix: env variable overwrite and action menu clipping in create function wizard

### DIFF
--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -182,6 +182,7 @@
                                             <Popover
                                                 padding="none"
                                                 placement="bottom-end"
+                                                portal
                                                 let:toggle>
                                                 <PinkButton.Button
                                                     icon

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -60,14 +60,14 @@
     const tableColumns = $derived(
         $isSmallViewport
             ? [
-                  { id: 'key', width: { min: 420 } },
-                  { id: 'value', width: { min: 240 } },
-                  { id: 'actions', width: 40 }
+                  { id: 'key', width: { min: 380, max: 520 } },
+                  { id: 'value', width: { min: 200, max: 320 } },
+                  { id: 'actions', width: 50 }
               ]
             : [
-                  { id: 'key', width: { min: 300 } },
-                  { id: 'value', width: { min: 280 } },
-                  { id: 'actions', width: 40 }
+                  { id: 'key', width: { min: 280, max: 420 } },
+                  { id: 'value', width: { min: 200, max: 400 } },
+                  { id: 'actions', width: 50 }
               ]
     );
 </script>

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -182,7 +182,6 @@
                                             <Popover
                                                 padding="none"
                                                 placement="bottom-end"
-                                                portal
                                                 let:toggle>
                                                 <PinkButton.Button
                                                     icon

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -280,7 +280,7 @@
 {/if}
 
 <style>
-    :global(.responsive-table [data-column='actions']) {
+    :global(.responsive-table [role='row'] [role='cell']:last-child) {
         overflow: visible;
     }
 </style>

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -60,9 +60,9 @@
     const tableColumns = $derived(
         $isSmallViewport
             ? [
-                  { id: 'key', width: { min: 380, max: 520 } },
-                  { id: 'value', width: { min: 200, max: 320 } },
-                  { id: 'actions', width: 50 }
+                  { id: 'key', width: { min: 120, max: 300 } },
+                  { id: 'value', width: { min: 100, max: 200 } },
+                  { id: 'actions', width: 40 }
               ]
             : [
                   { id: 'key', width: { min: 280, max: 420 } },

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -105,13 +105,15 @@
                     <Button
                         secondary
                         size="s"
+                        icon={$isSmallViewport}
                         on:click={() => {
                             showCreate = true;
                             trackEvent(Click.VariablesCreateClick, {
                                 source: createSource
                             });
                         }}>
-                        <Icon slot="start" icon={IconPlus} /> Create variable
+                        <Icon slot="start" icon={IconPlus} />
+                        {#if !$isSmallViewport}Create variable{/if}
                     </Button>
                 {/if}
             </Layout.Stack>

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -182,6 +182,7 @@
                                             <Popover
                                                 padding="none"
                                                 placement="bottom-end"
+                                                portal
                                                 let:toggle>
                                                 <PinkButton.Button
                                                     icon
@@ -201,9 +202,9 @@
                                                             <ActionMenu.Item.Button
                                                                 leadingIcon={IconPencil}
                                                                 onclick={(e) => {
-                                                                    toggle(e);
                                                                     currentVariable = variable;
                                                                     showUpdate = true;
+                                                                    toggle(e);
                                                                 }}>
                                                                 Update
                                                             </ActionMenu.Item.Button>
@@ -212,9 +213,9 @@
                                                             <ActionMenu.Item.Button
                                                                 leadingIcon={IconEyeOff}
                                                                 onclick={(e) => {
-                                                                    toggle(e);
                                                                     currentVariable = variable;
                                                                     showSecretModal = true;
+                                                                    toggle(e);
                                                                 }}>
                                                                 Secret
                                                             </ActionMenu.Item.Button>
@@ -223,9 +224,9 @@
                                                             status="danger"
                                                             leadingIcon={IconTrash}
                                                             onclick={(e) => {
-                                                                toggle(e);
                                                                 currentVariable = variable;
                                                                 showDelete = true;
+                                                                toggle(e);
                                                             }}>
                                                             Delete
                                                         </ActionMenu.Item.Button>
@@ -278,9 +279,3 @@
 {#if showDelete}
     <DeleteVariableModal bind:show={showDelete} bind:variables bind:currentVariable />
 {/if}
-
-<style>
-    :global(.responsive-table [role='row'] [role='cell']:last-child) {
-        overflow: visible;
-    }
-</style>

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -278,3 +278,9 @@
 {#if showDelete}
     <DeleteVariableModal bind:show={showDelete} bind:variables bind:currentVariable />
 {/if}
+
+<style>
+    :global(.responsive-table [data-column='actions']) {
+        overflow: visible;
+    }
+</style>

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -11,11 +11,7 @@
         Table,
         Tooltip
     } from '@appwrite.io/pink-svelte';
-    import {
-        IconCode,
-        IconUpload,
-        IconPlus
-    } from '@appwrite.io/pink-icons-svelte';
+    import { IconCode, IconUpload, IconPlus } from '@appwrite.io/pink-icons-svelte';
     import VariableActionMenu from './variableActionMenu.svelte';
     import type { Models } from '@appwrite.io/console';
     import VariableEditorModal from './variableEditorModal.svelte';

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -2,27 +2,21 @@
     import { Empty, Paginator } from '$lib/components';
     import { Button } from '$lib/elements/forms';
     import {
-        ActionMenu,
         Accordion,
         Badge,
         InteractiveText,
         Icon,
         Layout,
-        Popover,
         Skeleton,
         Table,
-        Tooltip,
-        Button as PinkButton
+        Tooltip
     } from '@appwrite.io/pink-svelte';
     import {
-        IconDotsHorizontal,
         IconCode,
         IconUpload,
-        IconPlus,
-        IconTrash,
-        IconEyeOff,
-        IconPencil
+        IconPlus
     } from '@appwrite.io/pink-icons-svelte';
+    import VariableActionMenu from './variableActionMenu.svelte';
     import type { Models } from '@appwrite.io/console';
     import VariableEditorModal from './variableEditorModal.svelte';
     import SecretVariableModal from './secretVariableModal.svelte';
@@ -179,60 +173,20 @@
                                     </Table.Cell>
                                     <Table.Cell column="actions" {root}>
                                         <div style="margin-inline-start: auto">
-                                            <Popover
-                                                padding="none"
-                                                placement="bottom-end"
-                                                portal
-                                                let:toggle>
-                                                <PinkButton.Button
-                                                    icon
-                                                    variant="text"
-                                                    size="s"
-                                                    aria-label="More options"
-                                                    onclick={(e) => {
-                                                        e.preventDefault();
-                                                        toggle(e);
-                                                    }}>
-                                                    <Icon icon={IconDotsHorizontal} size="s" />
-                                                </PinkButton.Button>
-
-                                                <svelte:fragment slot="tooltip" let:toggle>
-                                                    <ActionMenu.Root>
-                                                        {#if !variable?.secret}
-                                                            <ActionMenu.Item.Button
-                                                                leadingIcon={IconPencil}
-                                                                onclick={(e) => {
-                                                                    currentVariable = variable;
-                                                                    showUpdate = true;
-                                                                    toggle(e);
-                                                                }}>
-                                                                Update
-                                                            </ActionMenu.Item.Button>
-                                                        {/if}
-                                                        {#if !variable?.secret}
-                                                            <ActionMenu.Item.Button
-                                                                leadingIcon={IconEyeOff}
-                                                                onclick={(e) => {
-                                                                    currentVariable = variable;
-                                                                    showSecretModal = true;
-                                                                    toggle(e);
-                                                                }}>
-                                                                Secret
-                                                            </ActionMenu.Item.Button>
-                                                        {/if}
-                                                        <ActionMenu.Item.Button
-                                                            status="danger"
-                                                            leadingIcon={IconTrash}
-                                                            onclick={(e) => {
-                                                                currentVariable = variable;
-                                                                showDelete = true;
-                                                                toggle(e);
-                                                            }}>
-                                                            Delete
-                                                        </ActionMenu.Item.Button>
-                                                    </ActionMenu.Root>
-                                                </svelte:fragment>
-                                            </Popover>
+                                            <VariableActionMenu
+                                                {variable}
+                                                onUpdate={() => {
+                                                    currentVariable = variable;
+                                                    showUpdate = true;
+                                                }}
+                                                onSecret={() => {
+                                                    currentVariable = variable;
+                                                    showSecretModal = true;
+                                                }}
+                                                onDelete={() => {
+                                                    currentVariable = variable;
+                                                    showDelete = true;
+                                                }} />
                                         </div>
                                     </Table.Cell>
                                 </Table.Row.Base>

--- a/src/lib/components/variables/updateVariableModal.svelte
+++ b/src/lib/components/variables/updateVariableModal.svelte
@@ -23,10 +23,10 @@
     function handleVariable() {
         if (selectedVar) {
             variables = variables.map((variable) => {
-                if (variable.$id === selectedVar.$id) {
-                    return pair;
-                }
-                return variable;
+                const match = selectedVar.$id
+                    ? variable.$id === selectedVar.$id
+                    : variable.key === selectedVar.key;
+                return match ? pair : variable;
             });
         } else {
             variables = [...variables, pair];

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -25,6 +25,7 @@
     let open = $state(false);
     let triggerEl = $state<HTMLElement | null>(null);
     let menuEl = $state<HTMLElement | null>(null);
+    let cleanup: (() => void) | null = null;
 
     function hide() {
         open = false;
@@ -44,21 +45,21 @@
     }
 
     $effect(() => {
-        if (!open || !triggerEl || !menuEl) return;
-
-        const stop = autoUpdate(triggerEl, menuEl, () => {
-            computePosition(triggerEl, menuEl, {
-                placement: 'bottom-end',
-                strategy: 'fixed',
-                middleware: [offset(2), flip(), shift()]
-            }).then(({ x, y }) => {
-                if (menuEl) {
-                    Object.assign(menuEl.style, { left: `${x}px`, top: `${y}px` });
-                }
+        if (open && triggerEl && menuEl) {
+            cleanup = autoUpdate(triggerEl, menuEl, () => {
+                computePosition(triggerEl, menuEl, {
+                    placement: 'bottom-end',
+                    middleware: [offset(2), flip(), shift()]
+                }).then(({ x, y }) => {
+                    if (menuEl) {
+                        Object.assign(menuEl.style, { left: `${x}px`, top: `${y}px` });
+                    }
+                });
             });
-        });
-
-        return stop;
+        } else {
+            cleanup?.();
+            cleanup = null;
+        }
     });
 
     function handleWindowClick(e: MouseEvent) {
@@ -100,7 +101,7 @@
             {#if !variable?.secret}
                 <ActionMenu.Item.Button
                     leadingIcon={IconPencil}
-                    onclick={() => {
+                    on:click={() => {
                         hide();
                         onUpdate();
                     }}>
@@ -110,7 +111,7 @@
             {#if !variable?.secret}
                 <ActionMenu.Item.Button
                     leadingIcon={IconEyeOff}
-                    onclick={() => {
+                    on:click={() => {
                         hide();
                         onSecret();
                     }}>
@@ -120,7 +121,7 @@
             <ActionMenu.Item.Button
                 status="danger"
                 leadingIcon={IconTrash}
-                onclick={() => {
+                on:click={() => {
                     hide();
                     onDelete();
                 }}>

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -20,7 +20,6 @@
     let open = $state(false);
     let triggerEl = $state<HTMLElement | null>(null);
     let menuEl = $state<HTMLElement | null>(null);
-    let cleanup: (() => void) | null = null;
 
     function hide() {
         open = false;
@@ -40,21 +39,21 @@
     }
 
     $effect(() => {
-        if (open && triggerEl && menuEl) {
-            cleanup = autoUpdate(triggerEl, menuEl, () => {
-                computePosition(triggerEl, menuEl, {
-                    placement: 'bottom-end',
-                    middleware: [offset(2), flip(), shift()]
-                }).then(({ x, y }) => {
-                    if (menuEl) {
-                        Object.assign(menuEl.style, { left: `${x}px`, top: `${y}px` });
-                    }
-                });
+        if (!open || !triggerEl || !menuEl) return;
+
+        const stop = autoUpdate(triggerEl, menuEl, () => {
+            computePosition(triggerEl, menuEl, {
+                placement: 'bottom-end',
+                strategy: 'fixed',
+                middleware: [offset(2), flip(), shift()]
+            }).then(({ x, y }) => {
+                if (menuEl) {
+                    Object.assign(menuEl.style, { left: `${x}px`, top: `${y}px` });
+                }
             });
-        } else {
-            cleanup?.();
-            cleanup = null;
-        }
+        });
+
+        return stop;
     });
 
     function handleWindowClick(e: MouseEvent) {
@@ -96,21 +95,21 @@
             {#if !variable?.secret}
                 <ActionMenu.Item.Button
                     leadingIcon={IconPencil}
-                    on:click={() => { hide(); onUpdate(); }}>
+                    onclick={() => { hide(); onUpdate(); }}>
                     Update
                 </ActionMenu.Item.Button>
             {/if}
             {#if !variable?.secret}
                 <ActionMenu.Item.Button
                     leadingIcon={IconEyeOff}
-                    on:click={() => { hide(); onSecret(); }}>
+                    onclick={() => { hide(); onSecret(); }}>
                     Secret
                 </ActionMenu.Item.Button>
             {/if}
             <ActionMenu.Item.Button
                 status="danger"
                 leadingIcon={IconTrash}
-                on:click={() => { hide(); onDelete(); }}>
+                onclick={() => { hide(); onDelete(); }}>
                 Delete
             </ActionMenu.Item.Button>
         </ActionMenu.Root>

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -30,6 +30,15 @@
         open = !open;
     }
 
+    function portalToBody(node: HTMLElement) {
+        document.body.appendChild(node);
+        return {
+            destroy() {
+                node.parentNode?.removeChild(node);
+            }
+        };
+    }
+
     $effect(() => {
         if (open && triggerEl && menuEl) {
             cleanup = autoUpdate(triggerEl, menuEl, () => {
@@ -79,6 +88,7 @@
 
 {#if open}
     <div
+        use:portalToBody
         bind:this={menuEl}
         style="position: fixed; z-index: 9001; background: var(--bgcolor-neutral-primary); border: var(--border-width-s) solid var(--border-neutral); border-radius: var(--border-radius-m); box-shadow: 0 1px 3px 0 rgba(0,0,0,0.03), 0 4px 4px 0 rgba(0,0,0,0.04); overflow: hidden;"
         role="menu">

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -80,7 +80,7 @@
 {#if open}
     <div
         bind:this={menuEl}
-        style="position: fixed; z-index: 9001;"
+        style="position: fixed; z-index: 9001; background: var(--bgcolor-neutral-primary); border: var(--border-width-s) solid var(--border-neutral); border-radius: var(--border-radius-m); box-shadow: 0 1px 3px 0 rgba(0,0,0,0.03), 0 4px 4px 0 rgba(0,0,0,0.04); overflow: hidden;"
         role="menu">
         <ActionMenu.Root>
             {#if !variable?.secret}

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+    import { computePosition, flip, offset, shift, autoUpdate } from '@floating-ui/dom';
+    import { Icon, ActionMenu } from '@appwrite.io/pink-svelte';
+    import { IconDotsHorizontal, IconPencil, IconEyeOff, IconTrash } from '@appwrite.io/pink-icons-svelte';
+    import { Button as PinkButton } from '@appwrite.io/pink-svelte';
+    import type { Models } from '@appwrite.io/console';
+
+    let {
+        variable,
+        onUpdate,
+        onSecret,
+        onDelete
+    }: {
+        variable: Partial<Models.Variable>;
+        onUpdate: () => void;
+        onSecret: () => void;
+        onDelete: () => void;
+    } = $props();
+
+    let open = $state(false);
+    let triggerEl = $state<HTMLElement | null>(null);
+    let menuEl = $state<HTMLElement | null>(null);
+    let cleanup: (() => void) | null = null;
+
+    function hide() {
+        open = false;
+    }
+
+    function toggle() {
+        open = !open;
+    }
+
+    $effect(() => {
+        if (open && triggerEl && menuEl) {
+            cleanup = autoUpdate(triggerEl, menuEl, () => {
+                computePosition(triggerEl, menuEl, {
+                    placement: 'bottom-end',
+                    middleware: [offset(2), flip(), shift()]
+                }).then(({ x, y }) => {
+                    if (menuEl) {
+                        Object.assign(menuEl.style, { left: `${x}px`, top: `${y}px` });
+                    }
+                });
+            });
+        } else {
+            cleanup?.();
+            cleanup = null;
+        }
+    });
+
+    function handleWindowClick(e: MouseEvent) {
+        if (!open) return;
+        const target = e.target as Node;
+        if (triggerEl?.contains(target) || menuEl?.contains(target)) return;
+        hide();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === 'Escape') hide();
+    }
+</script>
+
+<svelte:window onclick={handleWindowClick} onkeydown={handleKeydown} />
+
+<span bind:this={triggerEl}>
+    <PinkButton.Button
+        icon
+        variant="text"
+        size="s"
+        aria-label="More options"
+        onclick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            toggle();
+        }}>
+        <Icon icon={IconDotsHorizontal} size="s" />
+    </PinkButton.Button>
+</span>
+
+{#if open}
+    <div
+        bind:this={menuEl}
+        style="position: fixed; z-index: 9001;"
+        role="menu">
+        <ActionMenu.Root>
+            {#if !variable?.secret}
+                <ActionMenu.Item.Button
+                    leadingIcon={IconPencil}
+                    on:click={() => { hide(); onUpdate(); }}>
+                    Update
+                </ActionMenu.Item.Button>
+            {/if}
+            {#if !variable?.secret}
+                <ActionMenu.Item.Button
+                    leadingIcon={IconEyeOff}
+                    on:click={() => { hide(); onSecret(); }}>
+                    Secret
+                </ActionMenu.Item.Button>
+            {/if}
+            <ActionMenu.Item.Button
+                status="danger"
+                leadingIcon={IconTrash}
+                on:click={() => { hide(); onDelete(); }}>
+                Delete
+            </ActionMenu.Item.Button>
+        </ActionMenu.Root>
+    </div>
+{/if}

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
     import { computePosition, flip, offset, shift, autoUpdate } from '@floating-ui/dom';
     import { Icon, ActionMenu } from '@appwrite.io/pink-svelte';
-    import { IconDotsHorizontal, IconPencil, IconEyeOff, IconTrash } from '@appwrite.io/pink-icons-svelte';
+    import {
+        IconDotsHorizontal,
+        IconPencil,
+        IconEyeOff,
+        IconTrash
+    } from '@appwrite.io/pink-icons-svelte';
     import { Button as PinkButton } from '@appwrite.io/pink-svelte';
     import type { Models } from '@appwrite.io/console';
 
@@ -95,21 +100,30 @@
             {#if !variable?.secret}
                 <ActionMenu.Item.Button
                     leadingIcon={IconPencil}
-                    onclick={() => { hide(); onUpdate(); }}>
+                    onclick={() => {
+                        hide();
+                        onUpdate();
+                    }}>
                     Update
                 </ActionMenu.Item.Button>
             {/if}
             {#if !variable?.secret}
                 <ActionMenu.Item.Button
                     leadingIcon={IconEyeOff}
-                    onclick={() => { hide(); onSecret(); }}>
+                    onclick={() => {
+                        hide();
+                        onSecret();
+                    }}>
                     Secret
                 </ActionMenu.Item.Button>
             {/if}
             <ActionMenu.Item.Button
                 status="danger"
                 leadingIcon={IconTrash}
-                onclick={() => { hide(); onDelete(); }}>
+                onclick={() => {
+                    hide();
+                    onDelete();
+                }}>
                 Delete
             </ActionMenu.Item.Button>
         </ActionMenu.Root>

--- a/src/lib/components/variables/variableActionMenu.svelte
+++ b/src/lib/components/variables/variableActionMenu.svelte
@@ -84,7 +84,6 @@
         aria-label="More options"
         onclick={(e) => {
             e.preventDefault();
-            e.stopPropagation();
             toggle();
         }}>
         <Icon icon={IconDotsHorizontal} size="s" />


### PR DESCRIPTION
## Summary

- **Env variable overwrite bug**: In the Create function wizard, variables are stored client-side with no \`\$id\` (not yet saved to the API). The update modal matched variables by \`variable.\$id === selectedVar.\$id\` — since all unsaved variables have \`\$id === undefined\`, every variable matched and got overwritten with the edited one's values. Fixed by falling back to key-based matching when \`\$id\` is absent.

## Root cause

\`updateVariableModal.svelte\` line 25:
\`\`\`js
// Before — undefined === undefined matches ALL unsaved variables
if (variable.\$id === selectedVar.\$id) { return pair; }

// After — fall back to key match when no \$id exists
const match = selectedVar.\$id
    ? variable.\$id === selectedVar.\$id
    : variable.key === selectedVar.key;
return match ? pair : variable;
\`\`\`

## Test plan

- [ ] Create function wizard: add 3 variables with different keys/values, edit one → only that variable should change
- [ ] Existing saved variables (with \`\$id\`) still update correctly via the function settings page