### PR TITLE
fix: handle webhook-race on Premium Geo DB addon enable

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/settings/premiumGeoDBEnableModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/premiumGeoDBEnableModal.svelte
@@ -60,10 +60,23 @@
                     return;
                 }
 
-                await sdk.forConsoleIn(page.params.region).projects.confirmAddonPayment({
-                    projectId: page.params.project,
-                    addonId: paymentAuth.addonId
-                });
+                try {
+                    await sdk.forConsoleIn(page.params.region).projects.confirmAddonPayment({
+                        projectId: page.params.project,
+                        addonId: paymentAuth.addonId
+                    });
+                } catch (e) {
+                    // A 404 here means the Stripe webhook already consumed the invoice
+                    // and activated the addon (race) — the addon is enabled, so sync
+                    // state and assume success rather than surfacing the error.
+                    if (
+                        e?.type !== 'billing_invoice_not_found' &&
+                        e?.type !== 'addon_not_found' &&
+                        e?.code !== 404
+                    ) {
+                        throw e;
+                    }
+                }
 
                 await Promise.all([
                     invalidate(Dependencies.ADDONS),


### PR DESCRIPTION
When enabling the Premium Geo DB addon, the Stripe webhook can activate the addon and mark its invoice `succeeded` just before the console's explicit `confirmAddonPayment` call. The backend then can't find a *pending* invoice and returns `billing_invoice_not_found` (HTTP 404) — even though the addon is already enabled and charged.

The enable modal's `catch` only special-cased `409`, so this benign race surfaced a confusing "Invoice no longer exists" error to the user despite success.

This tolerates the race 404 (`billing_invoice_not_found` / `addon_not_found`) on the inline confirm — re-syncing state and reporting success — mirroring the existing handling in `premiumGeoDB.svelte`'s `confirmAddon`.