### PR TITLE
feat: show active theme in selector menu

### DIFF
--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -26,6 +26,7 @@
     } from '@appwrite.io/pink-svelte';
     import { toggleCommandCenter } from '$lib/commandCenter/commandCenter.svelte';
     import {
+        IconCheck,
         IconChevronRight,
         IconLogoutRight,
         IconMenuAlt4,
@@ -353,6 +354,8 @@
                                     {
                                         name: 'Light',
                                         leadingIcon: IconSun,
+                                        trailingIcon:
+                                            activeTheme === 'light' ? IconCheck : undefined,
                                         onClick: () => {
                                             updateTheme('light');
                                         }
@@ -360,6 +363,8 @@
                                     {
                                         name: 'Dark',
                                         leadingIcon: IconMoon,
+                                        trailingIcon:
+                                            activeTheme === 'dark' ? IconCheck : undefined,
                                         onClick: () => {
                                             updateTheme('dark');
                                         }
@@ -367,6 +372,8 @@
                                     {
                                         name: 'System',
                                         leadingIcon: IconMode,
+                                        trailingIcon:
+                                            activeTheme === 'auto' ? IconCheck : undefined,
                                         onClick: () => {
                                             updateTheme('auto');
                                         }


### PR DESCRIPTION
## What does this PR do?

This PR improves the theme selector by adding a visual indicator for the currently selected theme.

### Changes

* Added a checkmark icon next to the active theme option in the theme submenu.
* Preserved the existing Light, Dark, and System theme functionality.
* Improved visual feedback, making it easier for users to identify the currently selected theme.

## Test Plan

1. Run the console locally using:

   ```bash
   bun install
   bun run dev
   ```

2. Open the Console and navigate to the Theme menu.

3. Verify that:

   * A checkmark is displayed next to the currently selected theme.
   * The checkmark updates correctly when switching between Light, Dark, and System themes.
   * Theme switching functionality continues to work as expected.

4. Run:

   ```bash
   bun run check
   ```

   Confirm that there are no new errors introduced by this change.

## Related PRs and Issues

Closes ### What does this PR do?

This PR improves the theme selector by adding a visual indicator for the currently selected theme.

### Changes

* Added a checkmark icon next to the active theme option in the theme submenu.
* Preserved the existing Light, Dark, and System theme functionality.
* Improved visual feedback, making it easier for users to identify the currently selected theme.

## Test Plan

1. Run the console locally using:

   ```bash
   bun install
   bun run dev
   ```

2. Open the Console and navigate to the Theme menu.

3. Verify that:

   * A checkmark is displayed next to the currently selected theme.
   * The checkmark updates correctly when switching between Light, Dark, and System themes.
   * Theme switching functionality continues to work as expected.

4. Run:

   ```bash
   bun run check
   ```

   Confirm that there are no new errors introduced by this change.

## Related PRs and Issues

Closes #3098 

## Have you read the Contributing Guidelines on issues?

Yes, I have read and followed the contributing guidelines.