### PR TITLE
Add Connect to Gitea button

### DIFF
--- a/src/lib/components/git/IconGitea.svelte
+++ b/src/lib/components/git/IconGitea.svelte
@@ -1,0 +1,18 @@
+<!--
+    Gitea has no icon in @appwrite.io/pink-icons-svelte yet, so this is a
+    hand-drawn stand-in (simplified teapot silhouette, matching Gitea's
+    mascot) kept local to the git-connect UI until a proper brand icon
+    lands in the shared icon package. Mirrors the monochrome,
+    currentcolor-fill convention of the other Icon* components (e.g.
+    IconGithub) so it drops into <Icon icon={IconGitea} /> unchanged.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20">
+    <path
+        fill="currentcolor"
+        fill-rule="evenodd"
+        d="M6 3.75A1.25 1.25 0 0 1 7.25 2.5h5.5A1.25 1.25 0 0 1 14 3.75V5h1.25A2.75 2.75 0 0 1 18 7.75v1.5A2.75 2.75 0 0 1 15.25 12H14v.114a3.886 3.886 0 0 1-3.886 3.886H9.886A3.886 3.886 0 0 1 6 12.114V3.75Zm7 5.75V3.75a.25.25 0 0 0-.25-.25h-5.5a.25.25 0 0 0-.25.25v8.364A2.886 2.886 0 0 0 9.886 15h.228A2.886 2.886 0 0 0 13 12.114V9.5ZM14 6v5h1.25c.966 0 1.75-.784 1.75-1.75v-1.5c0-.966-.784-1.75-1.75-1.75H14Z"
+        clip-rule="evenodd" />
+    <path
+        fill="currentcolor"
+        d="M4 16.5a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H4.75a.75.75 0 0 1-.75-.75Z" />
+</svg>

--- a/src/lib/components/git/connectGit.svelte
+++ b/src/lib/components/git/connectGit.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
     import { isSelfHosted } from '$lib/system';
-    import { connectGitHub } from '$lib/stores/git';
+    import { connectGitHub, connectGitea } from '$lib/stores/git';
     import Button from '$lib/elements/forms/button.svelte';
     import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Alert, Card, Empty, Icon, Layout } from '@appwrite.io/pink-svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
+    import IconGitea from './IconGitea.svelte';
 
     export let callbackState: Record<string, string> = null;
 
     let isVcsEnabled = $regionalConsoleVariables?._APP_VCS_ENABLED === true;
+    // Not in the SDK's generated types yet -- server already returns it.
+    let vcsProviders = ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })
+        ?._APP_VCS_PROVIDERS;
+    let isGiteaEnabled = vcsProviders?.includes('gitea') ?? false;
 </script>
 
 <Layout.Stack>
@@ -35,13 +40,24 @@
             title="No installation was added to the project yet"
             description="Add an installation to connect repositories">
             <svelte:fragment slot="actions">
-                <Button
-                    secondary
-                    href={connectGitHub(callbackState).toString()}
-                    disabled={!isVcsEnabled}>
-                    <Icon slot="start" icon={IconGithub} />
-                    Connect to GitHub
-                </Button>
+                <Layout.Stack direction="row">
+                    <Button
+                        secondary
+                        href={connectGitHub(callbackState).toString()}
+                        disabled={!isVcsEnabled}>
+                        <Icon slot="start" icon={IconGithub} />
+                        Connect to GitHub
+                    </Button>
+                    {#if isGiteaEnabled}
+                        <Button
+                            secondary
+                            href={connectGitea(callbackState).toString()}
+                            disabled={!isVcsEnabled}>
+                            <Icon slot="start" icon={IconGitea} />
+                            Connect to Gitea
+                        </Button>
+                    {/if}
+                </Layout.Stack>
             </svelte:fragment>
         </Empty>
     </Card.Base>

--- a/src/lib/stores/git.ts
+++ b/src/lib/stores/git.ts
@@ -1,19 +1,27 @@
 import { page } from '$app/state';
 import { getApiEndpoint } from './sdk';
 
-export function connectGitHub(callbackState: Record<string, string> = null) {
+function connectVcsProvider(provider: string, callbackState: Record<string, string> = null) {
     const redirect = new URL(page.url);
     if (callbackState) {
         Object.keys(callbackState).forEach((key) => {
             redirect.searchParams.append(key, callbackState[key]);
         });
     }
-    const target = new URL(`${getApiEndpoint(page.params.region)}/vcs/github/authorize`);
+    const target = new URL(`${getApiEndpoint(page.params.region)}/vcs/${provider}/authorize`);
     target.searchParams.set('project', page.params.project);
     target.searchParams.set('success', redirect.toString());
     target.searchParams.set('failure', redirect.toString());
     target.searchParams.set('mode', 'admin');
     return target;
+}
+
+export function connectGitHub(callbackState: Record<string, string> = null) {
+    return connectVcsProvider('github', callbackState);
+}
+
+export function connectGitea(callbackState: Record<string, string> = null) {
+    return connectVcsProvider('gitea', callbackState);
 }
 
 export function deploymentStatusConverter(status: string) {


### PR DESCRIPTION
## Summary
- Adds a "Connect to Gitea" button alongside the existing "Connect to GitHub" one, so Gitea installations (from appwrite/appwrite#12820) can be QA'd locally through the console.
- Gated behind `_APP_VCS_PROVIDERS` (server-side config) containing `gitea` — stays hidden unless Gitea is actually configured, no behavior change for GitHub-only environments.
- Ships a stand-in monochrome icon (`IconGitea.svelte`) since no Gitea icon exists in `@appwrite.io/pink-icons-svelte` yet; can be swapped once a proper brand icon is added to the shared package.

## Test plan
- [x] `prettier --check` on changed files
- [x] `svelte-check` — no new errors introduced (pre-existing errors elsewhere unrelated)
- [ ] Manual QA against a local Gitea instance once appwrite/appwrite#12820 is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

just for testing not gonna be live 