### PR TITLE
fix(auth): user limit resets to 100 on page refresh when policy is unset

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/security/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/+page.ts
@@ -32,6 +32,11 @@ const getDefaultPasswordStrengthPolicy = (): Models.PolicyPasswordStrength => ({
     symbols: false
 });
 
+const getDefaultUserLimitPolicy = (): Models.PolicyUserLimit => ({
+    $id: ProjectPolicyId.Userlimit,
+    total: 0
+});
+
 export const load: PageLoad = async ({ depends, params }) => {
     depends(Dependencies.PROJECT);
 
@@ -64,7 +69,9 @@ export const load: PageLoad = async ({ depends, params }) => {
             ProjectPolicyId.Sessioninvalidation
         ] as Models.PolicySessionInvalidation,
         sessionLimitPolicy: policiesById[ProjectPolicyId.Sessionlimit] as Models.PolicySessionLimit,
-        userLimitPolicy: policiesById[ProjectPolicyId.Userlimit] as Models.PolicyUserLimit,
+        userLimitPolicy:
+            (policiesById[ProjectPolicyId.Userlimit] as Models.PolicyUserLimit) ??
+            getDefaultUserLimitPolicy(),
         denyAliasedEmailPolicy:
             (policiesById[ProjectEmailPolicyId.DenyAliasedEmail] as EnabledPolicy) ??
             getDefaultEnabledPolicy(ProjectEmailPolicyId.DenyAliasedEmail),

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
@@ -23,6 +23,11 @@
     let value = $state(policy.total !== 0 ? 'limited' : 'unlimited');
     let newLimit = $state(policy.total !== 0 ? policy.total : 100);
 
+    $effect(() => {
+        value = policy.total !== 0 ? 'limited' : 'unlimited';
+        newLimit = policy.total !== 0 ? policy.total : 100;
+    });
+
     const isLimited = $derived(value === 'limited');
     const btnDisabled = $derived.by(() => {
         return (!isLimited && policy.total === 0) || (isLimited && policy.total === newLimit);


### PR DESCRIPTION
After the `listPolicies` migration, the user limit field in Auth > Security shows 100 on hard refresh regardless of the configured value.

Two bugs introduced by that migration:

1. `+page.ts` had no fallback default for `userLimitPolicy` when the policy is absent from the API response (i.e., never explicitly configured). `passwordStrengthPolicy` had a `?? getDefault...()` guard; `userLimitPolicy` did not. This caused the component to receive `undefined`, making `policy.total !== 0` evaluate to `false` and triggering the hardcoded `100` fallback.

2. `updateUsersLimit.svelte` initialized `value`/`newLimit` from the policy prop using `$state()`. In Svelte 5 runes mode, `$state()` runs once at mount and does not react to prop changes. After `invalidate(Dependencies.PROJECT)` re-fetches data and updates the policy prop, the form values stayed stale.

Fixes:
- Added `getDefaultUserLimitPolicy()` returning `{ $id: ProjectPolicyId.Userlimit, total: 0 }` and applied it as a fallback in `+page.ts` (matching the existing pattern for other policies).
- Added a `$effect` in `updateUsersLimit.svelte` to re-derive `value`/`newLimit` from the policy prop on updates.