### PR TITLE
fix: show real OAuth error on failure relay page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.8",
     "cookie": "^0.7.0",
     "devalue": "^5.8.1",
     "flatted": "^3.4.2",
@@ -98,6 +98,7 @@
     "js-yaml": "^4.3.0",
     "minimatch": "10.2.3",
     "picomatch": "^4.0.4",
+    "postcss": "^8.5.18",
     "vite": "npm:rolldown-vite@latest",
     "ws": "^8.21.0",
     "yaml": "^1.10.3",
@@ -649,7 +650,7 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -1193,7 +1194,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-load-config": ["postcss-load-config@3.1.4", "", { "dependencies": { "lilconfig": "^2.0.5", "yaml": "^1.10.2" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg=="],
 
@@ -1573,7 +1574,7 @@
 
     "popmotion/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "style-value-types/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "overrides": {
         "vite": "npm:rolldown-vite@latest",
         "minimatch": "10.2.3",
-        "brace-expansion": ">=5.0.7",
+        "brace-expansion": ">=5.0.8",
         "js-yaml": "^4.3.0",
         "immutable": "^5.1.8",
         "flatted": "^3.4.2",
@@ -112,6 +112,7 @@
         "yaml": "^1.10.3",
         "picomatch": "^4.0.4",
         "cookie": "^0.7.0",
-        "ws": "^8.21.0"
+        "ws": "^8.21.0",
+        "postcss": "^8.5.18"
     }
 }

--- a/src/routes/(public)/auth/oauth2/failure/+page.svelte
+++ b/src/routes/(public)/auth/oauth2/failure/+page.svelte
@@ -3,11 +3,27 @@
     import { Typography } from '@appwrite.io/pink-svelte';
 
     const project = page.url.searchParams.get('project');
+    const errorParam = page.url.searchParams.get('error');
     const link = `appwrite-callback-${project}://${page.url.search}`;
+
+    type OAuthError = {
+        message?: string;
+        type?: string;
+        code?: number;
+    };
+
+    let oauthError: OAuthError | null = null;
+    if (errorParam) {
+        try {
+            oauthError = JSON.parse(errorParam) as OAuthError;
+        } catch {
+            oauthError = { message: errorParam };
+        }
+    }
 
     const redirect = new Promise((_resolve, reject) => {
         if (!project) {
-            reject('no-project');
+            reject(oauthError ? 'oauth-error' : 'no-project');
         }
         window.location.href = link;
     });
@@ -27,15 +43,25 @@
 {:catch}
     <article class="card u-padding-16">
         <div class="u-flex u-flex-vertical u-gap-16">
-            <Typography.Title>Missing redirect URL</Typography.Title>
-            <p class="text">
-                Your OAuth login flow is missing a proper redirect URL. Please check the
-                <a
-                    class="link"
-                    href="https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session"
-                    >OAuth docs</a>
-                and send request for new session with a valid callback URL.
-            </p>
+            {#if oauthError}
+                <Typography.Title>Login failed</Typography.Title>
+                <p class="text">
+                    {oauthError.message ?? 'An error occurred during the OAuth login flow.'}
+                </p>
+                {#if oauthError.type}
+                    <p class="text u-color-text-offline">Error type: {oauthError.type}</p>
+                {/if}
+            {:else}
+                <Typography.Title>Missing redirect URL</Typography.Title>
+                <p class="text">
+                    Your OAuth login flow is missing a proper redirect URL. Please check the
+                    <a
+                        class="link"
+                        href="https://appwrite.io/docs/references/cloud/client-web/account#createOAuth2Session"
+                        >OAuth docs</a>
+                    and send request for new session with a valid callback URL.
+                </p>
+            {/if}
         </div>
     </article>
 {/await}


### PR DESCRIPTION
## What does this PR do?

The OAuth failure relay page previously treated a missing `project` query param as "Missing redirect URL", even when an `error` payload was present (e.g. `user_already_exists`). This shows the real error message/type when `error` is present, and only falls back to the missing-redirect copy when neither `project` nor a parseable error exists.

## Test Plan

1. Open `/console/auth/oauth2/failure?error=%7B%22message%22%3A%22User%20already%20exists%22%2C%22type%22%3A%22user_already_exists%22%2C%22code%22%3A409%7D` without `project`.
2. Confirm the page title is "Login failed" and the message shows "User already exists".
3. Open `/console/auth/oauth2/failure` with no params and confirm the existing "Missing redirect URL" copy still appears.
4. With `project` present, confirm the deep-link redirect behavior is unchanged.

## Related PRs and Issues

- Related API: https://github.com/appwrite/appwrite/pull/12976
- https://github.com/appwrite/appwrite/issues/12936
