### PR TITLE
fix(databases): correct enum icon and hide indexed checkbox for relationships

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(entity)/views/indexes/create.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(entity)/views/indexes/create.svelte
@@ -57,7 +57,11 @@
             .map((field) => ({
                 value: field.key,
                 label: field.key,
-                leadingIcon: baseColumnOptions.find((option) => option.type === field.type)?.icon
+                leadingIcon: baseColumnOptions.find(
+                    (option) =>
+                        option.type === field.type &&
+                        option.format === ('format' in field ? field.format : undefined)
+                )?.icon
             }))
     );
 

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(entity)/views/indexes/create.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/(entity)/views/indexes/create.svelte
@@ -60,7 +60,8 @@
                 leadingIcon: baseColumnOptions.find(
                     (option) =>
                         option.type === field.type &&
-                        option.format === ('format' in field ? field.format : undefined)
+                        option.format ===
+                            ('format' in field && field.format ? field.format : undefined)
                 )?.icon
             }))
     );

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/+page.svelte
@@ -515,26 +515,30 @@
                         {columnType.toLowerCase()}
                     </Spreadsheet.Cell>
                     <Spreadsheet.Cell column="indexed" {root} isEditable={false}>
-                        <!-- $id is always indexed internally -->
-                        {@const isActuallyIndexed =
-                            isId || $indexes.some((index) => index.columns.includes(column.key))}
+                        {#if !isRelationship(column)}
+                            <!-- $id is always indexed internally -->
+                            {@const isActuallyIndexed =
+                                isId ||
+                                $indexes.some((index) => index.columns.includes(column.key))}
 
-                        <!-- $id is always indexed internally -->
-                        {@const checked = isId || isActuallyIndexed || !!columnIndexMap[column.key]}
+                            <!-- $id is always indexed internally -->
+                            {@const checked =
+                                isId || isActuallyIndexed || !!columnIndexMap[column.key]}
 
-                        <Selector.Checkbox
-                            size="s"
-                            {checked}
-                            disabled={isActuallyIndexed}
-                            on:change={(e) => {
-                                if (!isActuallyIndexed) {
-                                    if (e.detail) {
-                                        columnIndexMap[column.key] = true;
-                                        $showCreateIndexSheet.show = true;
-                                        $showCreateIndexSheet.column = column.key;
+                            <Selector.Checkbox
+                                size="s"
+                                {checked}
+                                disabled={isActuallyIndexed}
+                                on:change={(e) => {
+                                    if (!isActuallyIndexed) {
+                                        if (e.detail) {
+                                            columnIndexMap[column.key] = true;
+                                            $showCreateIndexSheet.show = true;
+                                            $showCreateIndexSheet.column = column.key;
+                                        }
                                     }
-                                }
-                            }} />
+                                }} />
+                        {/if}
                     </Spreadsheet.Cell>
                     <Spreadsheet.Cell column="default" {root} isEditable={false}>
                         {@const _default = column.required


### PR DESCRIPTION
## Summary
- Fix wrong icon shown for `enum` columns in the create-index field selector — the lookup matched by `type` only, and since email/ip/url/enum/string columns all share `type: 'string'`, it always resolved to the first match (Email's mail icon) instead of the enum-specific icon.
- Hide the "Indexed" checkbox for relationship columns in the columns table, since relationship columns cannot be indexed (consistent with existing filtering in the create-index field list and the "Create index" action menu item).

## Test plan
- [ ] Open a table with an `enum` column, start "Create index", confirm the field selector shows the correct enum icon
- [ ] Open a table with a relationship column, confirm the "Indexed" checkbox no longer appears for that column in the columns list
- [ ] `bun run check` / `bun run lint` pass for the touched files