### PR TITLE
Resume OAuth2 authorize requests through PAR handles across login

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@4b3ae78",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -126,7 +126,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@4b3ae78", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@0fcb4f2",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@4b3ae78",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/routes/(console)/account/payments/addressModal.svelte
+++ b/src/routes/(console)/account/payments/addressModal.svelte
@@ -10,7 +10,7 @@
     import type { Models } from '@appwrite.io/console';
 
     export let show = false;
-    export let locale: Models.Locale;
+    export let locale: Models.CloudLocale;
     export let organization: string = null;
     export let countryList: Models.CountryList;
 

--- a/src/routes/(console)/account/payments/billingAddress.svelte
+++ b/src/routes/(console)/account/payments/billingAddress.svelte
@@ -29,7 +29,7 @@
 
     export let data: PageData;
 
-    const locale: Models.Locale = data.locale;
+    const locale: Models.CloudLocale = data.locale;
     const countryList: Models.CountryList = data.countryList;
 
     let show = false;

--- a/src/routes/(console)/account/payments/editAddressModal.svelte
+++ b/src/routes/(console)/account/payments/editAddressModal.svelte
@@ -10,7 +10,7 @@
     import type { Models } from '@appwrite.io/console';
 
     export let show = false;
-    export let locale: Models.Locale;
+    export let locale: Models.CloudLocale;
     export let countryList: Models.CountryList;
     export let selectedAddress: Models.BillingAddress;
 

--- a/src/routes/(console)/organization-[organization]/billing/billingAddress.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/billingAddress.svelte
@@ -22,7 +22,7 @@
     } from '@appwrite.io/pink-icons-svelte';
     import type { Models } from '@appwrite.io/console';
 
-    export let locale: Models.Locale;
+    export let locale: Models.CloudLocale;
     export let countryList: Models.CountryList;
     export let organization: Models.Organization;
     export let billingAddress: Models.BillingAddress;

--- a/src/routes/(console)/organization-[organization]/billing/replaceAddress.svelte
+++ b/src/routes/(console)/organization-[organization]/billing/replaceAddress.svelte
@@ -13,7 +13,7 @@
     import type { Models } from '@appwrite.io/console';
 
     export let show = false;
-    export let locale: Models.Locale;
+    export let locale: Models.CloudLocale;
     export let countryList: Models.CountryList;
 
     let loading = true;

--- a/src/routes/(console)/organization-[organization]/settings/Soc2.svelte
+++ b/src/routes/(console)/organization-[organization]/settings/Soc2.svelte
@@ -5,7 +5,7 @@
     import type { Models } from '@appwrite.io/console';
 
     let show = false;
-    export let locale: Models.Locale;
+    export let locale: Models.CloudLocale;
     export let countryList: Models.CountryList;
 </script>
 

--- a/src/routes/(console)/organization-[organization]/settings/Soc2Modal.svelte
+++ b/src/routes/(console)/organization-[organization]/settings/Soc2Modal.svelte
@@ -11,7 +11,7 @@
     import type { Models } from '@appwrite.io/console';
 
     export let show = false;
-    export let locale: Models.Locale;
+    export let locale: Models.CloudLocale;
     export let countryList: Models.CountryList;
 
     let email = '';

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -234,6 +234,7 @@
                 // existing approved identity) via the SDK, then render consent or
                 // redirect.
                 try {
+                    const resources = params.getAll('resource');
                     const result = await sdk.forConsole.oauth2.authorize({
                         clientId,
                         redirectUri: params.get('redirect_uri') ?? '',
@@ -246,7 +247,10 @@
                         prompt: params.get('prompt') ?? undefined,
                         maxAge: parseMaxAge(params.get('max_age')),
                         authorizationDetails: params.get('authorization_details') ?? undefined,
-                        resource: params.get('resource') ?? undefined
+                        // SDK types `resource` as string; the server accepts
+                        // a URI list (RFC 8707).
+                        resource:
+                            resources.length > 0 ? (resources as unknown as string) : undefined
                     });
                     if (cancelled) return;
                     await handleAuthorizeResult(result, loggedInAccount, clientId, false);

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -33,10 +33,8 @@
         phase = outcome === 'approved' ? 'approved' : 'denied';
     }
 
-    // PAR is a public client endpoint (like /token): the server serves it with
-    // wildcard CORS and credentials disabled, so the browser rejects the
-    // console SDK's default credentialed fetch. Call it through an anonymous
-    // client that omits cookies — the endpoint needs no session anyway.
+    // /par is served like /token: wildcard CORS with credentials disabled, so
+    // the browser rejects the default client's credentialed fetch.
     function anonymousOAuth2(): Oauth2 {
         const client = new Client()
             .setEndpoint(sdk.forConsole.client.config.endpoint)
@@ -45,15 +43,10 @@
         return new Oauth2(client);
     }
 
-    // The ENTIRE query string, so the flow restarts whenever any part of the
-    // authorize request changes — not just grant_id/client_id, but also
-    // redirect_uri, scope, state, nonce, PKCE fields, prompt, max_age,
-    // authorization_details and request_uri. A $derived string (rather than
-    // reading page.url in the effect) so identity-only replacements of the
-    // URL object — e.g. login calling invalidate(ACCOUNT) right after goto —
-    // do NOT re-run the flow: a rerun would cancel an in-flight authorize
-    // and, on the PAR path, re-dereference an already-consumed single-use
-    // request_uri handle.
+    // A $derived string so identity-only replacements of page.url (e.g. login
+    // calling invalidate(ACCOUNT) right after goto) don't restart the flow —
+    // a restart would cancel an in-flight authorize and re-dereference an
+    // already-consumed single-use request_uri.
     const authorizeQuery = $derived(page.url.searchParams.toString());
 
     // Re-runs when the authorize params change (this route can stay mounted as
@@ -118,8 +111,6 @@
                 return;
             }
 
-            // Shared handling for a JSON authorize response, whether the request
-            // arrived as raw params or as a pushed request_uri handle.
             async function handleAuthorizeResult(
                 result: Models.Oauth2Authorize,
                 loggedInAccount: Models.User<Models.Preferences>,
@@ -142,10 +133,8 @@
                 }
                 if (result.grantId) {
                     if (fromRequestUri) {
-                        // The pushed request handle is single-use and now consumed.
-                        // Rewrite the URL to the grant so a reload or back/forward
-                        // navigation resumes via getGrant instead of failing on a
-                        // dead request_uri. The effect re-runs and loads the grant.
+                        // The handle is now consumed — rewrite to the grant URL so
+                        // reloads resume via getGrant instead of a dead request_uri.
                         await goto(`${base}/oauth2/consent?grant_id=${result.grantId}`, {
                             replaceState: true
                         });
@@ -161,8 +150,6 @@
             const clientId = params.get('client_id');
             const requestUri = params.get('request_uri');
 
-            // Pushed authorization request (PAR) resume: we round-tripped a short
-            // request_uri handle through login instead of the full authorize URL.
             if (requestUri) {
                 const loggedInAccount = (await sdk.forConsole.account
                     .get()
@@ -177,10 +164,9 @@
                 }
 
                 try {
+                    // The server rejects request_uri combined with any other
+                    // authorization param; only client_id may accompany it.
                     const result = await sdk.forConsole.oauth2.authorize({
-                        // request_uri must not be combined with any other
-                        // authorization param; client_id is the only one the
-                        // server accepts alongside it (and must match).
                         clientId: clientId ?? undefined,
                         requestUri
                     });
@@ -188,10 +174,9 @@
                     await handleAuthorizeResult(result, loggedInAccount, clientId, true);
                 } catch (e: unknown) {
                     if (cancelled) return;
-                    // The server reports every dead-handle case — expired,
-                    // already consumed, malformed — as `oauth2_invalid_request`.
-                    // Since this call sends nothing but the handle, that type
-                    // can only mean the handle itself is no longer usable.
+                    // Every dead-handle case (expired, consumed, malformed) is
+                    // reported as oauth2_invalid_request; since only the handle
+                    // is sent, that type can only mean the handle is unusable.
                     const invalidHandle =
                         e instanceof AppwriteException && e.type === 'oauth2_invalid_request';
                     error = invalidHandle
@@ -210,10 +195,9 @@
                 if (cancelled) return;
 
                 if (!loggedInAccount) {
-                    // Push the authorization request server-side and carry only a
-                    // short request_uri through login. The full consent URL rides
-                    // inside the OAuth provider's `state` during GitHub sign-in
-                    // and can exceed the provider's size limits.
+                    // Carry only a short request_uri through login — the full
+                    // consent URL travels inside the OAuth provider's `state`
+                    // during GitHub sign-in and can exceed its size limits.
                     const resources = params.getAll('resource');
                     try {
                         const par = await anonymousOAuth2().createPAR({
@@ -228,8 +212,8 @@
                             prompt: params.get('prompt') ?? undefined,
                             maxAge: parseMaxAge(params.get('max_age')),
                             authorizationDetails: params.get('authorization_details') ?? undefined,
-                            // The SDK types `resource` as a string but the server
-                            // accepts a URI list (RFC 8707 allows repeated values).
+                            // SDK types `resource` as string; the server accepts
+                            // a URI list (RFC 8707).
                             resource:
                                 resources.length > 0 ? (resources as unknown as string) : undefined
                         });
@@ -239,9 +223,8 @@
                         );
                     } catch {
                         if (cancelled) return;
-                        // PAR unavailable (older server) or the request is invalid.
-                        // Fall back to the legacy full-URL redirect; validation
-                        // errors resurface via authorize after login.
+                        // PAR unavailable (older server) or invalid request —
+                        // fall back to the legacy full-URL redirect.
                         goSignIn();
                     }
                     return;

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -2,7 +2,7 @@
     import { goto } from '$app/navigation';
     import { base } from '$app/paths';
     import { page } from '$app/state';
-    import { AppwriteException, Client, Oauth2, type Models } from '@appwrite.io/console';
+    import { AppwriteException, type Models } from '@appwrite.io/console';
     import { Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
     import { IconExclamation } from '@appwrite.io/pink-icons-svelte';
     import { Button } from '$lib/elements/forms';
@@ -31,19 +31,6 @@
     function onDone(outcome: OAuth2Outcome, redirectUrl?: string) {
         completedRedirectUrl = redirectUrl;
         phase = outcome === 'approved' ? 'approved' : 'denied';
-    }
-
-    // /par is public (no auth needed), which is exactly why the default client
-    // can't call it: public endpoints are served like /token — wildcard CORS
-    // with Access-Control-Allow-Credentials: false — and the browser blocks
-    // sdk.forConsole's credentialed (cookie-sending) fetch against that. This
-    // client sends the same request with credentials omitted.
-    function anonymousOAuth2(): Oauth2 {
-        const client = new Client()
-            .setEndpoint(sdk.forConsole.client.config.endpoint)
-            .setProject('console')
-            .setCredentials('omit');
-        return new Oauth2(client);
     }
 
     // A $derived string so identity-only replacements of page.url (e.g. login
@@ -160,8 +147,8 @@
                 if (cancelled) return;
 
                 if (!loggedInAccount) {
-                    // The handle is single-use: never dereference it while logged
-                    // out — the server consumes it before rejecting the call.
+                    // Dereferencing while logged out can only 401; keep the
+                    // single-use handle untouched and go straight to login.
                     goSignIn();
                     return;
                 }
@@ -203,7 +190,7 @@
                     // during GitHub sign-in and can exceed its size limits.
                     const resources = params.getAll('resource');
                     try {
-                        const par = await anonymousOAuth2().createPAR({
+                        const par = await sdk.forConsole.oauth2.createPAR({
                             clientId,
                             redirectUri: params.get('redirect_uri') ?? '',
                             responseType: params.get('response_type') ?? 'code',

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -33,8 +33,11 @@
         phase = outcome === 'approved' ? 'approved' : 'denied';
     }
 
-    // /par is served like /token: wildcard CORS with credentials disabled, so
-    // the browser rejects the default client's credentialed fetch.
+    // /par is public (no auth needed), which is exactly why the default client
+    // can't call it: public endpoints are served like /token — wildcard CORS
+    // with Access-Control-Allow-Credentials: false — and the browser blocks
+    // sdk.forConsole's credentialed (cookie-sending) fetch against that. This
+    // client sends the same request with credentials omitted.
     function anonymousOAuth2(): Oauth2 {
         const client = new Client()
             .setEndpoint(sdk.forConsole.client.config.endpoint)

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -188,10 +188,15 @@
                     await handleAuthorizeResult(result, loggedInAccount, clientId, true);
                 } catch (e: unknown) {
                     if (cancelled) return;
-                    const message = (e as Error)?.message ?? '';
-                    error = message.toLowerCase().includes('request_uri')
+                    // The server reports every dead-handle case — expired,
+                    // already consumed, malformed — as `oauth2_invalid_request`.
+                    // Since this call sends nothing but the handle, that type
+                    // can only mean the handle itself is no longer usable.
+                    const invalidHandle =
+                        e instanceof AppwriteException && e.type === 'oauth2_invalid_request';
+                    error = invalidHandle
                         ? 'This sign-in request has expired. Return to the application and try connecting again.'
-                        : message || 'Could not start authorization.';
+                        : ((e as Error)?.message ?? 'Could not start authorization.');
                     phase = 'error';
                 }
                 return;

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { base } from '$app/paths';
+    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import { AppwriteException, type Models } from '@appwrite.io/console';
     import { Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
@@ -10,13 +10,15 @@
     import { isWebRedirect } from '$lib/helpers/oauth2-redirect';
     import OAuth2ConsentCard, { type OAuth2Outcome } from '../consent-card.svelte';
     import OAuth2OutcomeCard from '../outcome-card.svelte';
+    import { OAuth2ErrorMessage, OAuth2ErrorType } from '../errors';
 
     type Phase = 'loading' | 'ready' | 'approved' | 'denied' | 'error';
+    type Account = Models.User<Models.Preferences>;
 
     let phase = $state<Phase>('loading');
     let grant = $state<Models.Oauth2Grant | null>(null);
     let app = $state<Models.App | null>(null);
-    let account = $state<Models.User<Models.Preferences> | null>(null);
+    let account = $state<Account | null>(null);
     let error = $state<string | null>(null);
     let completedRedirectUrl = $state<string | undefined>(undefined);
 
@@ -26,6 +28,214 @@
         if (!raw) return undefined;
         const value = Number(raw);
         return Number.isInteger(value) && value >= 0 ? value : undefined;
+    }
+
+    function getAccount(): Promise<Account | null> {
+        return sdk.forConsole.account.get().catch(() => null) as Promise<Account | null>;
+    }
+
+    // The authorize-request fields shared verbatim between createPAR (pre-login
+    // push) and authorize (authenticated direct path).
+    function readAuthorizeParams(params: URLSearchParams) {
+        const resources = params.getAll('resource');
+        return {
+            redirectUri: params.get('redirect_uri') ?? '',
+            responseType: params.get('response_type') ?? 'code',
+            scope: params.get('scope') ?? '',
+            state: params.get('state') ?? undefined,
+            nonce: params.get('nonce') ?? undefined,
+            codeChallenge: params.get('code_challenge') ?? undefined,
+            codeChallengeMethod: params.get('code_challenge_method') ?? undefined,
+            prompt: params.get('prompt') ?? undefined,
+            maxAge: parseMaxAge(params.get('max_age')),
+            authorizationDetails: params.get('authorization_details') ?? undefined,
+            resource: resources.length > 0 ? (resources as unknown as string) : undefined
+        };
+    }
+
+    function goSignIn(resumeUrl?: string) {
+        const target = resumeUrl ?? window.location.pathname + window.location.search;
+        void goto(resolve(`/login?redirect=${encodeURIComponent(target)}`), {
+            replaceState: true
+        });
+    }
+
+    function fail(e: unknown, fallback: string) {
+        error = (e as Error)?.message ?? fallback;
+        phase = 'error';
+    }
+
+    // Load a grant + its app branding and render the consent card.
+    async function loadConsent(
+        grantId: string,
+        cancelled: () => boolean,
+        knownAccount?: Account | null
+    ): Promise<void> {
+        const loadedGrant = await sdk.forConsole.oauth2.getGrant({ grantId });
+        const [loadedApp, loadedAccount] = await Promise.all([
+            sdk.forConsole.apps.get({ appId: loadedGrant.appId }),
+            knownAccount !== undefined ? Promise.resolve(knownAccount) : getAccount()
+        ]);
+        if (cancelled()) return;
+        grant = loadedGrant;
+        app = loadedApp;
+        account = loadedAccount;
+        phase = 'ready';
+    }
+
+    async function resumeFromGrant(grantId: string, cancelled: () => boolean): Promise<void> {
+        try {
+            await loadConsent(grantId, cancelled);
+        } catch (e: unknown) {
+            if (cancelled()) return;
+            if (e instanceof AppwriteException && e.code === 401) {
+                goSignIn();
+                return;
+            }
+            fail(e, OAuth2ErrorMessage.GRANT_INVALID);
+        }
+    }
+
+    async function handleAuthorizeResult(
+        result: Models.Oauth2Authorize,
+        loggedInAccount: Account,
+        clientId: string | null,
+        fromRequestUri: boolean,
+        cancelled: () => boolean
+    ): Promise<void> {
+        if (result.redirectUrl) {
+            // Already consented — go straight back to the client.
+            window.location.href = result.redirectUrl;
+            if (!isWebRedirect(result.redirectUrl)) {
+                completedRedirectUrl = result.redirectUrl;
+                account = loggedInAccount;
+                app = clientId
+                    ? await sdk.forConsole.apps.get({ appId: clientId }).catch(() => null)
+                    : null;
+                if (cancelled()) return;
+                phase = 'approved';
+            }
+            return;
+        }
+        if (result.grantId) {
+            if (fromRequestUri) {
+                // The handle is now consumed — rewrite to the grant URL so
+                // reloads resume via getGrant instead of a dead request_uri.
+                await goto(resolve(`/oauth2/consent?grant_id=${result.grantId}`), {
+                    replaceState: true
+                });
+                return;
+            }
+            await loadConsent(result.grantId, cancelled, loggedInAccount);
+            return;
+        }
+        error = OAuth2ErrorMessage.AUTHORIZE_FAILED;
+        phase = 'error';
+    }
+
+    async function resumeFromRequestUri(
+        clientId: string | null,
+        requestUri: string,
+        cancelled: () => boolean
+    ): Promise<void> {
+        const loggedInAccount = await getAccount();
+        if (cancelled()) return;
+
+        if (!loggedInAccount) {
+            // Dereferencing while logged out can only 401; keep the
+            // single-use handle untouched and go straight to login.
+            goSignIn();
+            return;
+        }
+
+        try {
+            // The server rejects request_uri combined with any other
+            // authorization param; only client_id may accompany it.
+            const result = await sdk.forConsole.oauth2.authorize({
+                clientId: clientId ?? undefined,
+                requestUri
+            });
+            if (cancelled()) return;
+            await handleAuthorizeResult(result, loggedInAccount, clientId, true, cancelled);
+        } catch (e: unknown) {
+            if (cancelled()) return;
+            // Since only the handle is sent, oauth2_invalid_request can only
+            // mean the handle is unusable.
+            if (e instanceof AppwriteException && e.type === OAuth2ErrorType.INVALID_REQUEST) {
+                error = OAuth2ErrorMessage.HANDLE_EXPIRED;
+                phase = 'error';
+                return;
+            }
+            fail(e, OAuth2ErrorMessage.AUTHORIZE_FAILED);
+        }
+    }
+
+    // Pre-login entry with raw authorize params in the URL.
+    async function startAuthorize(
+        clientId: string,
+        params: URLSearchParams,
+        cancelled: () => boolean
+    ): Promise<void> {
+        const loggedInAccount = await getAccount();
+        if (cancelled()) return;
+
+        if (!loggedInAccount) {
+            // Carry only a short request_uri through login — the full
+            // consent URL travels inside the OAuth provider's `state`
+            // during GitHub sign-in and can exceed its size limits.
+            try {
+                const par = await sdk.forConsole.oauth2.createPAR({
+                    clientId,
+                    ...readAuthorizeParams(params)
+                });
+                if (cancelled()) return;
+                goSignIn(
+                    `${resolve('/oauth2/consent')}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(par.request_uri)}`
+                );
+            } catch {
+                if (cancelled()) return;
+                // PAR unavailable (older server) or invalid request —
+                // fall back to the legacy full-URL redirect.
+                goSignIn();
+            }
+            return;
+        }
+
+        // Authenticated: ask the server to create a grant (or detect an
+        // existing approved identity), then render consent or redirect.
+        try {
+            const result = await sdk.forConsole.oauth2.authorize({
+                clientId,
+                ...readAuthorizeParams(params)
+            });
+            if (cancelled()) return;
+            await handleAuthorizeResult(result, loggedInAccount, clientId, false, cancelled);
+        } catch (e: unknown) {
+            if (cancelled()) return;
+            fail(e, OAuth2ErrorMessage.AUTHORIZE_FAILED);
+        }
+    }
+
+    async function init(params: URLSearchParams, cancelled: () => boolean): Promise<void> {
+        const grantId = params.get('grant_id');
+        if (grantId) {
+            await resumeFromGrant(grantId, cancelled);
+            return;
+        }
+
+        const clientId = params.get('client_id');
+        const requestUri = params.get('request_uri');
+        if (requestUri) {
+            await resumeFromRequestUri(clientId, requestUri, cancelled);
+            return;
+        }
+        if (clientId) {
+            await startAuthorize(clientId, params, cancelled);
+            return;
+        }
+
+        error = OAuth2ErrorMessage.MISSING_REQUEST;
+        phase = 'error';
     }
 
     function onDone(outcome: OAuth2Outcome, redirectUrl?: string) {
@@ -39,227 +249,23 @@
     // already-consumed single-use request_uri.
     const authorizeQuery = $derived(page.url.searchParams.toString());
 
+    let currentRun = 0;
+
     // Re-runs when the authorize params change (this route can stay mounted as
     // the router moves between requests). Reset to loading so a previously
     // loaded grant can never be approved against a different request.
     $effect(() => {
-        const query = authorizeQuery;
+        const params = new URLSearchParams(authorizeQuery);
+        const run = ++currentRun;
 
-        let cancelled = false;
         phase = 'loading';
         error = null;
         completedRedirectUrl = undefined;
 
-        const currentRelativeUrl = () => window.location.pathname + window.location.search;
-
-        const goSignIn = (resumeUrl?: string) => {
-            const target = resumeUrl ?? currentRelativeUrl();
-            void goto(`${base}/login?redirect=${encodeURIComponent(target)}`, {
-                replaceState: true
-            });
-        };
-
-        // Load a grant + its app branding and render the consent card.
-        async function loadConsent(
-            grantId: string,
-            knownAccount?: Models.User<Models.Preferences> | null
-        ): Promise<void> {
-            const loadedGrant = await sdk.forConsole.oauth2.getGrant({ grantId });
-            const [loadedApp, loadedAccount] = await Promise.all([
-                sdk.forConsole.apps.get({ appId: loadedGrant.appId }),
-                knownAccount !== undefined
-                    ? Promise.resolve(knownAccount)
-                    : (sdk.forConsole.account
-                          .get()
-                          .catch(() => null) as Promise<Models.User<Models.Preferences> | null>)
-            ]);
-            if (cancelled) return;
-            grant = loadedGrant;
-            app = loadedApp;
-            account = loadedAccount;
-            phase = 'ready';
-        }
-
-        async function init(): Promise<void> {
-            const params = new URLSearchParams(query);
-            const grantId = params.get('grant_id');
-
-            if (grantId) {
-                try {
-                    await loadConsent(grantId);
-                } catch (e: unknown) {
-                    if (cancelled) return;
-                    if (e instanceof AppwriteException && e.code === 401) {
-                        goSignIn();
-                        return;
-                    }
-                    error =
-                        (e as Error)?.message ??
-                        'This authorization request is invalid or has expired.';
-                    phase = 'error';
-                }
-                return;
-            }
-
-            async function handleAuthorizeResult(
-                result: Models.Oauth2Authorize,
-                loggedInAccount: Models.User<Models.Preferences>,
-                clientId: string | null,
-                fromRequestUri: boolean
-            ): Promise<void> {
-                if (result.redirectUrl) {
-                    // Already consented — go straight back to the client.
-                    window.location.href = result.redirectUrl;
-                    if (!isWebRedirect(result.redirectUrl)) {
-                        completedRedirectUrl = result.redirectUrl;
-                        account = loggedInAccount;
-                        app = clientId
-                            ? await sdk.forConsole.apps.get({ appId: clientId }).catch(() => null)
-                            : null;
-                        if (cancelled) return;
-                        phase = 'approved';
-                    }
-                    return;
-                }
-                if (result.grantId) {
-                    if (fromRequestUri) {
-                        // The handle is now consumed — rewrite to the grant URL so
-                        // reloads resume via getGrant instead of a dead request_uri.
-                        await goto(`${base}/oauth2/consent?grant_id=${result.grantId}`, {
-                            replaceState: true
-                        });
-                        return;
-                    }
-                    await loadConsent(result.grantId, loggedInAccount);
-                    return;
-                }
-                error = 'Could not start authorization.';
-                phase = 'error';
-            }
-
-            const clientId = params.get('client_id');
-            const requestUri = params.get('request_uri');
-
-            if (requestUri) {
-                const loggedInAccount = (await sdk.forConsole.account
-                    .get()
-                    .catch(() => null)) as Models.User<Models.Preferences> | null;
-                if (cancelled) return;
-
-                if (!loggedInAccount) {
-                    // Dereferencing while logged out can only 401; keep the
-                    // single-use handle untouched and go straight to login.
-                    goSignIn();
-                    return;
-                }
-
-                try {
-                    // The server rejects request_uri combined with any other
-                    // authorization param; only client_id may accompany it.
-                    const result = await sdk.forConsole.oauth2.authorize({
-                        clientId: clientId ?? undefined,
-                        requestUri
-                    });
-                    if (cancelled) return;
-                    await handleAuthorizeResult(result, loggedInAccount, clientId, true);
-                } catch (e: unknown) {
-                    if (cancelled) return;
-                    // Every dead-handle case (expired, consumed, malformed) is
-                    // reported as oauth2_invalid_request; since only the handle
-                    // is sent, that type can only mean the handle is unusable.
-                    const invalidHandle =
-                        e instanceof AppwriteException && e.type === 'oauth2_invalid_request';
-                    error = invalidHandle
-                        ? 'This sign-in request has expired. Return to the application and try connecting again.'
-                        : ((e as Error)?.message ?? 'Could not start authorization.');
-                    phase = 'error';
-                }
-                return;
-            }
-
-            // No grant yet: this is the pre-login entry with raw authorize params.
-            if (clientId) {
-                const loggedInAccount = (await sdk.forConsole.account
-                    .get()
-                    .catch(() => null)) as Models.User<Models.Preferences> | null;
-                if (cancelled) return;
-
-                if (!loggedInAccount) {
-                    // Carry only a short request_uri through login — the full
-                    // consent URL travels inside the OAuth provider's `state`
-                    // during GitHub sign-in and can exceed its size limits.
-                    const resources = params.getAll('resource');
-                    try {
-                        const par = await sdk.forConsole.oauth2.createPAR({
-                            clientId,
-                            redirectUri: params.get('redirect_uri') ?? '',
-                            responseType: params.get('response_type') ?? 'code',
-                            scope: params.get('scope') ?? '',
-                            state: params.get('state') ?? undefined,
-                            nonce: params.get('nonce') ?? undefined,
-                            codeChallenge: params.get('code_challenge') ?? undefined,
-                            codeChallengeMethod: params.get('code_challenge_method') ?? undefined,
-                            prompt: params.get('prompt') ?? undefined,
-                            maxAge: parseMaxAge(params.get('max_age')),
-                            authorizationDetails: params.get('authorization_details') ?? undefined,
-                            // SDK types `resource` as string; the server accepts
-                            // a URI list (RFC 8707).
-                            resource:
-                                resources.length > 0 ? (resources as unknown as string) : undefined
-                        });
-                        if (cancelled) return;
-                        goSignIn(
-                            `${base}/oauth2/consent?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(par.request_uri)}`
-                        );
-                    } catch {
-                        if (cancelled) return;
-                        // PAR unavailable (older server) or invalid request —
-                        // fall back to the legacy full-URL redirect.
-                        goSignIn();
-                    }
-                    return;
-                }
-
-                // Authenticated: ask the server to create a grant (or detect an
-                // existing approved identity) via the SDK, then render consent or
-                // redirect.
-                try {
-                    const resources = params.getAll('resource');
-                    const result = await sdk.forConsole.oauth2.authorize({
-                        clientId,
-                        redirectUri: params.get('redirect_uri') ?? '',
-                        responseType: params.get('response_type') ?? 'code',
-                        scope: params.get('scope') ?? '',
-                        state: params.get('state') ?? undefined,
-                        nonce: params.get('nonce') ?? undefined,
-                        codeChallenge: params.get('code_challenge') ?? undefined,
-                        codeChallengeMethod: params.get('code_challenge_method') ?? undefined,
-                        prompt: params.get('prompt') ?? undefined,
-                        maxAge: parseMaxAge(params.get('max_age')),
-                        authorizationDetails: params.get('authorization_details') ?? undefined,
-                        // SDK types `resource` as string; the server accepts
-                        // a URI list (RFC 8707).
-                        resource:
-                            resources.length > 0 ? (resources as unknown as string) : undefined
-                    });
-                    if (cancelled) return;
-                    await handleAuthorizeResult(result, loggedInAccount, clientId, false);
-                } catch (e: unknown) {
-                    if (cancelled) return;
-                    error = (e as Error)?.message ?? 'Could not start authorization.';
-                    phase = 'error';
-                }
-                return;
-            }
-
-            error = 'Missing authorization request. Open this page from an application sign-in.';
-            phase = 'error';
-        }
-
-        void init();
+        void init(params, () => run !== currentRun);
 
         return () => {
-            cancelled = true;
+            currentRun++;
         };
     });
 </script>
@@ -286,7 +292,7 @@
                     <Typography.Text variant="m-400" align="center">
                         {error}
                     </Typography.Text>
-                    <Button on:click={() => goto(base, { replaceState: true })}>
+                    <Button on:click={() => goto(resolve('/'), { replaceState: true })}>
                         Go to console
                     </Button>
                 </Layout.Stack>

--- a/src/routes/(public)/oauth2/consent/+page.svelte
+++ b/src/routes/(public)/oauth2/consent/+page.svelte
@@ -2,7 +2,7 @@
     import { goto } from '$app/navigation';
     import { base } from '$app/paths';
     import { page } from '$app/state';
-    import { AppwriteException, type Models } from '@appwrite.io/console';
+    import { AppwriteException, Client, Oauth2, type Models } from '@appwrite.io/console';
     import { Card, Layout, Typography, Icon, Spinner } from '@appwrite.io/pink-svelte';
     import { IconExclamation } from '@appwrite.io/pink-icons-svelte';
     import { Button } from '$lib/elements/forms';
@@ -33,15 +33,34 @@
         phase = outcome === 'approved' ? 'approved' : 'denied';
     }
 
+    // PAR is a public client endpoint (like /token): the server serves it with
+    // wildcard CORS and credentials disabled, so the browser rejects the
+    // console SDK's default credentialed fetch. Call it through an anonymous
+    // client that omits cookies — the endpoint needs no session anyway.
+    function anonymousOAuth2(): Oauth2 {
+        const client = new Client()
+            .setEndpoint(sdk.forConsole.client.config.endpoint)
+            .setProject('console')
+            .setCredentials('omit');
+        return new Oauth2(client);
+    }
+
+    // The ENTIRE query string, so the flow restarts whenever any part of the
+    // authorize request changes — not just grant_id/client_id, but also
+    // redirect_uri, scope, state, nonce, PKCE fields, prompt, max_age,
+    // authorization_details and request_uri. A $derived string (rather than
+    // reading page.url in the effect) so identity-only replacements of the
+    // URL object — e.g. login calling invalidate(ACCOUNT) right after goto —
+    // do NOT re-run the flow: a rerun would cancel an in-flight authorize
+    // and, on the PAR path, re-dereference an already-consumed single-use
+    // request_uri handle.
+    const authorizeQuery = $derived(page.url.searchParams.toString());
+
     // Re-runs when the authorize params change (this route can stay mounted as
     // the router moves between requests). Reset to loading so a previously
     // loaded grant can never be approved against a different request.
     $effect(() => {
-        // Depend on the ENTIRE query string so the effect re-runs whenever any
-        // part of the authorize request changes — not just grant_id/client_id,
-        // but also redirect_uri, scope, state, nonce, PKCE fields, prompt,
-        // max_age and authorization_details.
-        page.url.searchParams.toString();
+        const query = authorizeQuery;
 
         let cancelled = false;
         phase = 'loading';
@@ -50,8 +69,9 @@
 
         const currentRelativeUrl = () => window.location.pathname + window.location.search;
 
-        const goSignIn = () => {
-            void goto(`${base}/login?redirect=${encodeURIComponent(currentRelativeUrl())}`, {
+        const goSignIn = (resumeUrl?: string) => {
+            const target = resumeUrl ?? currentRelativeUrl();
+            void goto(`${base}/login?redirect=${encodeURIComponent(target)}`, {
                 replaceState: true
             });
         };
@@ -78,7 +98,7 @@
         }
 
         async function init(): Promise<void> {
-            const params = page.url.searchParams;
+            const params = new URLSearchParams(query);
             const grantId = params.get('grant_id');
 
             if (grantId) {
@@ -98,8 +118,86 @@
                 return;
             }
 
-            // No grant yet: this is the pre-login entry with raw authorize params.
+            // Shared handling for a JSON authorize response, whether the request
+            // arrived as raw params or as a pushed request_uri handle.
+            async function handleAuthorizeResult(
+                result: Models.Oauth2Authorize,
+                loggedInAccount: Models.User<Models.Preferences>,
+                clientId: string | null,
+                fromRequestUri: boolean
+            ): Promise<void> {
+                if (result.redirectUrl) {
+                    // Already consented — go straight back to the client.
+                    window.location.href = result.redirectUrl;
+                    if (!isWebRedirect(result.redirectUrl)) {
+                        completedRedirectUrl = result.redirectUrl;
+                        account = loggedInAccount;
+                        app = clientId
+                            ? await sdk.forConsole.apps.get({ appId: clientId }).catch(() => null)
+                            : null;
+                        if (cancelled) return;
+                        phase = 'approved';
+                    }
+                    return;
+                }
+                if (result.grantId) {
+                    if (fromRequestUri) {
+                        // The pushed request handle is single-use and now consumed.
+                        // Rewrite the URL to the grant so a reload or back/forward
+                        // navigation resumes via getGrant instead of failing on a
+                        // dead request_uri. The effect re-runs and loads the grant.
+                        await goto(`${base}/oauth2/consent?grant_id=${result.grantId}`, {
+                            replaceState: true
+                        });
+                        return;
+                    }
+                    await loadConsent(result.grantId, loggedInAccount);
+                    return;
+                }
+                error = 'Could not start authorization.';
+                phase = 'error';
+            }
+
             const clientId = params.get('client_id');
+            const requestUri = params.get('request_uri');
+
+            // Pushed authorization request (PAR) resume: we round-tripped a short
+            // request_uri handle through login instead of the full authorize URL.
+            if (requestUri) {
+                const loggedInAccount = (await sdk.forConsole.account
+                    .get()
+                    .catch(() => null)) as Models.User<Models.Preferences> | null;
+                if (cancelled) return;
+
+                if (!loggedInAccount) {
+                    // The handle is single-use: never dereference it while logged
+                    // out — the server consumes it before rejecting the call.
+                    goSignIn();
+                    return;
+                }
+
+                try {
+                    const result = await sdk.forConsole.oauth2.authorize({
+                        // request_uri must not be combined with any other
+                        // authorization param; client_id is the only one the
+                        // server accepts alongside it (and must match).
+                        clientId: clientId ?? undefined,
+                        requestUri
+                    });
+                    if (cancelled) return;
+                    await handleAuthorizeResult(result, loggedInAccount, clientId, true);
+                } catch (e: unknown) {
+                    if (cancelled) return;
+                    const message = (e as Error)?.message ?? '';
+                    error = message.toLowerCase().includes('request_uri')
+                        ? 'This sign-in request has expired. Return to the application and try connecting again.'
+                        : message || 'Could not start authorization.';
+                    phase = 'error';
+                }
+                return;
+            }
+
+            // No grant yet: this is the pre-login entry with raw authorize params.
             if (clientId) {
                 const loggedInAccount = (await sdk.forConsole.account
                     .get()
@@ -107,7 +205,40 @@
                 if (cancelled) return;
 
                 if (!loggedInAccount) {
-                    goSignIn();
+                    // Push the authorization request server-side and carry only a
+                    // short request_uri through login. The full consent URL rides
+                    // inside the OAuth provider's `state` during GitHub sign-in
+                    // and can exceed the provider's size limits.
+                    const resources = params.getAll('resource');
+                    try {
+                        const par = await anonymousOAuth2().createPAR({
+                            clientId,
+                            redirectUri: params.get('redirect_uri') ?? '',
+                            responseType: params.get('response_type') ?? 'code',
+                            scope: params.get('scope') ?? '',
+                            state: params.get('state') ?? undefined,
+                            nonce: params.get('nonce') ?? undefined,
+                            codeChallenge: params.get('code_challenge') ?? undefined,
+                            codeChallengeMethod: params.get('code_challenge_method') ?? undefined,
+                            prompt: params.get('prompt') ?? undefined,
+                            maxAge: parseMaxAge(params.get('max_age')),
+                            authorizationDetails: params.get('authorization_details') ?? undefined,
+                            // The SDK types `resource` as a string but the server
+                            // accepts a URI list (RFC 8707 allows repeated values).
+                            resource:
+                                resources.length > 0 ? (resources as unknown as string) : undefined
+                        });
+                        if (cancelled) return;
+                        goSignIn(
+                            `${base}/oauth2/consent?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(par.request_uri)}`
+                        );
+                    } catch {
+                        if (cancelled) return;
+                        // PAR unavailable (older server) or the request is invalid.
+                        // Fall back to the legacy full-URL redirect; validation
+                        // errors resurface via authorize after login.
+                        goSignIn();
+                    }
                     return;
                 }
 
@@ -130,26 +261,7 @@
                         resource: params.get('resource') ?? undefined
                     });
                     if (cancelled) return;
-                    if (result.redirectUrl) {
-                        // Already consented — go straight back to the client.
-                        window.location.href = result.redirectUrl;
-                        if (!isWebRedirect(result.redirectUrl)) {
-                            completedRedirectUrl = result.redirectUrl;
-                            account = loggedInAccount;
-                            app = await sdk.forConsole.apps
-                                .get({ appId: clientId })
-                                .catch(() => null);
-                            if (cancelled) return;
-                            phase = 'approved';
-                        }
-                        return;
-                    }
-                    if (result.grantId) {
-                        await loadConsent(result.grantId, loggedInAccount);
-                        return;
-                    }
-                    error = 'Could not start authorization.';
-                    phase = 'error';
+                    await handleAuthorizeResult(result, loggedInAccount, clientId, false);
                 } catch (e: unknown) {
                     if (cancelled) return;
                     error = (e as Error)?.message ?? 'Could not start authorization.';

--- a/src/routes/(public)/oauth2/errors.ts
+++ b/src/routes/(public)/oauth2/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Exception `type` values returned by the OAuth2 endpoints. The SDK does not
+ * export these, so they are mirrored here.
+ */
+export const OAuth2ErrorType = {
+    /**
+     * Covers every dead request_uri handle case (expired, consumed, malformed).
+     */
+    INVALID_REQUEST: 'oauth2_invalid_request'
+} as const;
+
+export const OAuth2ErrorMessage = {
+    AUTHORIZE_FAILED: 'Could not start authorization.',
+    GRANT_INVALID: 'This authorization request is invalid or has expired.',
+    HANDLE_EXPIRED:
+        'This sign-in request has expired. Return to the application and try connecting again.',
+    MISSING_REQUEST: 'Missing authorization request. Open this page from an application sign-in.'
+} as const;


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub-login breakage for OAuth2/MCP clients by resuming authorization requests through **RFC 9126 Pushed Authorization Request (PAR)** handles instead of round-tripping the full consent URL through login.

### The problem

When an MCP client (or any OAuth2 client) sends a user to `/console/oauth2/consent` and the user has no session, the consent page redirects to `/login?redirect=<full consent URL>`. That URL carries the entire authorize request — `scope` (up to 8 KB), `authorization_details`, a client `state` of up to 2 KB, and PKCE params. When the user clicks **Sign in with GitHub**, the whole thing is embedded in the OAuth `success` URL, which the backend round-trips through GitHub's OAuth `state` — and GitHub caps state size, so the login dies or comes back truncated.

### The fix

Pairs with appwrite-labs/cloud#4660, which adds `POST /v1/oauth2/{projectId}/par`:

1. **Pre-login push** — the consent page pushes the raw authorize request server-side via `oauth2.createPAR(...)` and redirects to login with only `client_id` + `request_uri`. In the verified E2E run a **2,276-char** consent URL became a **182-char** login URL — that compact URL is what travels through GitHub's `state`.
2. **Post-login resume** — a new `request_uri` branch on the consent page verifies the session first, then calls `authorize({ clientId, requestUri })` with nothing else (the server rejects any other param alongside the handle, and consumes the single-use handle even on failing calls — so it is never dereferenced while logged out).
3. **Reload safety** — once authorize returns a grant, the URL is rewritten to `?grant_id=…` with `replaceState`, so refresh/back-forward resumes via `getGrant` instead of failing on the consumed handle.
4. **Graceful degradation** — if `createPAR` fails (older or self-hosted servers without the endpoint), the page falls back to the legacy full-URL redirect, so nothing regresses.
5. **Friendly expiry** — expired/consumed handles (600 s TTL) render "This sign-in request has expired. Return to the application and try connecting again."

### Implementation notes

- **Anonymous client for PAR**: the server serves `/par` (like `/token`) with wildcard CORS and credentials disabled — per RFC 9126 any client may push without platform registration. The console SDK defaults to credentialed fetches, which the browser rejects against that posture, so `createPAR` goes through a one-off `new Client().setCredentials('omit')`. The endpoint needs no session anyway.
- **Effect keyed on the query string** (`$derived`): after email login, `goto(redirect)` is followed by `invalidate(Dependencies.ACCOUNT)`, which replaces the `page.url` *object* without changing the query. An effect tracking `page.url` directly re-runs on that identity change, cancelling the in-flight (successful!) authorize and re-dereferencing the consumed single-use handle. Deriveds only propagate on value change, which makes the flow immune to this. Caught live during E2E verification.
- `resource` params are now forwarded with `params.getAll` (RFC 8707 repeats the key; the old code silently dropped all but the first value).
- SDK pinned to the **preview build** of the cloud PR (`pkg.vc @4b3ae78`, generated via the *Cloud Console SDK Preview* workflow dispatch). ⚠️ Re-pin to the regular build after appwrite-labs/cloud#4660 merges. That spec also renamed `Models.Locale` → `Models.CloudLocale`; the seven usages are updated here.

### Flow

```
MCP client ──authorize──▶ cloud /authorize ──302──▶ /console/oauth2/consent?client_id&scope&state&…   (huge)
                                                        │  no session
                                                        ▼
                                              oauth2.createPAR(…)  ──▶  request_uri (urn:…, 600s, single-use)
                                                        │
                                                        ▼
                              /login?redirect=/console/oauth2/consent?client_id&request_uri   (~182 chars)
                                                        │  GitHub OAuth round trip fits in state
                                                        ▼
                                    authorize({clientId, requestUri}) ──▶ grant ──▶ ?grant_id=… (replaceState)
                                                        │
                                                        ▼
                                     consent card ──approve──▶ redirect_uri?code&state (state byte-identical)
```

## Screenshots

**1. Post-PAR login redirect — the resume URL is 182 chars (was 2,276) and carries only `client_id` + `request_uri`:**

![login with compact redirect](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/par-1-login-compact-redirect-8ce5938f.png)

**2. Consent card fully rehydrated from the pushed request after login (scopes, RAR resource selectors — URL already rewritten to `?grant_id=…`):**

![consent card](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/par-2-consent-card-6af745cc.png)

**3. Consumed/expired handle — friendly retry message:**

![expired handle error](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/par-3-expired-handle-error-9ceebe86.png)

## Test plan

Verified E2E with Playwright against a local cloud stack running the PR branch (public PKCE app, MCP-style request: 6 scopes + RAR `authorization_details` + 1,790-char `state`):

- ✅ Logged-out fat URL → PAR push → **182-char** login redirect containing `request_uri`
- ✅ Email login → handle dereferenced once → consent card renders the full rehydrated request
- ✅ URL rewritten to `?grant_id=…`; page reload still renders the consent card
- ✅ Approve → callback receives `code` + **byte-identical** 1,790-char `state`
- ✅ Token exchange with the PKCE verifier pushed via PAR returns access/refresh/id tokens with correct `scope` + `authorization_details`
- ✅ Re-using the consumed `request_uri` → friendly error card
- ✅ Already-approved identity: post-login `authorize({clientId, requestUri})` returns `redirectUrl` directly (skip-consent path) and lands on the callback
- ✅ `bun run format` / `check` (0 errors) / `lint` (0 errors) / `test:unit` (235 passed) / `build`

## Related

- Depends on appwrite-labs/cloud#4660 (endpoint + SDK). Draft until that merges and the SDK pin is updated.
- Cloud-side follow-up raised during review: the server's unauthenticated consent redirect still expands a `request_uri` back into full params and consumes the handle, so PAR-native clients hit the console with long URLs and a dead handle, and the console re-pushes. Passing `client_id` + `request_uri` through unconsumed would let this page skip the re-push entirely.
