### PR TITLE
Fix Sites fallback file placeholder

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -32,7 +32,7 @@
     let buildCommand = $state(site?.buildCommand);
     let startCommand = $state(site?.startCommand);
     let outputDirectory = $state(site?.outputDirectory);
-    let fallback = $state(site?.fallbackFile);
+    let fallback = $state(site?.fallbackFile ?? '');
     let adapter: Adapter = $state(site.adapter as Adapter);
 
     let selectedFramework = $state(
@@ -108,16 +108,6 @@
         }
 
         lastFrameworkAdapterKey = `${selectedFramework.key}:${adapter ?? ''}`;
-    });
-
-    $effect(() => {
-        if (adapter === Adapter.Static) {
-            if (!fallback) {
-                fallback ||= selectedFramework.adapters.find(
-                    (a) => a.key === Adapter.Static
-                ).fallbackFile;
-            }
-        }
     });
 
     $effect(() => {


### PR DESCRIPTION
## Summary
- keep empty Sites fallback file values empty in build settings
- leave index.html as placeholder-only unless the user explicitly sets it or changes framework/adapter defaults

## Tests
- bun run check