### PR TITLE
fix: bump immutable override to clear high-severity audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,7 +94,7 @@
     "cookie": "^0.7.0",
     "devalue": "^5.8.1",
     "flatted": "^3.4.2",
-    "immutable": "^5.1.5",
+    "immutable": "^5.1.8",
     "js-yaml": "^4.3.0",
     "minimatch": "10.2.3",
     "picomatch": "^4.0.4",
@@ -959,7 +959,7 @@
 
     "ignore": ["ignore@6.0.2", "", {}, "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A=="],
 
-    "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
+    "immutable": ["immutable@5.1.9", "", {}, "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "minimatch": "10.2.3",
         "brace-expansion": ">=5.0.7",
         "js-yaml": "^4.3.0",
-        "immutable": "^5.1.5",
+        "immutable": "^5.1.8",
         "flatted": "^3.4.2",
         "devalue": "^5.8.1",
         "yaml": "^1.10.3",


### PR DESCRIPTION
## Summary
- `bun audit --audit-level high` was failing CI on two high-severity `immutable` advisories (pulled in transitively via `sass`): a 32-bit trie overflow DoS and a hash-collision algorithmic complexity DoS.
- Bumped the existing `immutable` override from `^5.1.5` to `^5.1.8` to reach the patched range.
- No direct dependency changes — only the transitive override.

## Test plan
- [x] `bun audit --audit-level high` — 0 vulnerabilities
- [x] `bun install --frozen-lockfile` — succeeds
- [x] `bun run check` — 0 errors