### PR TITLE
feat: add Google sign-up option to Console

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -126,15 +126,15 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-quGmIH/8M0SfV3e0f6fuYP2qF12g11qQHjZPdV6HLO5323bEvvey8H2jGiMxVZprEUsIZ8WfFPVrFwBFRF0mtw=="],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 
-    "@appwrite.io/pink-icons-svelte": ["@appwrite.io/pink-icons-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3", { "peerDependencies": { "svelte": "^4.0.0" } }],
+    "@appwrite.io/pink-icons-svelte": ["@appwrite.io/pink-icons-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3", { "peerDependencies": { "svelte": "^4.0.0" } }, "sha512-2HYl/CC2OlfZIR7LzbLXuSPBn0iNkjbnxpaeGCkZ7UNZ/hFeSeeWjDJqTBMdZ8+X95uuZqHx62XPTiE/svuSXQ=="],
 
     "@appwrite.io/pink-legacy": ["@appwrite.io/pink-legacy@1.0.3", "", { "dependencies": { "@appwrite.io/pink-icons": "1.0.0", "the-new-css-reset": "^1.11.2" } }, "sha512-GGde5fmPhs+s6/3aFeMPc/kKADG/gTFkYQSy6oBN8pK0y0XNCLrZZgBv+EBbdhwdtqVEWXa0X85Mv9w7jcIlwQ=="],
 
-    "@appwrite.io/pink-svelte": ["@appwrite.io/pink-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-svelte@8dcaa17", { "dependencies": { "@appwrite.io/pink-icons-svelte": "2.0.0-RC.1", "@floating-ui/dom": "^1.6.13", "@melt-ui/pp": "^0.3.2", "@melt-ui/svelte": "^0.86.6", "@tanstack/svelte-virtual": "^3.13.10", "ansicolor": "^2.0.3", "d3": "^7.9.0", "fuse.js": "^7.1.0", "pretty-bytes": "^6.1.1", "shiki": "^1.18.0", "svelte-motion": "^0.12.2", "svelte-sonner": "^0.3.28" }, "peerDependencies": { "svelte": "^4.0.0" } }],
+    "@appwrite.io/pink-svelte": ["@appwrite.io/pink-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-svelte@8dcaa17", { "dependencies": { "@appwrite.io/pink-icons-svelte": "2.0.0-RC.1", "@floating-ui/dom": "^1.6.13", "@melt-ui/pp": "^0.3.2", "@melt-ui/svelte": "^0.86.6", "@tanstack/svelte-virtual": "^3.13.10", "ansicolor": "^2.0.3", "d3": "^7.9.0", "fuse.js": "^7.1.0", "pretty-bytes": "^6.1.1", "shiki": "^1.18.0", "svelte-motion": "^0.12.2", "svelte-sonner": "^0.3.28" }, "peerDependencies": { "svelte": "^4.0.0" } }, "sha512-rw3zXN7/cUciCnhj0FR8M0H5Db+LYYMaKtPxvOAIMxNTBmStzU8kTw6grqIvdtFu9vybIsjKtIwm9QLHpNDBjA=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 

--- a/src/routes/(public)/(guest)/login/+page.svelte
+++ b/src/routes/(public)/(guest)/login/+page.svelte
@@ -124,6 +124,25 @@
             scopes: ['read:user', 'user:email']
         });
     }
+    function onGoogleLogin() {
+        let url = window.location.origin;
+
+        if (page.url.searchParams) {
+            const redirect = page.url.searchParams.get('redirect');
+            page.url.searchParams.delete('redirect');
+            if (redirect) {
+                url = `${redirect}${page.url.search}`;
+            } else {
+                url = `${base}${page.url.search ?? ''}`;
+            }
+        }
+        sdk.forConsole.account.createOAuth2Session({
+            provider: OAuthProvider.Google,
+            success: window.location.origin + url,
+            failure: window.location.origin,
+            scopes: ['profile', 'email']
+        });
+    }
 </script>
 
 <svelte:head>
@@ -136,12 +155,16 @@
         <Form onSubmit={login}>
             <Layout.Stack>
                 {#if isCloud}
-                    <div style:margin-bottom="var(--gap-s, 8px)">
+                    <Layout.Stack gap="s">
                         <Button secondary fullWidth on:click={onGithubLogin} {disabled}>
                             <span class="icon-github" aria-hidden="true"></span>
                             <span class="text">Sign in with GitHub</span>
                         </Button>
-                    </div>
+                        <Button secondary fullWidth on:click={onGoogleLogin} {disabled}>
+                            <span class="icon-google" aria-hidden="true"></span>
+                            <span class="text">Sign in with Google</span>
+                        </Button>
+                    </Layout.Stack>
                     <span class="with-separators eyebrow-heading-3">or</span>
                 {/if}
                 <InputEmail

--- a/src/routes/(public)/(guest)/register/+page.svelte
+++ b/src/routes/(public)/(guest)/register/+page.svelte
@@ -121,6 +121,22 @@
             scopes: ['read:user', 'user:email']
         });
     }
+    function onGoogleLogin() {
+        let successUrl = window.location.origin;
+
+        if (page.url.searchParams.has('code')) {
+            successUrl += `?code=${page.url.searchParams.get('code')}`;
+        } else if (page.url.searchParams.has('campaign')) {
+            successUrl += `?campaign=${page.url.searchParams.get('campaign')}`;
+        }
+
+        sdk.forConsole.account.createOAuth2Session({
+            provider: OAuthProvider.Google,
+            success: successUrl,
+            failure: window.location.origin,
+            scopes: ['profile', 'email']
+        });
+    }
 </script>
 
 <svelte:head>
@@ -138,6 +154,12 @@
                             <span class="icon-github" aria-hidden="true"></span>
                             <span class="text">Sign up with GitHub</span>
                         </Button>
+                        <div style:margin-top="var(--gap-s, 8px)">
+                            <Button secondary fullWidth on:click={onGoogleLogin} {disabled}>
+                                <span class="icon-google" aria-hidden="true"></span>
+                                <span class="text">Sign up with Google</span>
+                            </Button>
+                        </div>
                     </div>
                     <span class="with-separators eyebrow-heading-3">or</span>
                 {/if}


### PR DESCRIPTION
## What this PR does
Adds a "Sign up with Google" option to the Console sign-up page, alongside the existing GitHub OAuth option.
Adds a "Sign in with Google" option to the Console sign-in page, alongside the existing GitHub OAuth option.


## Changes
- Added `onGoogleLogin()` handler using the existing `OAuthProvider.Google` provider from the SDK
- Added a new "Sign up with Google" button, following the same pattern as the existing GitHub button
- Added a new "Sign in with Google" button, following the same pattern as the existing GitHub button


## Testing
Tested locally against a self-hosted Appwrite instance with `PUBLIC_CONSOLE_MODE=cloud` set temporarily to verify rendering. Both buttons render correctly and trigger their respective OAuth flows. Google OAuth provider wasn't configured in my local test project, so the full redirect wasn't exercised end-to-end, but the button correctly calls `createOAuth2Session` with the Google provider.

Closes appwrite/appwrite#12777

<img width="1902" height="937" alt="Screenshot 2026-07-03 034151" src="https://github.com/user-attachments/assets/8f79452f-55ca-4372-805d-5e5b4ee1660e" />
<img width="1911" height="955" alt="Screenshot 2026-07-03 041840" src="https://github.com/user-attachments/assets/e845936b-ed3d-4516-aa76-47dbe51f9feb" />
