### PR TITLE
fix: guard against undefined table in updateKeyName

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/relationship.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/columns/relationship.svelte
@@ -110,7 +110,9 @@
     function updateKeyName() {
         if (!editing) {
             const table = tableList.tables.find((n) => n.$id === data.relatedTable);
-            data.key = camelize(table.name);
+            if (table) {
+                data.key = camelize(table.name);
+            }
         }
     }
 


### PR DESCRIPTION
`Array.find()` returns `undefined` when no table matches the selected `relatedTable` id (e.g. while the table list is still loading or the value was pre-populated from a saved state). Calling `.name` on `undefined` throws a runtime error.

Added an `if (table)` guard before accessing `table.name`.