### PR TITLE
feat: sort users and projects by last activity by default

### DIFF
--- a/src/routes/(console)/organization-[organization]/+page.ts
+++ b/src/routes/(console)/organization-[organization]/+page.ts
@@ -64,7 +64,7 @@ export const load: PageLoad = async ({ params, url, route, depends, parent }) =>
             ...projectScopeQueries,
             Query.offset(offset),
             Query.limit(limit),
-            Query.orderDesc(''),
+            Query.orderDesc('accessedAt'),
             Query.equal('teamId', params.organization)
         ]
     });

--- a/src/routes/(console)/project-[region]-[project]/auth/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/+page.ts
@@ -23,7 +23,7 @@ export const load: PageLoad = async ({ url, route, params, depends }) => {
         search,
         page,
         users: await sdk.forProject(params.region, params.project).users.list({
-            queries: [Query.limit(limit), Query.offset(offset), Query.orderDesc('')],
+            queries: [Query.limit(limit), Query.offset(offset), Query.orderDesc('accessedAt')],
             search
         })
     };


### PR DESCRIPTION
## Summary
- Users list (`/auth`) now defaults to `orderDesc('accessedAt')` — most recently active users appear first
- Projects list (org page) now defaults to `orderDesc('accessedAt')` — most recently accessed projects appear first

