### PR TITLE
fix(databases): clarify autoscaling max is an absolute cap (DAT-1770)

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/settings/updateAutoscaling.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/settings/updateAutoscaling.svelte
@@ -77,6 +77,7 @@
                         min={database.storage}
                         max={10000}
                         bind:value={maxGb}
+                        helper="The maximum total size this database's storage can grow to. Autoscaling stops at this limit."
                         required />
                 {/if}
             </ul>


### PR DESCRIPTION
## What

Adds helper text to the "Maximum storage (GB)" input in the dedicated database storage autoscaling settings, clarifying that the value is the absolute total size the volume may grow to — not headroom above current storage.

**Before:** label "Maximum storage (GB)" with no helper text.

**After:** same label, with helper: "The maximum total size this database's storage can grow to. Autoscaling stops at this limit."

## Why

Fixes [DAT-1770](https://linear.app/appwrite/issue/DAT-1770) — the input read as an amount of headroom to add above current storage, when it is actually the absolute cap at which autoscaling stops.

Copy-only change, no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)