### PR TITLE
Show a success screen when the OAuth redirect targets a native app

### DIFF
--- a/src/lib/helpers/oauth2-redirect.ts
+++ b/src/lib/helpers/oauth2-redirect.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether an OAuth2 redirect URI points back to the web (http/https) rather
+ * than a native application deep link (e.g. cursor://). Native redirects hand
+ * off to the OS and leave the tab open, so the console shows an outcome
+ * screen instead of relying on the navigation.
+ */
+export function isWebRedirect(uri: string): boolean {
+    try {
+        const { protocol } = new URL(uri);
+        return protocol === 'http:' || protocol === 'https:';
+    } catch {
+        return false;
+    }
+}

--- a/src/routes/(public)/oauth2/consent-card.svelte
+++ b/src/routes/(public)/oauth2/consent-card.svelte
@@ -35,12 +35,22 @@
     import ResourceSelector from './resource-selector.svelte';
 
     export type OAuth2Flow = 'authorization' | 'device';
+    export type OAuth2Outcome = 'approved' | 'denied';
 
     function hostnameOf(uri: string): string | null {
         try {
             return new URL(uri).hostname;
         } catch {
             return null;
+        }
+    }
+
+    function isWebRedirect(uri: string): boolean {
+        try {
+            const { protocol } = new URL(uri);
+            return protocol === 'http:' || protocol === 'https:';
+        } catch {
+            return false;
         }
     }
 
@@ -65,10 +75,10 @@
         app: Models.App;
         accountLabel?: string;
         flow: OAuth2Flow;
-        onDeviceDone?: (outcome: 'approved' | 'denied') => void;
+        onDone?: (outcome: OAuth2Outcome, redirectUrl?: string) => void;
     }
 
-    let { grant, app, accountLabel = undefined, flow, onDeviceDone }: Props = $props();
+    let { grant, app, accountLabel = undefined, flow, onDone }: Props = $props();
 
     let error = $state<string | null>(null);
     let approving = $state(false);
@@ -202,10 +212,13 @@
             if (grant.$id !== grantId) return;
             trackEvent(Submit.AccountOAuth2ConsentApprove, { app_id: grant.appId, flow });
             if (flow === 'device' || !result.redirectUrl) {
-                onDeviceDone?.('approved');
+                onDone?.('approved', result.redirectUrl);
                 return;
             }
             window.location.href = result.redirectUrl;
+            if (!isWebRedirect(result.redirectUrl)) {
+                onDone?.('approved', result.redirectUrl);
+            }
         } catch (e: unknown) {
             if (grant.$id !== grantId) return;
             const message = (e as Error)?.message ?? 'Failed to authorize the application';
@@ -227,10 +240,13 @@
             if (grant.$id !== grantId) return;
             trackEvent(Submit.AccountOAuth2ConsentDeny, { app_id: grant.appId, flow });
             if (flow === 'device' || !result.redirectUrl) {
-                onDeviceDone?.('denied');
+                onDone?.('denied', result.redirectUrl);
                 return;
             }
             window.location.href = result.redirectUrl;
+            if (!isWebRedirect(result.redirectUrl)) {
+                onDone?.('denied', result.redirectUrl);
+            }
         } catch (e: unknown) {
             if (grant.$id !== grantId) return;
             const message = (e as Error)?.message ?? 'Failed to cancel the request';

--- a/src/routes/(public)/oauth2/consent-card.svelte
+++ b/src/routes/(public)/oauth2/consent-card.svelte
@@ -18,6 +18,7 @@
     import { sdk } from '$lib/stores/sdk';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
     import { splitConsentScopes, buildConsentPermissions } from '$lib/helpers/oauth2-scopes';
+    import { isWebRedirect } from '$lib/helpers/oauth2-redirect';
     import {
         parseAuthorizationDetails,
         mergeIdentifiers,
@@ -42,15 +43,6 @@
             return new URL(uri).hostname;
         } catch {
             return null;
-        }
-    }
-
-    function isWebRedirect(uri: string): boolean {
-        try {
-            const { protocol } = new URL(uri);
-            return protocol === 'http:' || protocol === 'https:';
-        } catch {
-            return false;
         }
     }
 

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -7,6 +7,7 @@
     import { IconExclamation } from '@appwrite.io/pink-icons-svelte';
     import { Button } from '$lib/elements/forms';
     import { sdk } from '$lib/stores/sdk';
+    import { isWebRedirect } from '$lib/helpers/oauth2-redirect';
     import OAuth2ConsentCard, { type OAuth2Outcome } from '../consent-card.svelte';
     import OAuth2OutcomeCard from '../outcome-card.svelte';
 
@@ -25,15 +26,6 @@
         if (!raw) return undefined;
         const value = Number(raw);
         return Number.isInteger(value) && value >= 0 ? value : undefined;
-    }
-
-    function isWebRedirect(uri: string): boolean {
-        try {
-            const { protocol } = new URL(uri);
-            return protocol === 'http:' || protocol === 'https:';
-        } catch {
-            return false;
-        }
     }
 
     function onDone(outcome: OAuth2Outcome, redirectUrl?: string) {
@@ -147,6 +139,7 @@
                             app = await sdk.forConsole.apps
                                 .get({ appId: clientId })
                                 .catch(() => null);
+                            if (cancelled) return;
                             phase = 'approved';
                         }
                         return;

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -7,15 +7,17 @@
     import { IconExclamation } from '@appwrite.io/pink-icons-svelte';
     import { Button } from '$lib/elements/forms';
     import { sdk } from '$lib/stores/sdk';
-    import OAuth2ConsentCard from '../consent-card.svelte';
+    import OAuth2ConsentCard, { type OAuth2Outcome } from '../consent-card.svelte';
+    import OAuth2OutcomeCard from '../outcome-card.svelte';
 
-    type Phase = 'loading' | 'ready' | 'error';
+    type Phase = 'loading' | 'ready' | 'approved' | 'denied' | 'error';
 
     let phase = $state<Phase>('loading');
     let grant = $state<Models.Oauth2Grant | null>(null);
     let app = $state<Models.App | null>(null);
     let account = $state<Models.User<Models.Preferences> | null>(null);
     let error = $state<string | null>(null);
+    let completedRedirectUrl = $state<string | undefined>(undefined);
 
     // OIDC `max_age` is a non-negative integer count of seconds. Reject anything
     // else (e.g. `max_age=abc`) so we omit the param rather than forwarding NaN.
@@ -23,6 +25,20 @@
         if (!raw) return undefined;
         const value = Number(raw);
         return Number.isInteger(value) && value >= 0 ? value : undefined;
+    }
+
+    function isWebRedirect(uri: string): boolean {
+        try {
+            const { protocol } = new URL(uri);
+            return protocol === 'http:' || protocol === 'https:';
+        } catch {
+            return false;
+        }
+    }
+
+    function onDone(outcome: OAuth2Outcome, redirectUrl?: string) {
+        completedRedirectUrl = redirectUrl;
+        phase = outcome === 'approved' ? 'approved' : 'denied';
     }
 
     // Re-runs when the authorize params change (this route can stay mounted as
@@ -38,6 +54,7 @@
         let cancelled = false;
         phase = 'loading';
         error = null;
+        completedRedirectUrl = undefined;
 
         const currentRelativeUrl = () => window.location.pathname + window.location.search;
 
@@ -124,6 +141,14 @@
                     if (result.redirectUrl) {
                         // Already consented — go straight back to the client.
                         window.location.href = result.redirectUrl;
+                        if (!isWebRedirect(result.redirectUrl)) {
+                            completedRedirectUrl = result.redirectUrl;
+                            account = loggedInAccount;
+                            app = await sdk.forConsole.apps
+                                .get({ appId: clientId })
+                                .catch(() => null);
+                            phase = 'approved';
+                        }
                         return;
                     }
                     if (result.grantId) {
@@ -184,7 +209,15 @@
                 {grant}
                 {app}
                 accountLabel={account?.email || account?.name || undefined}
-                flow="authorization" />
+                flow="authorization"
+                {onDone} />
+        {:else if phase === 'approved' || phase === 'denied'}
+            <OAuth2OutcomeCard
+                outcome={phase}
+                flow="authorization"
+                {app}
+                accountLabel={account?.email || account?.name || undefined}
+                redirectUrl={completedRedirectUrl} />
         {/if}
     </div>
 </div>

--- a/src/routes/(public)/oauth2/device/+page.svelte
+++ b/src/routes/(public)/oauth2/device/+page.svelte
@@ -5,16 +5,13 @@
     import { page } from '$app/state';
     import { AppwriteException, type Models } from '@appwrite.io/console';
     import { Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
-    import {
-        IconDesktopComputer,
-        IconCheckCircle,
-        IconXCircle
-    } from '@appwrite.io/pink-icons-svelte';
+    import { IconDesktopComputer } from '@appwrite.io/pink-icons-svelte';
     import { Button, Form, Label } from '$lib/elements/forms';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Submit, trackError, trackEvent } from '$lib/actions/analytics';
-    import OAuth2ConsentCard, { type OAuth2Flow } from '../consent-card.svelte';
+    import OAuth2ConsentCard, { type OAuth2Flow, type OAuth2Outcome } from '../consent-card.svelte';
+    import OAuth2OutcomeCard from '../outcome-card.svelte';
 
     type Phase = 'loading' | 'enter-code' | 'consent' | 'approved' | 'denied';
 
@@ -127,7 +124,7 @@
         }
     }
 
-    function onDeviceDone(outcome: 'approved' | 'denied') {
+    function onDone(outcome: OAuth2Outcome) {
         phase = outcome === 'approved' ? 'approved' : 'denied';
     }
 </script>
@@ -209,32 +206,13 @@
                 {app}
                 accountLabel={account?.email || account?.name || undefined}
                 flow={DEVICE_FLOW}
-                {onDeviceDone} />
-        {:else if phase === 'approved'}
-            <Card.Base padding="l" radius="l" style="width: 100%;">
-                <Layout.Stack gap="l" alignItems="center" alignContent="center">
-                    <div class="success-icon-wrap">
-                        <Icon icon={IconCheckCircle} size="l" color="--fgcolor-success" />
-                    </div>
-                    <Typography.Title size="m" align="center">Device connected</Typography.Title>
-                    <Typography.Text variant="m-400" align="center">
-                        You've authorized {app?.name ?? 'the application'}. You can return to your
-                        device — it will continue automatically.
-                    </Typography.Text>
-                </Layout.Stack>
-            </Card.Base>
-        {:else if phase === 'denied'}
-            <Card.Base padding="l" radius="l" style="width: 100%;">
-                <Layout.Stack gap="l" alignItems="center" alignContent="center">
-                    <div class="denied-icon-wrap">
-                        <Icon icon={IconXCircle} size="l" color="--fgcolor-neutral-secondary" />
-                    </div>
-                    <Typography.Title size="m" align="center">Request cancelled</Typography.Title>
-                    <Typography.Text variant="m-400" align="center">
-                        No access was granted. You can close this page.
-                    </Typography.Text>
-                </Layout.Stack>
-            </Card.Base>
+                {onDone} />
+        {:else if phase === 'approved' || phase === 'denied'}
+            <OAuth2OutcomeCard
+                outcome={phase}
+                flow={DEVICE_FLOW}
+                {app}
+                accountLabel={account?.email || account?.name || undefined} />
         {/if}
     </div>
 </div>
@@ -298,26 +276,6 @@
 
     .code-input:disabled {
         opacity: 0.6;
-    }
-
-    .success-icon-wrap {
-        width: 3rem;
-        height: 3rem;
-        border-radius: 50%;
-        background: var(--bgcolor-success-secondary, rgba(16, 185, 129, 0.1));
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    .denied-icon-wrap {
-        width: 3rem;
-        height: 3rem;
-        border-radius: 50%;
-        background: var(--bgcolor-neutral-secondary, #f4f4f4);
-        display: flex;
-        align-items: center;
-        justify-content: center;
     }
 
     .bold {

--- a/src/routes/(public)/oauth2/outcome-card.svelte
+++ b/src/routes/(public)/oauth2/outcome-card.svelte
@@ -58,14 +58,20 @@
                 {:else}
                     <div class="avatar placeholder">{appInitial}</div>
                 {/if}
-                <span class="connector">
-                    <span class="connector-line"></span>
-                    <span class="connector-node">
+                {#if accountLabel}
+                    <span class="connector">
+                        <span class="connector-line"></span>
+                        <span class="connector-node">
+                            <Icon icon={approved ? IconCheck : IconX} size="s" />
+                        </span>
+                        <span class="connector-line"></span>
+                    </span>
+                    <div class="avatar account">{accountInitial}</div>
+                {:else}
+                    <span class="status-badge" class:approved>
                         <Icon icon={approved ? IconCheck : IconX} size="s" />
                     </span>
-                    <span class="connector-line"></span>
-                </span>
-                <div class="avatar account">{accountInitial}</div>
+                {/if}
             </div>
 
             <div class="headline">
@@ -119,9 +125,33 @@
        connector becomes a solid line with a status node when approved; stays
        dashed with an X when the request was cancelled. */
     .identity {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: center;
+    }
+
+    /* Fallback when no account is known: the status sits on the app avatar's
+       corner instead of in the connector. */
+    .status-badge {
+        position: absolute;
+        right: -0.5rem;
+        bottom: -0.35rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.5rem;
+        height: 1.5rem;
+        border-radius: 50%;
+        border: 1px solid var(--border-neutral);
+        background: var(--bgcolor-neutral-primary);
+        color: var(--fgcolor-neutral-secondary);
+    }
+
+    .status-badge.approved {
+        border-color: var(--border-success, rgba(16, 185, 129, 0.45));
+        background: var(--bgcolor-success-weaker, rgba(16, 185, 129, 0.12));
+        color: var(--fgcolor-success);
     }
 
     .avatar {

--- a/src/routes/(public)/oauth2/outcome-card.svelte
+++ b/src/routes/(public)/oauth2/outcome-card.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+    import type { Models } from '@appwrite.io/console';
+    import { Card, Typography, Icon } from '@appwrite.io/pink-svelte';
+    import { IconCheck, IconX, IconLockClosed } from '@appwrite.io/pink-icons-svelte';
+    import { Button } from '$lib/elements/forms';
+    import type { OAuth2Flow, OAuth2Outcome } from './consent-card.svelte';
+
+    interface Props {
+        outcome: OAuth2Outcome;
+        flow: OAuth2Flow;
+        app?: Models.App | null;
+        accountLabel?: string;
+        /**
+         * Present when the client redirect is a native deep link (cursor://…).
+         * The browser already attempted it once; the button retries it for users
+         * who dismissed the OS "open application" prompt.
+         */
+        redirectUrl?: string;
+    }
+
+    let {
+        outcome,
+        flow,
+        app = null,
+        accountLabel = undefined,
+        redirectUrl = undefined
+    }: Props = $props();
+
+    const approved = $derived(outcome === 'approved');
+    const appName = $derived(app?.name ?? 'the application');
+    const appInitial = $derived((app?.name || '?').charAt(0).toUpperCase());
+    const accountInitial = $derived((accountLabel || '?').charAt(0).toUpperCase());
+
+    const title = $derived(
+        approved ? (flow === 'device' ? 'Device connected' : 'Access granted') : 'Request cancelled'
+    );
+
+    const message = $derived.by(() => {
+        if (!approved) {
+            return `No access was granted to ${appName}. You can close this tab.`;
+        }
+        if (flow === 'device') {
+            return `You've authorized ${appName}. Return to your device — it will continue automatically.`;
+        }
+        if (redirectUrl) {
+            return `Return to ${appName} to continue. If it didn't open automatically, use the button below.`;
+        }
+        return `Return to ${appName} to continue. You can close this tab.`;
+    });
+</script>
+
+<Card.Base padding="none" radius="l" style="width: 100%; overflow: hidden;">
+    <div class="outcome" class:approved>
+        <header class="header">
+            <div class="identity">
+                {#if app?.logoUri}
+                    <img src={app.logoUri} alt={appName} class="avatar" />
+                {:else}
+                    <div class="avatar placeholder">{appInitial}</div>
+                {/if}
+                <span class="connector">
+                    <span class="connector-line"></span>
+                    <span class="connector-node">
+                        <Icon icon={approved ? IconCheck : IconX} size="s" />
+                    </span>
+                    <span class="connector-line"></span>
+                </span>
+                <div class="avatar account">{accountInitial}</div>
+            </div>
+
+            <div class="headline">
+                <Typography.Title size="m" align="center">{title}</Typography.Title>
+                <Typography.Text variant="m-400" align="center" color="--fgcolor-neutral-secondary">
+                    {message}
+                </Typography.Text>
+            </div>
+        </header>
+
+        <div class="body">
+            {#if approved && redirectUrl}
+                <Button fullWidth on:click={() => (window.location.href = redirectUrl)}>
+                    Open {app?.name ?? 'application'}
+                </Button>
+                <p class="close-hint">It's safe to close this tab.</p>
+            {/if}
+
+            <p class="footnote">
+                <Icon icon={IconLockClosed} size="s" />
+                {#if approved}
+                    <span>You can revoke access anytime in your account settings</span>
+                {:else}
+                    <span>{appName} was not given access to your account</span>
+                {/if}
+            </p>
+        </div>
+    </div>
+</Card.Base>
+
+<style lang="scss">
+    .outcome {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1.25rem;
+        padding: 2.5rem 1.75rem 0.5rem;
+        background: radial-gradient(
+            120% 100% at 50% 0%,
+            var(--bgcolor-neutral-secondary) 0%,
+            transparent 70%
+        );
+    }
+
+    /* Same identity row as the consent card, now resolved: the dashed "pending"
+       connector becomes a solid line with a status node when approved; stays
+       dashed with an X when the request was cancelled. */
+    .identity {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .avatar {
+        width: 3.5rem;
+        height: 3.5rem;
+        border-radius: var(--border-radius-l, 0.85rem);
+        object-fit: cover;
+        flex-shrink: 0;
+        border: 1px solid var(--border-neutral-strong);
+        background: var(--bgcolor-neutral-primary);
+    }
+
+    .avatar.placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--bgcolor-neutral-secondary);
+        color: var(--fgcolor-neutral-secondary);
+        font-size: 1.25rem;
+        font-weight: 600;
+    }
+
+    .avatar.account {
+        width: 3rem;
+        height: 3rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--bgcolor-neutral-invert);
+        color: var(--fgcolor-neutral-on-invert, var(--bgcolor-neutral-primary));
+        font-size: 1.1rem;
+        font-weight: 600;
+    }
+
+    .connector {
+        display: flex;
+        align-items: center;
+        margin-inline: 0.35rem;
+    }
+
+    .connector-line {
+        width: 1.1rem;
+        height: 0;
+        border-top: 2px dashed var(--border-neutral-strong);
+    }
+
+    .connector-node {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.75rem;
+        height: 1.75rem;
+        border-radius: 50%;
+        border: 1px solid var(--border-neutral);
+        background: var(--bgcolor-neutral-primary);
+        color: var(--fgcolor-neutral-secondary);
+    }
+
+    .approved .connector-line {
+        border-top-style: solid;
+        border-top-color: var(--border-success, rgba(16, 185, 129, 0.45));
+    }
+
+    .approved .connector-node {
+        border-color: var(--border-success, rgba(16, 185, 129, 0.45));
+        background: var(--bgcolor-success-weaker, rgba(16, 185, 129, 0.12));
+        color: var(--fgcolor-success);
+        animation: node-pop 0.35s cubic-bezier(0.2, 0.9, 0.3, 1.4) both;
+    }
+
+    @keyframes node-pop {
+        from {
+            transform: scale(0.5);
+            opacity: 0;
+        }
+        to {
+            transform: scale(1);
+            opacity: 1;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .approved .connector-node {
+            animation: none;
+        }
+    }
+
+    .headline {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        max-width: 22rem;
+    }
+
+    .body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        padding: 1.25rem 1.75rem 1.75rem;
+    }
+
+    .close-hint {
+        margin: 0;
+        text-align: center;
+        font-size: 0.78rem;
+        color: var(--fgcolor-neutral-tertiary);
+    }
+
+    .footnote {
+        margin: 0.25rem 0 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        font-size: 0.78rem;
+        color: var(--fgcolor-neutral-tertiary);
+        text-align: center;
+    }
+</style>


### PR DESCRIPTION
## What does this PR do?

When an OAuth2 client's redirect URI uses a custom protocol (e.g. `cursor://` for Cursor), the browser hands the redirect off to the OS and the consent tab is left hanging on the consent card with no feedback. This PR detects non-web (`http`/`https`) redirect URIs after approve/reject and renders an outcome screen instead.

- `approve()`/`reject()` in the consent card now report completion via a unified `onDone(outcome, redirectUrl)` callback when the redirect is a native deep link (or when there is no redirect), instead of the device-only `onDeviceDone`.
- New shared `outcome-card.svelte` renders the terminal state for both the authorization and device flows. It completes the consent card's identity row: the dashed "pending" connector between the app and account avatars resolves to a solid line with a check node when approved, and stays dashed with a neutral X when cancelled.
- On success with a deep link, an **Open {app}** button retries the redirect for users who dismissed the OS "open application" prompt.
- The already-consented fast path (`authorize` returns a `redirectUrl` immediately) shows the same screen for native redirects.
- The device flow's approved/denied screens were replaced with the shared card, removing the duplicated markup.

## Screenshots

### Access granted (desktop / mobile)

![oauth-consent-success-desktop](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/oauth-consent-success-desktop-bb067bf0.png)

<img src="https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/oauth-consent-success-mobile-346c2caa.png" width="390" alt="oauth-consent-success-mobile" />

### Request cancelled (desktop / mobile)

![oauth-consent-denied-desktop](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/oauth-consent-denied-desktop-fc8c449f.png)

<img src="https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/oauth-consent-denied-mobile-c714507b.png" width="390" alt="oauth-consent-denied-mobile" />

## Test plan

- `bun run check`, `bun run lint`, `bun run test:unit` (235 passed), `bun run build` all pass.
- Verified in the browser (Playwright against the dev server with mocked API responses): approved via immediate-redirect path, and denied via the consent card's Cancel button, on desktop and mobile viewports in dark mode.

## Related PRs and Issues

- None