### PR TITLE
fix(messaging): show delete for a processing message

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "cookie": "^0.7.0",
     "devalue": "^5.8.1",
     "flatted": "^3.4.2",
@@ -650,7 +650,7 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "overrides": {
         "vite": "npm:rolldown-vite@latest",
         "minimatch": "10.2.3",
-        "brace-expansion": ">=5.0.8",
+        "brace-expansion": ">=5.0.9",
         "js-yaml": "^4.3.0",
         "immutable": "^5.1.8",
         "flatted": "^3.4.2",

--- a/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/+page.svelte
@@ -37,7 +37,5 @@
         message={$message}
         selectedTargetsById={data.targetsById}
         selectedRecipients={data.messageRecipients} />
-    {#if $message.status !== 'processing'}
-        <Delete message={$message} />
-    {/if}
+    <Delete message={$message} />
 </Container>

--- a/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/messaging/message-[message]/+page.svelte
@@ -12,6 +12,7 @@
     import { MessagingProviderType } from '@appwrite.io/console';
     import UpdateTopics from './updateTopics.svelte';
     import UpdateTargets from './updateTargets.svelte';
+    import { canWriteMessages } from '$lib/stores/roles';
     import { onMount } from 'svelte';
 
     export let data: PageData;
@@ -37,5 +38,7 @@
         message={$message}
         selectedTargetsById={data.targetsById}
         selectedRecipients={data.messageRecipients} />
-    <Delete message={$message} />
+    {#if $canWriteMessages}
+        <Delete message={$message} />
+    {/if}
 </Container>


### PR DESCRIPTION
## What does this PR do?

The message detail page gated the whole delete card on status:

```svelte
{#if $message.status !== 'processing'}
    <Delete message={$message} />
{/if}
```

That mirrored the server, which rejected the delete with `message_already_scheduled`. The problem is that `processing` is not always transient — a worker that died before writing a terminal status left the message there permanently, and the queue dead-letters a failed job rather than redelivering it. Nothing ever moved the message on, so the record could not be removed from the console at all. This is what the reported support case ran into.

appwrite/appwrite#13091 fixed the server side: the worker now writes `failed` when a job dies before a terminal status, and the delete endpoint no longer rejects `processing`.

This replaces that status gate with a **write-scope** gate. The card had no permission check at all, so a reader with `messages.read` saw a delete control that only failed once confirmed — that was true before this PR for every other status, and simply removing the condition would have widened it. The rest of the feature already derives this from `messages.write`: `+layout.svelte:29` disables the tab action, and the list gates its create button (`+page.svelte:144`) and row selection (`:154`) on `$canWriteMessages`. The card now tracks permission rather than status, which is what it should have keyed on in the first place.

Scope stays narrow:

- `overview.svelte` still hides the footer for `processing` and `sent`, and updating a `processing` message is still rejected server-side with `message_already_processing`. Editing stays blocked.
- Status polling in `helper.ts` and the list page is untouched.
- The list-page bulk delete was never gated on status, so it needed no change — it simply stops failing now.

## Test Plan

With `messages.write`: open a message stuck in `processing` and confirm the "Delete message" card renders and the delete succeeds. Before this change the card was absent entirely.

With only `messages.read`: confirm the card is now hidden, on any status.

`prettier --check` and `eslint` pass on the changed file. There are no messaging journeys under `e2e/`, so no test needed updating.

Worth a reviewer's opinion: `delete.svelte` appends ", and its delivery will be canceled" only for `scheduled`. Deleting a `processing` message does **not** stop an in-flight send — the queue has no cancellation primitive — so the copy is accurate as-is, but a note for `processing` may be worth adding. I left the wording alone since that is a product call.

## Related PRs and Issues

- appwrite/appwrite#13091
- appwrite/console#3146 — unblocks the red `build` job here (unrelated `brace-expansion` advisory)
