### PR TITLE
chore(deps): raise the brace-expansion floor to 5.0.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9",
     "cookie": "^0.7.0",
     "devalue": "^5.8.1",
     "flatted": "^3.4.2",
@@ -650,7 +650,7 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "overrides": {
         "vite": "npm:rolldown-vite@latest",
         "minimatch": "10.2.3",
-        "brace-expansion": ">=5.0.8",
+        "brace-expansion": ">=5.0.9",
         "js-yaml": "^4.3.0",
         "immutable": "^5.1.8",
         "flatted": "^3.4.2",


### PR DESCRIPTION
## What does this PR do?

`bun audit --audit-level high` (`.github/workflows/tests.yml:24`) is failing on every branch, so the `build` job is red repo-wide:

```
brace-expansion  >=4.0.0 <5.0.9
  eslint › @eslint/eslintrc › minimatch › brace-expansion
  @sentry/sveltekit › @sentry/vite-plugin › @sentry/bundler-plugin-core › glob › minimatch › brace-expansion
  high: brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation
1 vulnerabilities (1 high)
```

`package.json` already carries a `brace-expansion` override, pinned at `>=5.0.8`. GHSA-rgw5-rvv9-x895 widened the affected range to `<5.0.9`, so that floor stopped clearing the advisory and the lock stayed on the now-vulnerable 5.0.8. This raises the floor to `>=5.0.9`, matching the existing security-override pattern in that block.

All reachable paths are dev-only (eslint, typescript-eslint, `@sentry/vite-plugin`), so nothing ships to users — but the job is red, which blocks unrelated PRs.

## Test Plan

```
 bun.lock     | 4 ++--
 package.json | 2 +-
```

Three lines: the pinned floor, and the resolved version plus its integrity hash.

- `bun audit --audit-level high` → exit 0, no vulnerabilities.
- `bun install --dry-run --frozen-lockfile` → exit 0, so the lock is still consistent with `package.json`.

Worth noting for reviewers: running `bun install --lockfile-only` to regenerate the lock silently **dropped the integrity hashes** from the three private-registry `@appwrite.io/*` entries (`console`, `pink-svelte`, `pink-icons-svelte`), presumably because `pkg.vc` was not authenticated locally. I discarded that and edited the two `brace-expansion` lines directly so those hashes are preserved — the diff above confirms nothing else moved. Anyone regenerating this lock without registry auth should watch for the same thing.

## Related PRs and Issues

- Unblocks the `build` job on appwrite/console#3145 and any other open PR.
