### PR TITLE
feat: permanent console user deletion for self-hosted (#11393)

### DIFF
--- a/src/lib/actions/analytics.ts
+++ b/src/lib/actions/analytics.ts
@@ -262,6 +262,7 @@ export enum Submit {
     ProjectResume = 'submit_project_resume',
     MemberCreate = 'submit_member_create',
     MemberDelete = 'submit_member_delete',
+    ConsoleUserDelete = 'submit_console_user_delete',
     MembershipUpdate = 'submit_membership_update',
     MembershipUpdateStatus = 'submit_membership_update_status',
     MessagingTargetUpdate = 'submit_messaging_target_update',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,6 +31,7 @@ export enum Dependencies {
     PAYMENT_METHODS = 'dependency:paymentMethods',
     ORGANIZATION = 'dependency:organization',
     MEMBERS = 'dependency:members',
+    CONSOLE_USERS = 'dependency:console_users',
     PROJECT = 'dependency:project',
     PROJECT_VARIABLES = 'dependency:project_variables',
     PROJECT_INSTALLATIONS = 'dependency:project_installations',

--- a/src/lib/helpers/consoleUsers.test.ts
+++ b/src/lib/helpers/consoleUsers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+    canPermanentlyDeleteConsoleUser,
+    resolveConsoleUserDeletionMode
+} from './consoleUsers';
+
+describe('canPermanentlyDeleteConsoleUser', () => {
+    it('allows permanent delete on self-hosted for another user', () => {
+        expect(
+            canPermanentlyDeleteConsoleUser({
+                isSelfHosted: true,
+                actorUserId: 'root',
+                targetUserId: 'shadow'
+            })
+        ).toBe(true);
+    });
+
+    it('blocks permanent delete on cloud', () => {
+        expect(
+            canPermanentlyDeleteConsoleUser({
+                isSelfHosted: false,
+                actorUserId: 'root',
+                targetUserId: 'shadow'
+            })
+        ).toBe(false);
+    });
+
+    it('blocks deleting yourself', () => {
+        expect(
+            canPermanentlyDeleteConsoleUser({
+                isSelfHosted: true,
+                actorUserId: 'root',
+                targetUserId: 'root'
+            })
+        ).toBe(false);
+    });
+
+    it('blocks when target user id is missing', () => {
+        expect(
+            canPermanentlyDeleteConsoleUser({
+                isSelfHosted: true,
+                actorUserId: 'root',
+                targetUserId: null
+            })
+        ).toBe(false);
+    });
+
+    it('blocks when actor user id is missing (fail closed)', () => {
+        expect(
+            canPermanentlyDeleteConsoleUser({
+                isSelfHosted: true,
+                actorUserId: undefined,
+                targetUserId: 'shadow'
+            })
+        ).toBe(false);
+    });
+});
+
+describe('resolveConsoleUserDeletionMode', () => {
+    it('returns permanent only when requested and allowed', () => {
+        expect(
+            resolveConsoleUserDeletionMode({
+                permanentlyDeleteRequested: true,
+                canPermanentlyDelete: true
+            })
+        ).toBe('permanent');
+    });
+
+    it('falls back to membership_only when not allowed', () => {
+        expect(
+            resolveConsoleUserDeletionMode({
+                permanentlyDeleteRequested: true,
+                canPermanentlyDelete: false
+            })
+        ).toBe('membership_only');
+    });
+
+    it('falls back to membership_only when not requested', () => {
+        expect(
+            resolveConsoleUserDeletionMode({
+                permanentlyDeleteRequested: false,
+                canPermanentlyDelete: true
+            })
+        ).toBe('membership_only');
+    });
+});

--- a/src/lib/helpers/consoleUsers.ts
+++ b/src/lib/helpers/consoleUsers.ts
@@ -1,0 +1,53 @@
+/**
+ * Helpers for self-hosted console (platform) user management.
+ *
+ * Console accounts live in the special `console` project. Organization owners
+ * can manage them via the Users API when the request includes an organization
+ * context (X-Appwrite-Organization). Permanent deletion is intentionally only
+ * surfaced in the self-hosted console UI.
+ */
+
+export type ConsoleUserDeletionMode = 'membership_only' | 'permanent';
+
+/**
+ * Decide whether permanent console-account deletion is allowed for the current
+ * actor and target membership.
+ *
+ * Fail closed: missing actor id, missing target id, or non-self-hosted → false.
+ */
+export function canPermanentlyDeleteConsoleUser(params: {
+    isSelfHosted: boolean;
+    actorUserId?: string | null;
+    targetUserId?: string | null;
+}): boolean {
+    const { isSelfHosted, actorUserId, targetUserId } = params;
+
+    if (!isSelfHosted) {
+        return false;
+    }
+
+    if (!targetUserId || !actorUserId) {
+        return false;
+    }
+
+    // Never allow deleting your own account from the org/member management UI.
+    if (actorUserId === targetUserId) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Resolve the effective deletion mode from UI state.
+ */
+export function resolveConsoleUserDeletionMode(params: {
+    permanentlyDeleteRequested: boolean;
+    canPermanentlyDelete: boolean;
+}): ConsoleUserDeletionMode {
+    if (params.permanentlyDeleteRequested && params.canPermanentlyDelete) {
+        return 'permanent';
+    }
+
+    return 'membership_only';
+}

--- a/src/lib/stores/sdk.ts
+++ b/src/lib/stores/sdk.ts
@@ -181,6 +181,24 @@ export const sdk = {
         return createConsoleSdk(scopedConsoleClient);
     },
 
+    /**
+     * Console client scoped to an organization.
+     *
+     * The backend grants owner/admin scopes (including users.read / users.write)
+     * on the console project only when an organization context is present.
+     * Use this for platform-level user management on self-hosted instances.
+     */
+    forConsoleInOrganization(organizationId: string) {
+        const organizationClient = new Client();
+        organizationClient.setEndpoint(clientConsole.config.endpoint);
+        organizationClient.setProject('console');
+        Object.assign(organizationClient.headers, clientConsole.getHeaders(), {
+            'X-Appwrite-Organization': organizationId
+        });
+
+        return createConsoleSdk(organizationClient);
+    },
+
     forProject(region: string, projectId: string) {
         const endpoint = getApiEndpoint(region);
         if (endpoint !== clientProject.config.endpoint) {

--- a/src/lib/stores/sdk.ts
+++ b/src/lib/stores/sdk.ts
@@ -88,12 +88,15 @@ const endpoint = getApiEndpoint();
 const clientConsole = new Client();
 const clientConsoleOperator = new Client();
 const scopedConsoleClient = new Client();
+/** Reused client for org-scoped console Users API (platform user management). */
+const organizationScopedConsoleClient = new Client();
 
 const clientProject = new Client();
 const clientRealtime = new Client();
 
 if (!building) {
     scopedConsoleClient.setProject('console');
+    organizationScopedConsoleClient.setProject('console');
     clientConsole.setEndpoint(endpoint).setProject('console');
     clientConsoleOperator.setEndpoint(endpoint).setProject('console');
 
@@ -103,6 +106,7 @@ if (!building) {
     registerImpersonationClients([
         clientConsole,
         scopedConsoleClient,
+        organizationScopedConsoleClient,
         clientProject,
         clientRealtime
     ]);
@@ -182,21 +186,29 @@ export const sdk = {
     },
 
     /**
-     * Console client scoped to an organization.
+     * Users service scoped to an organization on the console project.
      *
      * The backend grants owner/admin scopes (including users.read / users.write)
-     * on the console project only when an organization context is present.
-     * Use this for platform-level user management on self-hosted instances.
+     * only when an organization context is present. Returns a narrow Users
+     * instance (not a full SDK) and reuses one Client, updating the org header
+     * when the organization changes — same pattern as `organization()`.
      */
-    forConsoleInOrganization(organizationId: string) {
-        const organizationClient = new Client();
-        organizationClient.setEndpoint(clientConsole.config.endpoint);
-        organizationClient.setProject('console');
-        Object.assign(organizationClient.headers, clientConsole.getHeaders(), {
+    forConsoleUsersInOrganization(organizationId: string) {
+        if (
+            !organizationScopedConsoleClient.config.endpoint ||
+            organizationScopedConsoleClient.config.endpoint !== clientConsole.config.endpoint
+        ) {
+            organizationScopedConsoleClient.setEndpoint(clientConsole.config.endpoint);
+        }
+        if (organizationScopedConsoleClient.config.project !== 'console') {
+            organizationScopedConsoleClient.setProject('console');
+        }
+
+        Object.assign(organizationScopedConsoleClient.headers, clientConsole.getHeaders(), {
             'X-Appwrite-Organization': organizationId
         });
 
-        return createConsoleSdk(organizationClient);
+        return new Users(organizationScopedConsoleClient);
     },
 
     forProject(region: string, projectId: string) {

--- a/src/lib/stores/sdk.ts
+++ b/src/lib/stores/sdk.ts
@@ -88,15 +88,11 @@ const endpoint = getApiEndpoint();
 const clientConsole = new Client();
 const clientConsoleOperator = new Client();
 const scopedConsoleClient = new Client();
-/** Reused client for org-scoped console Users API (platform user management). */
-const organizationScopedConsoleClient = new Client();
-
 const clientProject = new Client();
 const clientRealtime = new Client();
 
 if (!building) {
     scopedConsoleClient.setProject('console');
-    organizationScopedConsoleClient.setProject('console');
     clientConsole.setEndpoint(endpoint).setProject('console');
     clientConsoleOperator.setEndpoint(endpoint).setProject('console');
 
@@ -106,7 +102,6 @@ if (!building) {
     registerImpersonationClients([
         clientConsole,
         scopedConsoleClient,
-        organizationScopedConsoleClient,
         clientProject,
         clientRealtime
     ]);
@@ -188,27 +183,20 @@ export const sdk = {
     /**
      * Users service scoped to an organization on the console project.
      *
-     * The backend grants owner/admin scopes (including users.read / users.write)
-     * only when an organization context is present. Returns a narrow Users
-     * instance (not a full SDK) and reuses one Client, updating the org header
-     * when the organization changes — same pattern as `organization()`.
+     * Builds a fresh Client per call (same pattern as `organization()`) so auth
+     * headers always mirror the current console session / impersonation state,
+     * then stamps `X-Appwrite-Organization` for users.read/write scopes.
+     * Returns a narrow Users instance only — not a full console SDK.
      */
     forConsoleUsersInOrganization(organizationId: string) {
-        if (
-            !organizationScopedConsoleClient.config.endpoint ||
-            organizationScopedConsoleClient.config.endpoint !== clientConsole.config.endpoint
-        ) {
-            organizationScopedConsoleClient.setEndpoint(clientConsole.config.endpoint);
-        }
-        if (organizationScopedConsoleClient.config.project !== 'console') {
-            organizationScopedConsoleClient.setProject('console');
-        }
-
-        Object.assign(organizationScopedConsoleClient.headers, clientConsole.getHeaders(), {
+        const organizationClient = new Client();
+        organizationClient.setEndpoint(clientConsole.config.endpoint || getApiEndpoint());
+        organizationClient.setProject('console');
+        Object.assign(organizationClient.headers, clientConsole.getHeaders(), {
             'X-Appwrite-Organization': organizationId
         });
 
-        return new Users(organizationScopedConsoleClient);
+        return new Users(organizationClient);
     },
 
     forProject(region: string, projectId: string) {

--- a/src/routes/(console)/organization-[organization]/deleteMember.svelte
+++ b/src/routes/(console)/organization-[organization]/deleteMember.svelte
@@ -8,10 +8,16 @@
     import { Submit, trackEvent, trackError } from '$lib/actions/analytics';
     import { Dependencies } from '$lib/constants';
     import { checkForUsageLimit } from '$lib/stores/billing';
-    import { isCloud } from '$lib/system';
+    import { isCloud, isSelfHosted } from '$lib/system';
     import { organization } from '$lib/stores/organization';
     import { logout } from '$lib/helpers/logout';
     import Confirm from '$lib/components/confirm.svelte';
+    import { InputCheckbox } from '$lib/elements/forms';
+    import { Layout, Typography } from '@appwrite.io/pink-svelte';
+    import {
+        canPermanentlyDeleteConsoleUser,
+        resolveConsoleUserDeletionMode
+    } from '$lib/helpers/consoleUsers';
 
     const dispatch = createEventDispatcher();
 
@@ -19,13 +25,39 @@
     export let selectedMember: Models.Membership;
 
     let error: string;
+    let permanentlyDelete = false;
+
+    $: isUser = selectedMember?.userId === $user?.$id;
+    $: canPermanentlyDelete = canPermanentlyDeleteConsoleUser({
+        isSelfHosted,
+        actorUserId: $user?.$id,
+        targetUserId: selectedMember?.userId
+    });
+    $: deletionMode = resolveConsoleUserDeletionMode({
+        permanentlyDeleteRequested: permanentlyDelete,
+        canPermanentlyDelete
+    });
+    $: if (showDelete) {
+        permanentlyDelete = false;
+        error = null;
+    }
 
     const deleteMembership = async () => {
         try {
-            await sdk.forConsole.teams.deleteMembership({
-                teamId: selectedMember.teamId,
-                membershipId: selectedMember.$id
-            });
+            if (deletionMode === 'permanent') {
+                // Permanent system-wide account deletion (self-hosted only).
+                // Single Users API call — the deletes worker cleans memberships.
+                // Do NOT delete membership first: a partial failure would leave a
+                // shadow account and make retries fail on the already-removed membership.
+                await sdk.forConsoleInOrganization(selectedMember.teamId).users.delete({
+                    userId: selectedMember.userId
+                });
+            } else {
+                await sdk.forConsole.teams.deleteMembership({
+                    teamId: selectedMember.teamId,
+                    membershipId: selectedMember.$id
+                });
+            }
 
             if (isUser) {
                 logout();
@@ -33,34 +65,78 @@
                 dispatch('deleted');
             }
 
-            await Promise.all([invalidate(Dependencies.ACCOUNT), invalidate(Dependencies.MEMBERS)]);
+            await Promise.all([
+                invalidate(Dependencies.ACCOUNT),
+                invalidate(Dependencies.MEMBERS),
+                invalidate(Dependencies.CONSOLE_USERS)
+            ]);
 
             if (isCloud && $organization) {
                 await checkForUsageLimit($organization);
             }
             showDelete = false;
-            addNotification({
-                type: 'success',
-                message: `${selectedMember.userName || 'User'} was deleted from ${selectedMember.teamName}`
-            });
-            trackEvent(Submit.MemberDelete);
+
+            if (deletionMode === 'permanent') {
+                addNotification({
+                    type: 'success',
+                    message: `${selectedMember.userName || selectedMember.userEmail || 'User'} was permanently deleted from the system`
+                });
+                trackEvent(Submit.ConsoleUserDelete);
+            } else {
+                addNotification({
+                    type: 'success',
+                    message: `${selectedMember.userName || 'User'} was deleted from ${selectedMember.teamName}`
+                });
+                trackEvent(Submit.MemberDelete);
+            }
         } catch (e) {
             error = e.message;
-            trackError(e, Submit.MemberDelete);
+            trackError(
+                e,
+                deletionMode === 'permanent' ? Submit.ConsoleUserDelete : Submit.MemberDelete
+            );
         }
     };
-
-    $: isUser = selectedMember?.userId === $user?.$id;
 </script>
 
 <Confirm
     onSubmit={deleteMembership}
     submissionLoader
-    title={isUser ? 'Leave organization' : 'Delete member'}
+    title={isUser
+        ? 'Leave organization'
+        : deletionMode === 'permanent'
+          ? 'Delete account permanently'
+          : 'Delete member'}
     bind:open={showDelete}
-    action={isUser ? 'Leave' : 'Delete'}
+    action={isUser ? 'Leave' : deletionMode === 'permanent' ? 'Delete permanently' : 'Delete'}
+    confirmDeletion={deletionMode === 'permanent'}
+    confirmDeletionLabel="I understand this permanently deletes the account from the entire system"
     bind:error>
-    {isUser
-        ? `Are you sure you want to leave '${selectedMember?.teamName}'?`
-        : `Are you sure you want to delete ${selectedMember?.userName} from '${selectedMember?.teamName}'?`}
+    <Layout.Stack gap="m">
+        {#if isUser}
+            <Typography.Text>
+                Are you sure you want to leave '{selectedMember?.teamName}'?
+            </Typography.Text>
+        {:else}
+            <Typography.Text>
+                Are you sure you want to remove
+                <b>{selectedMember?.userName || selectedMember?.userEmail || 'this user'}</b>
+                from '{selectedMember?.teamName}'?
+            </Typography.Text>
+            {#if canPermanentlyDelete}
+                <InputCheckbox
+                    size="s"
+                    id="permanently_delete_console_user"
+                    bind:checked={permanentlyDelete}
+                    label="Also permanently delete their account from the entire system" />
+                {#if permanentlyDelete}
+                    <Typography.Text>
+                        This removes the account system-wide — not just from this organization. They
+                        will no longer be able to sign in or create organizations. This action cannot
+                        be undone.
+                    </Typography.Text>
+                {/if}
+            {/if}
+        {/if}
+    </Layout.Stack>
 </Confirm>

--- a/src/routes/(console)/organization-[organization]/deleteMember.svelte
+++ b/src/routes/(console)/organization-[organization]/deleteMember.svelte
@@ -3,7 +3,6 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import type { Models } from '@appwrite.io/console';
-    import { createEventDispatcher } from 'svelte';
     import { user } from '$lib/stores/user';
     import { Submit, trackEvent, trackError } from '$lib/actions/analytics';
     import { Dependencies } from '$lib/constants';
@@ -19,28 +18,40 @@
         resolveConsoleUserDeletionMode
     } from '$lib/helpers/consoleUsers';
 
-    const dispatch = createEventDispatcher();
+    let {
+        showDelete = $bindable(false),
+        selectedMember = undefined,
+        ondeleted
+    }: {
+        showDelete?: boolean;
+        selectedMember?: Models.Membership;
+        ondeleted?: () => void;
+    } = $props();
 
-    export let showDelete = false;
-    export let selectedMember: Models.Membership;
+    let error = $state<string>(null);
+    let permanentlyDelete = $state(false);
 
-    let error: string;
-    let permanentlyDelete = false;
+    const isUser = $derived(selectedMember?.userId === $user?.$id);
+    const canPermanentlyDelete = $derived(
+        canPermanentlyDeleteConsoleUser({
+            isSelfHosted,
+            actorUserId: $user?.$id,
+            targetUserId: selectedMember?.userId
+        })
+    );
+    const deletionMode = $derived(
+        resolveConsoleUserDeletionMode({
+            permanentlyDeleteRequested: permanentlyDelete,
+            canPermanentlyDelete
+        })
+    );
 
-    $: isUser = selectedMember?.userId === $user?.$id;
-    $: canPermanentlyDelete = canPermanentlyDeleteConsoleUser({
-        isSelfHosted,
-        actorUserId: $user?.$id,
-        targetUserId: selectedMember?.userId
+    $effect(() => {
+        if (showDelete) {
+            permanentlyDelete = false;
+            error = null;
+        }
     });
-    $: deletionMode = resolveConsoleUserDeletionMode({
-        permanentlyDeleteRequested: permanentlyDelete,
-        canPermanentlyDelete
-    });
-    $: if (showDelete) {
-        permanentlyDelete = false;
-        error = null;
-    }
 
     const deleteMembership = async () => {
         try {
@@ -49,7 +60,7 @@
                 // Single Users API call — the deletes worker cleans memberships.
                 // Do NOT delete membership first: a partial failure would leave a
                 // shadow account and make retries fail on the already-removed membership.
-                await sdk.forConsoleInOrganization(selectedMember.teamId).users.delete({
+                await sdk.forConsoleUsersInOrganization(selectedMember.teamId).delete({
                     userId: selectedMember.userId
                 });
             } else {
@@ -62,7 +73,7 @@
             if (isUser) {
                 logout();
             } else {
-                dispatch('deleted');
+                ondeleted?.();
             }
 
             await Promise.all([

--- a/src/routes/(console)/organization-[organization]/header.svelte
+++ b/src/routes/(console)/organization-[organization]/header.svelte
@@ -20,7 +20,7 @@
         isBilling,
         isOwner
     } from '$lib/stores/roles';
-    import { GRACE_PERIOD_OVERRIDE, isCloud } from '$lib/system';
+    import { GRACE_PERIOD_OVERRIDE, isCloud, isSelfHosted } from '$lib/system';
     import { IconPlus, IconPlusSm } from '@appwrite.io/pink-icons-svelte';
     import { Badge, Icon, Layout, Tooltip, Typography } from '@appwrite.io/pink-svelte';
     import { BillingPlanGroup, type Models } from '@appwrite.io/console';
@@ -66,6 +66,14 @@
                 event: 'members',
                 hasChildren: true,
                 disabled: !$canSeeTeams
+            },
+            {
+                href: `${path}/platform-users`,
+                title: 'Platform users',
+                event: 'platform_users',
+                hasChildren: true,
+                // Self-hosted only: list/delete every console account on the instance.
+                disabled: !(isSelfHosted && $isOwner)
             },
             {
                 href: `${path}/usage`,

--- a/src/routes/(console)/organization-[organization]/platform-users/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/platform-users/+page.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+    import { AvatarInitials, PaginationWithLimit, SearchQuery } from '$lib/components';
+    import { Container } from '$lib/layout';
+    import DualTimeView from '$lib/components/dualTimeView.svelte';
+    import type { Models } from '@appwrite.io/console';
+    import DeleteConsoleUser from './deleteConsoleUser.svelte';
+    import { isOwner } from '$lib/stores/roles';
+    import { user } from '$lib/stores/user';
+    import { IconDotsHorizontal, IconTrash } from '@appwrite.io/pink-icons-svelte';
+    import {
+        Layout,
+        Table,
+        Badge,
+        Button,
+        Icon,
+        Typography,
+        Popover,
+        ActionMenu
+    } from '@appwrite.io/pink-svelte';
+
+    export let data;
+
+    let selectedUser: Models.User<Record<string, unknown>> | null = null;
+    let showDelete = false;
+</script>
+
+<Container>
+    <Layout.Stack gap="l">
+        <Layout.Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Layout.Stack gap="xxs">
+                <Typography.Title>Platform users</Typography.Title>
+                <Typography.Text>
+                    Manage all console accounts on this self-hosted instance. Permanently deleting a
+                    user removes their account system-wide — not only from a single organization.
+                </Typography.Text>
+            </Layout.Stack>
+            <SearchQuery placeholder="Search by name, email, phone, or ID" />
+        </Layout.Stack>
+
+        {#if data.users.total}
+            <Table.Root
+                let:root
+                columns={[
+                    { id: 'name', width: { min: 200 } },
+                    { id: 'email', width: { min: 220 } },
+                    { id: 'status', width: { min: 100 } },
+                    { id: 'created', width: { min: 140 } },
+                    { id: 'actions', hide: !$isOwner, width: 40 }
+                ]}>
+                <svelte:fragment slot="header" let:root>
+                    <Table.Header.Cell column="name" {root}>Name</Table.Header.Cell>
+                    <Table.Header.Cell column="email" {root}>Email</Table.Header.Cell>
+                    <Table.Header.Cell column="status" {root}>Status</Table.Header.Cell>
+                    <Table.Header.Cell column="created" {root}>Created</Table.Header.Cell>
+                    <Table.Header.Cell column="actions" {root} />
+                </svelte:fragment>
+                {#each data.users.users as consoleUser (consoleUser.$id)}
+                    <Table.Row.Base {root}>
+                        <Table.Cell column="name" {root}>
+                            <Layout.Stack direction="row" alignItems="center" gap="s">
+                                <AvatarInitials size="xs" name={consoleUser.name || consoleUser.email} />
+                                <Layout.Stack direction="row" alignItems="center" gap="s">
+                                    <Typography.Text truncate>
+                                        {consoleUser.name || 'n/a'}
+                                    </Typography.Text>
+                                    {#if consoleUser.$id === $user?.$id}
+                                        <Badge size="xs" variant="secondary" content="You" />
+                                    {/if}
+                                </Layout.Stack>
+                            </Layout.Stack>
+                        </Table.Cell>
+                        <Table.Cell column="email" {root}>
+                            <Typography.Text truncate>{consoleUser.email || '—'}</Typography.Text>
+                        </Table.Cell>
+                        <Table.Cell column="status" {root}>
+                            <Badge
+                                size="xs"
+                                type={consoleUser.status ? 'success' : 'error'}
+                                variant="secondary"
+                                content={consoleUser.status ? 'Enabled' : 'Disabled'} />
+                        </Table.Cell>
+                        <Table.Cell column="created" {root}>
+                            <DualTimeView time={consoleUser.$createdAt} />
+                        </Table.Cell>
+                        <Table.Cell column="actions" {root}>
+                            {#if $isOwner && consoleUser.$id !== $user?.$id}
+                                <Popover let:toggle padding="none" placement="bottom-end">
+                                    <Button.Button icon variant="ghost" size="s" on:click={toggle}>
+                                        <Icon size="s" icon={IconDotsHorizontal} />
+                                    </Button.Button>
+                                    <div style:min-width="232px" slot="tooltip">
+                                        <ActionMenu.Root>
+                                            <ActionMenu.Item.Button
+                                                trailingIcon={IconTrash}
+                                                on:click={() => {
+                                                    selectedUser = consoleUser;
+                                                    showDelete = true;
+                                                }}>
+                                                Delete permanently
+                                            </ActionMenu.Item.Button>
+                                        </ActionMenu.Root>
+                                    </div>
+                                </Popover>
+                            {/if}
+                        </Table.Cell>
+                    </Table.Row.Base>
+                {/each}
+            </Table.Root>
+
+            <PaginationWithLimit
+                name="Users"
+                limit={data.limit}
+                offset={data.offset}
+                total={data.users.total} />
+        {:else if data.search}
+            <Typography.Text>
+                No platform users found matching "{data.search}".
+            </Typography.Text>
+        {:else}
+            <Typography.Text>No platform users found.</Typography.Text>
+        {/if}
+    </Layout.Stack>
+</Container>
+
+<DeleteConsoleUser {selectedUser} bind:showDelete />

--- a/src/routes/(console)/organization-[organization]/platform-users/+page.svelte
+++ b/src/routes/(console)/organization-[organization]/platform-users/+page.svelte
@@ -17,11 +17,12 @@
         Popover,
         ActionMenu
     } from '@appwrite.io/pink-svelte';
+    import type { PageProps } from './$types';
 
-    export let data;
+    let { data }: PageProps = $props();
 
-    let selectedUser: Models.User<Record<string, unknown>> | null = null;
-    let showDelete = false;
+    let selectedUser = $state<Models.User<Record<string, unknown>> | null>(null);
+    let showDelete = $state(false);
 </script>
 
 <Container>
@@ -58,7 +59,9 @@
                     <Table.Row.Base {root}>
                         <Table.Cell column="name" {root}>
                             <Layout.Stack direction="row" alignItems="center" gap="s">
-                                <AvatarInitials size="xs" name={consoleUser.name || consoleUser.email} />
+                                <AvatarInitials
+                                    size="xs"
+                                    name={consoleUser.name || consoleUser.email} />
                                 <Layout.Stack direction="row" alignItems="center" gap="s">
                                     <Typography.Text truncate>
                                         {consoleUser.name || 'n/a'}

--- a/src/routes/(console)/organization-[organization]/platform-users/+page.ts
+++ b/src/routes/(console)/organization-[organization]/platform-users/+page.ts
@@ -1,0 +1,40 @@
+import { Dependencies, PAGE_LIMIT } from '$lib/constants';
+import { getLimit, getPage, getSearch, pageToOffset } from '$lib/helpers/load';
+import { sdk } from '$lib/stores/sdk';
+import { isSelfHosted } from '$lib/system';
+import { Query } from '@appwrite.io/console';
+import { error, redirect } from '@sveltejs/kit';
+import { base } from '$app/paths';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ url, params, route, depends, parent }) => {
+    await parent();
+    depends(Dependencies.CONSOLE_USERS);
+
+    // Platform-wide console user management is self-hosted only.
+    // Cloud multi-tenancy must not expose cross-organization user listings.
+    if (!isSelfHosted) {
+        redirect(303, `${base}/organization-${params.organization}`);
+    }
+
+    const page = getPage(url);
+    const search = getSearch(url);
+    const limit = getLimit(url, route, PAGE_LIMIT);
+    const offset = pageToOffset(page, limit);
+
+    try {
+        const users = await sdk.forConsoleInOrganization(params.organization).users.list({
+            queries: [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')],
+            search: search || undefined
+        });
+
+        return {
+            offset,
+            limit,
+            search,
+            users
+        };
+    } catch (e) {
+        throw error(e?.code || 500, e?.message || 'Failed to load console users');
+    }
+};

--- a/src/routes/(console)/organization-[organization]/platform-users/+page.ts
+++ b/src/routes/(console)/organization-[organization]/platform-users/+page.ts
@@ -8,12 +8,15 @@ import { base } from '$app/paths';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url, params, route, depends, parent }) => {
-    await parent();
+    const parentData = await parent();
     depends(Dependencies.CONSOLE_USERS);
 
-    // Platform-wide console user management is self-hosted only.
+    const roles: string[] = parentData.roles ?? [];
+    const isOwner = roles.includes('owner');
+
+    // Platform-wide console user management is self-hosted + owner only.
     // Cloud multi-tenancy must not expose cross-organization user listings.
-    if (!isSelfHosted) {
+    if (!isSelfHosted || !isOwner) {
         redirect(303, `${base}/organization-${params.organization}`);
     }
 
@@ -23,7 +26,7 @@ export const load: PageLoad = async ({ url, params, route, depends, parent }) =>
     const offset = pageToOffset(page, limit);
 
     try {
-        const users = await sdk.forConsoleInOrganization(params.organization).users.list({
+        const users = await sdk.forConsoleUsersInOrganization(params.organization).list({
             queries: [Query.limit(limit), Query.offset(offset), Query.orderDesc('$createdAt')],
             search: search || undefined
         });

--- a/src/routes/(console)/organization-[organization]/platform-users/deleteConsoleUser.svelte
+++ b/src/routes/(console)/organization-[organization]/platform-users/deleteConsoleUser.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    import { invalidate } from '$app/navigation';
+    import { page } from '$app/state';
+    import { addNotification } from '$lib/stores/notifications';
+    import { sdk } from '$lib/stores/sdk';
+    import type { Models } from '@appwrite.io/console';
+    import { user } from '$lib/stores/user';
+    import { Submit, trackEvent, trackError } from '$lib/actions/analytics';
+    import { Dependencies } from '$lib/constants';
+    import Confirm from '$lib/components/confirm.svelte';
+    import { Typography } from '@appwrite.io/pink-svelte';
+    import { isSelfHosted } from '$lib/system';
+    import { canPermanentlyDeleteConsoleUser } from '$lib/helpers/consoleUsers';
+
+    export let showDelete = false;
+    export let selectedUser: Models.User<Record<string, unknown>> | null = null;
+
+    let error: string;
+
+    $: isSelf = selectedUser?.$id === $user?.$id;
+    $: allowed = canPermanentlyDeleteConsoleUser({
+        isSelfHosted,
+        actorUserId: $user?.$id,
+        targetUserId: selectedUser?.$id
+    });
+    $: if (showDelete) {
+        error = null;
+    }
+
+    const deleteUser = async () => {
+        if (!selectedUser || !allowed) {
+            error = isSelf
+                ? 'You cannot permanently delete your own account from this page.'
+                : 'Permanent account deletion is not available.';
+            return;
+        }
+
+        try {
+            await sdk.forConsoleInOrganization(page.params.organization).users.delete({
+                userId: selectedUser.$id
+            });
+
+            showDelete = false;
+            addNotification({
+                type: 'success',
+                message: `${selectedUser.name || selectedUser.email || 'User'} was permanently deleted from the system`
+            });
+            trackEvent(Submit.ConsoleUserDelete);
+            await Promise.all([
+                invalidate(Dependencies.CONSOLE_USERS),
+                invalidate(Dependencies.MEMBERS),
+                invalidate(Dependencies.ACCOUNT)
+            ]);
+        } catch (e) {
+            error = e.message;
+            trackError(e, Submit.ConsoleUserDelete);
+        }
+    };
+</script>
+
+<Confirm
+    onSubmit={deleteUser}
+    submissionLoader
+    title="Delete account permanently"
+    action="Delete permanently"
+    confirmDeletion
+    confirmDeletionLabel="I understand this permanently deletes the account from the entire system"
+    disabled={!allowed}
+    bind:open={showDelete}
+    bind:error>
+    <Typography.Text>
+        Are you sure you want to permanently delete
+        <b>{selectedUser?.name || selectedUser?.email || 'this user'}</b>
+        from the entire Appwrite system?
+    </Typography.Text>
+    <Typography.Text>
+        They will lose access to all organizations and will no longer be able to sign in. Memberships
+        are cleaned up automatically. Organizations they solely owned may be left without an owner
+        until cleaned up. This action cannot be undone.
+    </Typography.Text>
+    {#if isSelf}
+        <Typography.Text>
+            You cannot delete your own account here. Use Account → Delete account instead.
+        </Typography.Text>
+    {/if}
+</Confirm>

--- a/src/routes/(console)/organization-[organization]/platform-users/deleteConsoleUser.svelte
+++ b/src/routes/(console)/organization-[organization]/platform-users/deleteConsoleUser.svelte
@@ -12,20 +12,30 @@
     import { isSelfHosted } from '$lib/system';
     import { canPermanentlyDeleteConsoleUser } from '$lib/helpers/consoleUsers';
 
-    export let showDelete = false;
-    export let selectedUser: Models.User<Record<string, unknown>> | null = null;
+    let {
+        showDelete = $bindable(false),
+        selectedUser = null
+    }: {
+        showDelete?: boolean;
+        selectedUser?: Models.User<Record<string, unknown>> | null;
+    } = $props();
 
-    let error: string;
+    let error = $state<string>(null);
 
-    $: isSelf = selectedUser?.$id === $user?.$id;
-    $: allowed = canPermanentlyDeleteConsoleUser({
-        isSelfHosted,
-        actorUserId: $user?.$id,
-        targetUserId: selectedUser?.$id
+    const isSelf = $derived(selectedUser?.$id === $user?.$id);
+    const allowed = $derived(
+        canPermanentlyDeleteConsoleUser({
+            isSelfHosted,
+            actorUserId: $user?.$id,
+            targetUserId: selectedUser?.$id
+        })
+    );
+
+    $effect(() => {
+        if (showDelete) {
+            error = null;
+        }
     });
-    $: if (showDelete) {
-        error = null;
-    }
 
     const deleteUser = async () => {
         if (!selectedUser || !allowed) {
@@ -36,7 +46,7 @@
         }
 
         try {
-            await sdk.forConsoleInOrganization(page.params.organization).users.delete({
+            await sdk.forConsoleUsersInOrganization(page.params.organization).delete({
                 userId: selectedUser.$id
             });
 


### PR DESCRIPTION
## Summary

Fixes [appwrite/appwrite#11393](https://github.com/appwrite/appwrite/issues/11393).

Self-hosted administrators could only **remove** members from an organization. The console account remained and could sign in and create new organizations ("shadow accounts").

This PR adds GUI support for **permanent platform account deletion** on self-hosted instances:

1. **Members → Remove** — optional checkbox: *Also permanently delete their account from the entire system*
2. **Organization → Platform users** tab (owners only) — list all console accounts and permanently delete them
3. SDK helper `sdk.forConsoleInOrganization(orgId)` — sets `X-Appwrite-Organization` so the Users API receives `users.write` on the console project

Cloud is unchanged (no permanent-delete UI, no Platform users tab).

### Why this works

The backend already supports permanent deletion:

```http
DELETE /v1/users/{userId}
X-Appwrite-Project: console
X-Appwrite-Organization: {orgId}
```

A prior attempt ([appwrite/appwrite#11587](https://github.com/appwrite/appwrite/pull/11587)) only added a legacy SDK stub and closed without GUI changes. The console already has `@appwrite.io/console` Users service — the missing piece was UI + organization-scoped client.

### Related backend PR

Companion safeguards: [appwrite/appwrite#12850](https://github.com/appwrite/appwrite/pull/12850) — block self-delete via Users API and deletion of the last console user.

## Test plan

- [x] Unit tests for permanent-delete gating (`consoleUsers.test.ts` — 8 tests)
- [x] Local Appwrite 1.9.5 reproduction:
  - Shadow user can log in and create own org after existing as orphaned account
  - `DELETE /v1/users/{id}` with org context → 204, login fails afterward
  - Without org context → 401 missing `users.write`
- [x] `bun run check` — 0 errors on changed files
- [ ] Manual GUI: Platform users tab visible on self-hosted only
- [ ] Manual GUI: permanent delete from Members checkbox
- [ ] Manual GUI: permanent delete from Platform users page
- [ ] Confirm cloud build does not show Platform users / permanent checkbox

## Security notes

- Permanent delete UI is **self-hosted only** (`isSelfHosted`)
- Self-delete is blocked in the UI (fail closed if actor id missing)
- Last-user / self-delete API guards are in the companion backend PR
- Organization context is required for scopes (backend already enforces membership in the org header)