### PR TITLE
fix(databases): remove Usage tab from collection header

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/header.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/header.svelte
@@ -28,12 +28,6 @@
                 event: 'indexes'
             },
             {
-                href: `${path}/usage`,
-                title: 'Usage',
-                event: 'usage',
-                hasChildren: true
-            },
-            {
                 href: `${path}/settings`,
                 title: 'Settings',
                 event: 'settings',


### PR DESCRIPTION
## What

Removes the `Usage` navigation tab from the DocumentsDB collection header (`collection-[collection]/header.svelte`).

## Why

Follow-up to **#3111**, which deleted the collection `usage/` route and its command-center shortcut but missed the header tab. As Greptile flagged on that PR, the header still rendered a `Usage` tab linking to `${path}/usage` — the now-deleted route — so it would **404 for every collection page** reachable by `multi-db` users.

## Scope

Single file: removes the one tab entry from the `tabs` array. Documents / Indexes / Settings tabs unchanged.

## Verification

`bun run check` → **0 errors** (88 pre-existing warnings unchanged). Prettier + ESLint clean.