### PR TITLE
fix(vcs): surface invalid installation tokens instead of empty results

### DIFF
--- a/src/lib/components/git/branchSelector.svelte
+++ b/src/lib/components/git/branchSelector.svelte
@@ -9,28 +9,79 @@
     import { Query } from '@appwrite.io/console';
     import { sdk } from '$lib/stores/sdk';
     import { page } from '$app/state';
-    import { createEventDispatcher, hasContext, tick } from 'svelte';
+    import { createEventDispatcher, hasContext, tick, untrack } from 'svelte';
+    import { getVcsInstallationErrorKind } from '$lib/helpers/vcsError';
+    import { installation, installations } from '$lib/stores/vcs';
+    import InstallationError from './installationError.svelte';
 
-    export let value = '';
-    export let installationId: string;
-    export let repositoryId: string;
-    export let label = 'Production branch';
-    export let placeholder = 'Select branch';
+    type Props = {
+        value?: string;
+        installationId: string;
+        repositoryId: string;
+        label?: string;
+        placeholder?: string;
+        /**
+         * Set to `false` when the surrounding surface already renders its own
+         * installation alert for the same installation, so the user is not shown
+         * the same "Reconnect" warning twice. The in-list error state stays
+         * either way: the branch list must never read as "no branches".
+         */
+        showInstallationError?: boolean;
+    };
 
-    const dispatch = createEventDispatcher();
+    let {
+        value = $bindable(''),
+        installationId,
+        repositoryId,
+        label = 'Production branch',
+        placeholder = 'Select branch',
+        showInstallationError = true
+    }: Props = $props();
+
+    // Deprecated in Svelte 5 but kept deliberately: every call site listens with
+    // `on:select`, and none of them are in scope here.
+    const dispatch = createEventDispatcher<{ select: string }>();
     const inDialogGroup = hasContext('dialog-group');
 
-    let open = false;
-    let searchQuery = '';
-    let branches: string[] = [];
-    let searchResults: string[] = [];
-    let loading = false;
-    let loaded = false;
-    let searching = false;
+    let open = $state(false);
+    let searchQuery = $state('');
+    let branches = $state<string[]>([]);
+    let searchResults = $state<string[]>([]);
+    let loading = $state(false);
+    let searching = $state(false);
+    /**
+     * The last failure from the branch endpoints. Without it a dead installation
+     * token renders as a successful empty list ("No branches available"), which
+     * is the opposite of what happened.
+     */
+    let error = $state<unknown>(null);
+    /** Repository the cached `branches` belong to, or `null` when nothing loaded. */
+    let loadedFor = $state<string | null>(null);
     let searchTimer: ReturnType<typeof setTimeout>;
-    let searchInput: HTMLInputElement;
-    let containerEl: HTMLDivElement;
-    let dropdownRect = { top: 0, left: 0, width: 0 };
+    let searchInput = $state<HTMLInputElement>();
+    let containerEl = $state<HTMLDivElement>();
+    let dropdownRect = $state({ top: 0, left: 0, width: 0 });
+
+    const repositoryKey = $derived(`${installationId}:${repositoryId}`);
+    const errorKind = $derived(getVcsInstallationErrorKind(error));
+    const displayBranches = $derived(searchQuery ? searchResults : branches);
+
+    /**
+     * Provider and owner for the reconnect alert. Every route that renders a
+     * branch selector loads `page.data.installations`; the writable store covers
+     * the surfaces that pick an installation client side.
+     */
+    const installationDetails = $derived(
+        $installations?.installations?.find((entry) => entry.$id === installationId) ??
+            ($installation?.$id === installationId ? $installation : undefined)
+    );
+
+    /**
+     * When the list could not be loaded the typed query is the only way left to
+     * name a branch, so it is offered as a selectable value. Only in the error
+     * state: with a working list, committing an unverified name would be wrong.
+     */
+    const typedBranch = $derived(error ? searchQuery.trim() : '');
 
     function portal(node: HTMLElement) {
         const target = inDialogGroup ? document.querySelector('dialog[open]') : document.body;
@@ -48,16 +99,26 @@
         dropdownRect = { top: rect.bottom + 4, left: rect.left, width: rect.width };
     }
 
-    $: (installationId,
-        repositoryId,
-        (() => {
+    $effect(() => {
+        // Cached branches and any recorded failure belong to the repository they
+        // were loaded for, so a change to either id throws them away. Only the
+        // key is tracked: reading `loadedFor` reactively would re-run this on
+        // every load and wipe the failure it had just recorded.
+        const key = repositoryKey;
+        untrack(() => {
+            if (loadedFor === key) return;
             branches = [];
-            loaded = false;
-        })());
+            searchResults = [];
+            error = null;
+            loadedFor = null;
+        });
+    });
 
-    async function loadBranches() {
-        if (loading || loaded || !installationId || !repositoryId) return;
+    async function loadBranches(force = false) {
+        const key = repositoryKey;
+        if (loading || (!force && loadedFor === key) || !installationId || !repositoryId) return;
         loading = true;
+        error = null;
         try {
             const { branches: result } = await sdk
                 .forProject(page.params.region, page.params.project)
@@ -67,7 +128,11 @@
                     queries: [Query.limit(100)]
                 });
             branches = result.map((b) => b.name);
-            loaded = true;
+            loadedFor = key;
+        } catch (e) {
+            error = e;
+            branches = [];
+            loadedFor = null;
         } finally {
             loading = false;
         }
@@ -77,6 +142,14 @@
         if (!query) {
             searchResults = [];
             searching = false;
+            // A failed search must not outlive the query that caused it. When
+            // the base list never loaded there is nothing underneath to fall
+            // back to, so fetch it rather than showing a bare empty list.
+            if (loadedFor === repositoryKey) {
+                error = null;
+            } else {
+                loadBranches();
+            }
             return;
         }
         searching = true;
@@ -90,6 +163,12 @@
                     queries: [Query.limit(100)]
                 });
             searchResults = results.map((b) => b.name);
+            // Cleared on success only, so a failed load keeps explaining itself
+            // (and keeps the typed value selectable) while the search is running.
+            error = null;
+        } catch (e) {
+            error = e;
+            searchResults = [];
         } finally {
             searching = false;
         }
@@ -100,11 +179,40 @@
         searchTimer = setTimeout(() => searchBranches(searchQuery), 300);
     }
 
+    function onSearchKeydown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || !typedBranch) return;
+        event.preventDefault();
+        select(typedBranch);
+    }
+
+    function clearSearch() {
+        clearTimeout(searchTimer);
+        searchQuery = '';
+        searchResults = [];
+        searching = false;
+        // Same reasoning as searchBranches, but only while the dropdown is
+        // open: the close paths call this too, and reloading then is wasted.
+        if (loadedFor === repositoryKey) {
+            error = null;
+        } else if (open) {
+            loadBranches();
+        }
+    }
+
+    function retry() {
+        error = null;
+        if (searchQuery) {
+            clearTimeout(searchTimer);
+            searchBranches(searchQuery);
+            return;
+        }
+        loadBranches(true);
+    }
+
     function select(branch: string) {
         value = branch;
         open = false;
-        searchQuery = '';
-        searchResults = [];
+        clearSearch();
         dispatch('select', branch);
     }
 
@@ -116,43 +224,46 @@
             await tick();
             searchInput?.focus();
         } else {
-            searchQuery = '';
-            searchResults = [];
+            clearSearch();
         }
     }
 
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === 'Escape') {
             open = false;
-            searchQuery = '';
-            searchResults = [];
+            clearSearch();
         }
     }
 
     function handleOutsideClick(e: MouseEvent) {
-        if (open && !containerEl.contains(e.target as Node)) {
+        if (open && !containerEl?.contains(e.target as Node)) {
             const dropdown = document.querySelector('.branch-selector-portal');
             if (dropdown && dropdown.contains(e.target as Node)) return;
             open = false;
-            searchQuery = '';
-            searchResults = [];
+            clearSearch();
         }
     }
-
-    $: displayBranches = searchQuery ? searchResults : branches;
 </script>
 
-<svelte:window on:click={handleOutsideClick} on:keydown={handleKeydown} />
+<svelte:window onclick={handleOutsideClick} onkeydown={handleKeydown} />
 
 <div class="branch-selector" bind:this={containerEl}>
     {#if label}
-        <!-- svelte-ignore a11y-label-has-associated-control -->
+        <!-- svelte-ignore a11y_label_has_associated_control -->
         <label class="label">{label}</label>
     {/if}
-    <button type="button" class="trigger" class:open on:click={toggle}>
+    <button type="button" class="trigger" class:open onclick={toggle}>
         <span class="trigger-value" class:muted={!value}>{value || placeholder}</span>
         <Icon icon={open ? IconChevronUp : IconChevronDown} size="m" />
     </button>
+
+    {#if errorKind && showInstallationError}
+        <InstallationError
+            kind={errorKind}
+            provider={installationDetails?.provider}
+            organization={installationDetails?.organization}
+            onRetry={retry} />
+    {/if}
 
     {#if open}
         <div
@@ -164,18 +275,13 @@
                 <input
                     bind:this={searchInput}
                     bind:value={searchQuery}
-                    on:input={onSearchInput}
+                    oninput={onSearchInput}
+                    onkeydown={onSearchKeydown}
                     type="text"
                     placeholder="Find a branch..."
                     autocomplete="off" />
                 {#if searchQuery}
-                    <button
-                        type="button"
-                        class="clear-btn"
-                        on:click={() => {
-                            searchQuery = '';
-                            searchResults = [];
-                        }}>
+                    <button type="button" class="clear-btn" onclick={clearSearch}>
                         <Icon icon={IconX} size="s" />
                     </button>
                 {/if}
@@ -185,18 +291,32 @@
                     <li class="state-item">Loading...</li>
                 {:else if searching}
                     <li class="state-item">Searching...</li>
+                {:else if error}
+                    <!-- Never claim the repository has no branches when the call failed. -->
+                    <li class="state-item">Branches could not be loaded</li>
+                    {#if typedBranch}
+                        <!-- svelte-ignore a11y_click_events_have_key_events -->
+                        <li
+                            role="option"
+                            aria-selected={typedBranch === value}
+                            onclick={() => select(typedBranch)}>
+                            Use "{typedBranch}"
+                        </li>
+                    {:else}
+                        <li class="hint-item">Type a branch name to use it anyway</li>
+                    {/if}
                 {:else if displayBranches.length === 0 && searchQuery}
                     <li class="state-item">No branches found</li>
                 {:else if displayBranches.length === 0}
                     <li class="state-item">No branches available</li>
                 {:else}
                     {#each displayBranches as branch}
-                        <!-- svelte-ignore a11y-click-events-have-key-events -->
+                        <!-- svelte-ignore a11y_click_events_have_key_events -->
                         <li
                             role="option"
                             aria-selected={branch === value}
                             class:active={branch === value}
-                            on:click={() => select(branch)}>
+                            onclick={() => select(branch)}>
                             {branch}
                         </li>
                     {/each}

--- a/src/lib/components/git/connectRepoModal.svelte
+++ b/src/lib/components/git/connectRepoModal.svelte
@@ -14,6 +14,8 @@
     import RepositoryBehaviour from '$lib/components/git/repositoryBehaviour.svelte';
     import { page } from '$app/state';
     import { connectGitHub } from '$lib/stores/git';
+    import type { VcsInstallationErrorKind } from '$lib/helpers/vcsError';
+    import InstallationError from '$lib/components/git/installationError.svelte';
 
     let {
         show = $bindable(false),
@@ -38,6 +40,10 @@
     let selectedRepository = $state('');
     let installations = $state({ installations: [], total: 0 });
     let error = $state('');
+    // Set by <Repositories> when the list failed because the installation is
+    // broken. The permissions hint in the footer is wrong in that case: no
+    // amount of scope fiddling fixes a token Appwrite can no longer refresh.
+    let installationErrorKind = $state<VcsInstallationErrorKind | null>(null);
 
     onMount(async () => {
         installations = await sdk
@@ -100,6 +106,14 @@
                 <RepositoryBehaviour bind:repositoryBehaviour />
             {/if}
             {#if repositoryBehaviour === 'new'}
+                {#if installationErrorKind}
+                    <!-- Create is disabled below for the same reason, so say why
+                         here rather than leaving a dead button. -->
+                    <InstallationError
+                        kind={installationErrorKind}
+                        provider={$installation?.provider}
+                        organization={$installation?.organization} />
+                {/if}
                 <NewRepository
                     bind:repositoryName
                     bind:repositoryPrivate
@@ -108,6 +122,7 @@
             {:else}
                 <Repositories
                     bind:selectedRepository
+                    bind:installationErrorKind
                     {product}
                     action="button"
                     {callbackState}
@@ -141,7 +156,7 @@
         <ConnectGit {callbackState} />
     {/if}
     <svelte:fragment slot="footer">
-        {#if repositoryBehaviour === 'existing'}
+        {#if repositoryBehaviour === 'existing' && !installationErrorKind}
             <Layout.Stack>
                 <Link variant="quiet" href={connectGitHub(callbackState).toString()}>
                     <Layout.Stack direction="row" gap="xs">
@@ -152,7 +167,12 @@
             </Layout.Stack>
         {:else if repositoryBehaviour === 'new'}
             <Button text size="s" on:click={() => (show = false)}>Cancel</Button>
-            <Button size="s" submit disabled={!repositoryName || !$installation?.$id}>
+            <!-- Creating a repository refreshes the installation token first, so
+                 it fails the same way the listing just did. -->
+            <Button
+                size="s"
+                submit
+                disabled={!repositoryName || !$installation?.$id || !!installationErrorKind}>
                 Create
             </Button>
         {/if}

--- a/src/lib/components/git/connectRepoModal.svelte
+++ b/src/lib/components/git/connectRepoModal.svelte
@@ -15,7 +15,7 @@
     import { page } from '$app/state';
     import { connectGitHub } from '$lib/stores/git';
     import type { VcsInstallationErrorKind } from '$lib/helpers/vcsError';
-    import InstallationError from '$lib/components/git/installationError.svelte';
+    import InstallationError from './installationError.svelte';
 
     let {
         show = $bindable(false),

--- a/src/lib/components/git/index.ts
+++ b/src/lib/components/git/index.ts
@@ -10,3 +10,4 @@ export { default as ProductionBranchFieldset } from './productionBranchFieldset.
 export { default as BranchSelector } from './branchSelector.svelte';
 export { default as RepositoryCard } from './repositoryCard.svelte';
 export { default as ConnectRepoModal } from './connectRepoModal.svelte';
+export { default as InstallationError } from './installationError.svelte';

--- a/src/lib/components/git/installationError.svelte
+++ b/src/lib/components/git/installationError.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
     /**
-     * Shared rendering for a VCS call that failed because of the installation
-     * itself, rather than because the repository, branch or directory is
-     * genuinely empty.
+     * Use anywhere a Git surface would otherwise show "No repositories found",
+     * "No branches available" or a spinner that never resolves.
      *
-     * Use this anywhere a Git surface would otherwise show "No repositories
-     * found", "No branches available" or a spinner that never resolves. It
-     * explains what happened and offers the action that actually fixes it.
-     *
-     * Reconnecting is a plain full page redirect to the provider's authorize
-     * endpoint. The callback upserts onto the existing installation row, so the
-     * stored token is replaced in place and the installation never has to be
-     * removed first. That is why the label is "Reconnect installation" and not
-     * "Remove and reconnect".
+     * Reconnecting redirects to the provider's authorize endpoint. The callback
+     * upserts onto the existing installation row, so the token is replaced in
+     * place: the label is "Reconnect installation", not "Remove and reconnect".
      */
     import { page } from '$app/state';
     import { Alert, Layout, Typography } from '@appwrite.io/pink-svelte';

--- a/src/lib/components/git/installationError.svelte
+++ b/src/lib/components/git/installationError.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+    /**
+     * Shared rendering for a VCS call that failed because of the installation
+     * itself, rather than because the repository, branch or directory is
+     * genuinely empty.
+     *
+     * Use this anywhere a Git surface would otherwise show "No repositories
+     * found", "No branches available" or a spinner that never resolves. It
+     * explains what happened and offers the action that actually fixes it.
+     *
+     * Reconnecting is a plain full page redirect to the provider's authorize
+     * endpoint. The callback upserts onto the existing installation row, so the
+     * stored token is replaced in place and the installation never has to be
+     * removed first. That is why the label is "Reconnect installation" and not
+     * "Remove and reconnect".
+     */
+    import { page } from '$app/state';
+    import { Alert, Layout, Typography } from '@appwrite.io/pink-svelte';
+    import { Button } from '$lib/elements/forms';
+    import { connectGitHub, connectGitea } from '$lib/stores/git';
+    import { canWriteVcs } from '$lib/stores/roles';
+    import type { VcsInstallationErrorKind } from '$lib/helpers/vcsError';
+
+    type Props = {
+        kind: VcsInstallationErrorKind;
+        /** Installation provider (`github`, `gitea`); unknown values hide the reconnect link. */
+        provider?: string;
+        /** Installation owner, shown so the user knows which account is affected. */
+        organization?: string;
+        /** Retry the failed request. Shown as the primary action for transient kinds. */
+        onRetry?: () => void;
+    };
+
+    let {
+        kind,
+        provider = undefined,
+        organization = undefined,
+        onRetry = undefined
+    }: Props = $props();
+
+    /**
+     * The providers this console can actually re-authorize. GitLab is not a Git
+     * installation provider here (it only exists as an end user OAuth2 provider
+     * and as a template source), so there is deliberately no entry for it, and
+     * an unknown provider renders without a reconnect link rather than pointing
+     * at a fabricated authorize URL.
+     */
+    const providers: Record<string, { label: string; connect: () => URL }> = {
+        github: { label: 'GitHub', connect: connectGitHub },
+        gitea: { label: 'Gitea', connect: connectGitea }
+    };
+
+    const knownProvider = $derived(providers[provider?.toLowerCase() ?? '']);
+
+    /**
+     * Provider and owner, so the user knows which account broke. Untranslated on
+     * purpose: both halves are proper nouns.
+     */
+    const identity = $derived(
+        [knownProvider?.label ?? provider, organization].filter(Boolean).join(' / ')
+    );
+
+    const copy = $derived.by(() => {
+        if (kind === 'reconnect') {
+            return {
+                status: 'warning' as const,
+                title: 'Reconnect this Git installation',
+                description:
+                    'Appwrite can no longer access this Git provider on your behalf. Reconnect the installation to restore access to your repositories.',
+                reconnectIsPrimary: true
+            };
+        }
+
+        if (kind === 'locked') {
+            return {
+                status: 'info' as const,
+                title: 'This installation is being refreshed',
+                description:
+                    'Another request is already refreshing this installation. Try again in a moment.',
+                reconnectIsPrimary: false
+            };
+        }
+
+        return {
+            status: 'warning' as const,
+            title: 'Could not reach the Git provider',
+            description: 'This is usually temporary. Try again in a moment.',
+            reconnectIsPrimary: false
+        };
+    });
+
+    /**
+     * A held refresh lock means the installation is fine, so never send the user
+     * off to re-authorize over it. A provider outage keeps the link as a
+     * secondary action, because a dead token can also surface as one.
+     */
+    const showReconnect = $derived(kind !== 'locked');
+
+    const reconnectUrl = $derived.by(() => {
+        // `connectGitHub` / `connectGitea` read the project and region off the
+        // current route, so there is nothing to link to outside a project.
+        if (!showReconnect || !knownProvider || !$canWriteVcs || !page.params.project) return null;
+        return knownProvider.connect().toString();
+    });
+</script>
+
+<Alert.Inline status={copy.status} title={copy.title}>
+    <Layout.Stack gap="xxs">
+        <span>{copy.description}</span>
+        {#if identity}
+            <Typography.Caption variant="400" color="--fgcolor-neutral-tertiary">
+                {identity}
+            </Typography.Caption>
+        {/if}
+    </Layout.Stack>
+
+    <!-- Always passed: `svelte:fragment` has to be a direct child of the component,
+         so the per kind conditionals live inside it. -->
+    <svelte:fragment slot="actions">
+        {#if copy.reconnectIsPrimary && reconnectUrl}
+            <Button compact href={reconnectUrl} event="vcs_installation_reconnect">
+                Reconnect installation
+            </Button>
+        {/if}
+
+        {#if onRetry}
+            <Button
+                compact={!copy.reconnectIsPrimary}
+                text={copy.reconnectIsPrimary}
+                on:click={onRetry}>
+                Try again
+            </Button>
+        {/if}
+
+        {#if !copy.reconnectIsPrimary && reconnectUrl}
+            <Button text href={reconnectUrl} event="vcs_installation_reconnect">
+                Reconnect installation
+            </Button>
+        {/if}
+    </svelte:fragment>
+</Alert.Inline>

--- a/src/lib/components/git/productionBranchFieldset.svelte
+++ b/src/lib/components/git/productionBranchFieldset.svelte
@@ -1,43 +1,114 @@
 <script lang="ts">
     import { Button, InputText } from '$lib/elements/forms';
-    import { Fieldset, Layout, Selector } from '@appwrite.io/pink-svelte';
+    import { Alert, Fieldset, Layout, Selector } from '@appwrite.io/pink-svelte';
     import SelectRootModal from './selectRootModal.svelte';
     import BranchSelector from './branchSelector.svelte';
+    import InstallationError from './installationError.svelte';
     import { sdk } from '$lib/stores/sdk';
     import { page } from '$app/state';
+    import { getVcsInstallationErrorKind } from '$lib/helpers/vcsError';
+    import { installation, installations } from '$lib/stores/vcs';
 
-    export let branch = 'main';
-    export let rootDir: string;
-    export let silentMode: boolean;
-    export let installationId: string;
-    export let repositoryId: string;
-    export let product: 'sites' | 'functions';
+    type Props = {
+        branch?: string;
+        rootDir: string;
+        silentMode: boolean;
+        installationId: string;
+        repositoryId: string;
+        product: 'sites' | 'functions';
+    };
 
-    let show = false;
+    let {
+        branch = $bindable('main'),
+        rootDir = $bindable(),
+        silentMode = $bindable(),
+        installationId,
+        repositoryId,
+        product
+    }: Props = $props();
+
+    let show = $state(false);
+    let loading = $state(true);
+    /**
+     * The last failure from the default branch lookup. Without it the fieldset
+     * rendered nothing at all when the installation token was dead, because the
+     * `{#await}` this replaced had no `{:catch}`.
+     */
+    let error = $state<unknown>(null);
+
+    const errorKind = $derived(getVcsInstallationErrorKind(error));
+
+    /**
+     * Provider and owner for the reconnect alert. Every route that renders this
+     * fieldset loads `page.data.installations`; the writable store covers the
+     * surfaces that pick an installation client side.
+     */
+    const installationDetails = $derived(
+        $installations?.installations?.find((entry) => entry.$id === installationId) ??
+            ($installation?.$id === installationId ? $installation : undefined)
+    );
 
     async function loadDefaultBranch() {
-        const repo = await sdk
-            .forProject(page.params.region, page.params.project)
-            .vcs.getRepository({
-                installationId,
-                providerRepositoryId: repositoryId
-            });
-        branch = repo.defaultBranch ?? 'main';
+        loading = true;
+        error = null;
+        try {
+            const repo = await sdk
+                .forProject(page.params.region, page.params.project)
+                .vcs.getRepository({
+                    installationId,
+                    providerRepositoryId: repositoryId
+                });
+            branch = repo.defaultBranch ?? 'main';
+        } catch (e) {
+            // The default branch is unknown, but the rest of the form still has
+            // to work. Keep whatever the parent seeded so the user can pick or
+            // type a branch instead of being left with an empty fieldset.
+            error = e;
+            branch = branch || 'main';
+        } finally {
+            loading = false;
+        }
     }
+
+    $effect(() => {
+        // Re-detects whenever the target repository changes, which is what the
+        // `{#await loadDefaultBranch()}` this replaced did implicitly.
+        if (!installationId || !repositoryId) {
+            loading = false;
+            return;
+        }
+        loadDefaultBranch();
+    });
 </script>
 
 <Fieldset legend="Branch">
-    {#await loadDefaultBranch()}
+    {#if loading}
         <Layout.Stack gap="xl">
             <Layout.Stack gap="xs" />
         </Layout.Stack>
-    {:then}
+    {:else}
         <Layout.Stack gap="xl">
+            {#if errorKind}
+                <InstallationError
+                    kind={errorKind}
+                    provider={installationDetails?.provider}
+                    organization={installationDetails?.organization}
+                    onRetry={loadDefaultBranch} />
+            {:else if error}
+                <Alert.Inline status="warning" title="Could not detect the default branch">
+                    Appwrite could not read this repository, so the branch below is a fallback
+                    rather than the repository's own default. Check it before you deploy.
+                    <svelte:fragment slot="actions">
+                        <Button compact on:click={loadDefaultBranch}>Try again</Button>
+                    </svelte:fragment>
+                </Alert.Inline>
+            {/if}
+
             <BranchSelector
                 bind:value={branch}
                 {installationId}
                 {repositoryId}
-                on:select={(e) => (branch = e.detail)} />
+                showInstallationError={!errorKind} />
             <Layout.Stack direction="row" gap="s" alignItems="flex-end">
                 <InputText
                     id="root"
@@ -54,7 +125,7 @@
                 description="If selected, comments will not be created when pushing changes to this repository."
                 bind:checked={silentMode} />
         </Layout.Stack>
-    {/await}
+    {/if}
 </Fieldset>
 
 {#if show}

--- a/src/lib/components/git/repositories.svelte
+++ b/src/lib/components/git/repositories.svelte
@@ -16,6 +16,11 @@
     } from '@appwrite.io/pink-svelte';
     import { IconLockClosed, IconPlus } from '@appwrite.io/pink-icons-svelte';
     import ConnectGit from './connectGit.svelte';
+    import InstallationError from './installationError.svelte';
+    import {
+        getVcsInstallationErrorKind,
+        type VcsInstallationErrorKind
+    } from '$lib/helpers/vcsError';
     import SvgIcon from '../svgIcon.svelte';
     import { Query, VCSDetectionType, type Models } from '@appwrite.io/console';
     import { getFrameworkIcon } from '$lib/stores/sites';
@@ -34,6 +39,7 @@
         hasInstallations = $bindable($installations?.total > 0),
         product = 'functions',
         callbackState = null,
+        installationErrorKind = $bindable(null),
         connect = () => {}
     }: {
         action?: 'button' | 'select';
@@ -42,6 +48,14 @@
         hasInstallations?: boolean;
         product?: 'functions' | 'sites';
         callbackState?: Record<string, string> | null;
+        /**
+         * Read only output: set when the repository list failed because of the
+         * installation itself rather than because it is empty. Bind to it to
+         * hide surrounding copy that would be wrong while it is set, such as a
+         * "missing a repository? check your permissions" hint, which sends the
+         * user to fix scopes when the real problem is a dead token.
+         */
+        installationErrorKind?: VcsInstallationErrorKind | null;
         connect?: (repository: Models.ProviderRepository) => void;
     } = $props();
 
@@ -53,6 +67,12 @@
     let connectingRepositoryId = $state<string | null>(null);
     let loadRepositoriesRequestId = 0;
     const limit = 5;
+
+    // The installation the list is currently showing, so a failure can name the
+    // provider and owner the user has to go and reconnect.
+    const activeInstallation = $derived(
+        installationsMap?.find((entry) => entry.$id === selectedInstallation)
+    );
 
     onMount(() => {
         isLoadingRepositories = true;
@@ -104,7 +124,10 @@
                 );
             }
             installationsMap = installationList.installations;
-        } else {
+            return;
+        }
+
+        try {
             const { installations } = await sdk
                 .forProject(page.params.region, page.params.project)
                 .vcs.listInstallations();
@@ -115,37 +138,76 @@
                 installation.set(installations.find((entry) => entry.$id === selectedInstallation));
             }
             installationsMap = installations;
+        } catch (error) {
+            // Without this the disabled "Loading..." placeholder below never
+            // resolves, which reads as a hung UI rather than a failed request.
+            installationsMap = [];
+            isLoadingRepositories = false;
+            addNotification({
+                type: 'error',
+                message: error?.message ?? 'Failed to load Git installations'
+            });
         }
     }
 
     async function loadRepositories(installationId: string, search: string) {
         const requestId = ++loadRepositoriesRequestId;
+        installationErrorKind = null;
 
-        const result = await sdk
-            .forProject(page.params.region, page.params.project)
-            .vcs.listRepositories({
-                installationId,
-                type:
-                    product === 'functions' ? VCSDetectionType.Runtime : VCSDetectionType.Framework,
-                search: search || undefined,
-                queries: [Query.limit(limit), Query.offset(offset)]
+        try {
+            const result = await sdk
+                .forProject(page.params.region, page.params.project)
+                .vcs.listRepositories({
+                    installationId,
+                    type:
+                        product === 'functions'
+                            ? VCSDetectionType.Runtime
+                            : VCSDetectionType.Framework,
+                    search: search || undefined,
+                    queries: [Query.limit(limit), Query.offset(offset)]
+                });
+
+            // Stale request
+            if (requestId !== loadRepositoriesRequestId) {
+                return;
+            }
+
+            $repositories.repositories =
+                product === 'functions'
+                    ? (result as unknown as Models.ProviderRepositoryRuntimeList)
+                          .runtimeProviderRepositories
+                    : (result as unknown as Models.ProviderRepositoryFrameworkList)
+                          .frameworkProviderRepositories; //TODO: remove forced cast after backend fixes
+            $repositories.total = result.total;
+            $repositories.search = search;
+            $repositories.installationId = installationId;
+            return $repositories.repositories;
+        } catch (error) {
+            // Stale request
+            if (requestId !== loadRepositoriesRequestId) {
+                return;
+            }
+
+            const kind = getVcsInstallationErrorKind(error);
+            if (kind) {
+                // Drop the previous page only when something replaces it.
+                // Rendered in the list position, so the empty state never gets
+                // a chance to claim the installation simply has no repositories.
+                $repositories.repositories = [];
+                $repositories.total = 0;
+                $repositories.search = search;
+                $repositories.installationId = installationId;
+                installationErrorKind = kind;
+                return;
+            }
+
+            // Any other failure only gets a toast, so keep the previous page
+            // rather than swapping it for a bare "no repositories found".
+            addNotification({
+                type: 'error',
+                message: error?.message ?? 'Failed to load repositories'
             });
-
-        // Stale request
-        if (requestId !== loadRepositoriesRequestId) {
-            return;
         }
-
-        $repositories.repositories =
-            product === 'functions'
-                ? (result as unknown as Models.ProviderRepositoryRuntimeList)
-                      .runtimeProviderRepositories
-                : (result as unknown as Models.ProviderRepositoryFrameworkList)
-                      .frameworkProviderRepositories; //TODO: remove forced cast after backend fixes
-        $repositories.total = result.total;
-        $repositories.search = search;
-        $repositories.installationId = installationId;
-        return $repositories.repositories;
     }
 
     selectedRepository;
@@ -190,6 +252,10 @@
                                 window.location.href = connectGitHub(callbackState).toString();
                             }
                             search = '';
+                            // A different installation has its own health, so
+                            // clear immediately instead of leaving the previous
+                            // one's error up for the debounce window.
+                            installationErrorKind = null;
                             installation.set(
                                 installationsMap.find((entry) => entry.$id === selectedInstallation)
                             );
@@ -205,6 +271,12 @@
             <!-- manual installation change -->
             {#if isLoadingRepositories}
                 <SkeletonRepoList count={limit} />
+            {:else if installationErrorKind}
+                <InstallationError
+                    kind={installationErrorKind}
+                    provider={activeInstallation?.provider}
+                    organization={activeInstallation?.organization}
+                    onRetry={loadRepositoryPage} />
             {:else if $repositories.total > 0}
                 <Table.Root columns={1} let:root>
                     {#each $repositories.repositories as repo}

--- a/src/lib/components/git/selectRootModal.svelte
+++ b/src/lib/components/git/selectRootModal.svelte
@@ -7,7 +7,7 @@
     import { installation, repository } from '$lib/stores/vcs';
     import { VCSDetectionType, type Models } from '@appwrite.io/console';
     import DirectoryPicker from '$lib/components/git/DirectoryPicker.svelte';
-    import InstallationError from '$lib/components/git/installationError.svelte';
+    import InstallationError from './installationError.svelte';
     import {
         getVcsInstallationErrorKind,
         type VcsInstallationErrorKind

--- a/src/lib/components/git/selectRootModal.svelte
+++ b/src/lib/components/git/selectRootModal.svelte
@@ -7,6 +7,11 @@
     import { installation, repository } from '$lib/stores/vcs';
     import { VCSDetectionType, type Models } from '@appwrite.io/console';
     import DirectoryPicker from '$lib/components/git/DirectoryPicker.svelte';
+    import InstallationError from '$lib/components/git/installationError.svelte';
+    import {
+        getVcsInstallationErrorKind,
+        type VcsInstallationErrorKind
+    } from '$lib/helpers/vcsError';
     import { writable } from 'svelte/store';
 
     type Directory = {
@@ -32,6 +37,15 @@
     } = $props();
 
     let isLoading = $state(true);
+    /**
+     * Reading the tree goes through the installation token, so a dead token
+     * surfaces here as a failed contents call. Left unhandled the picker either
+     * sits on its spinner forever or renders an empty tree, both of which read
+     * as "this repository has no directories".
+     */
+    let installationErrorKind = $state<VcsInstallationErrorKind | null>(null);
+    /** Whether the root listing ever succeeded, so the tree has something real in it. */
+    let loadedRoot = $state(false);
     let directories = $state<Directory[]>([
         {
             title: 'Repository (root)',
@@ -218,12 +232,22 @@
         }
 
         for (const pathToLoad of pathsToLoad) {
-            const { fileCount, directories } = await fetchContents(pathToLoad);
-            const targetDir = getDirByPath(pathToLoad);
-            if (targetDir) {
-                targetDir.fileCount = fileCount;
+            try {
+                const { fileCount, directories } = await fetchContents(pathToLoad);
+                const targetDir = getDirByPath(pathToLoad);
+                if (targetDir) {
+                    targetDir.fileCount = fileCount;
+                }
+                ensureChildren(pathToLoad, directories);
+            } catch (error) {
+                const kind = getVcsInstallationErrorKind(error);
+                if (!kind) throw error;
+                // Every remaining segment goes through the same installation,
+                // so stop rather than firing a request per level that is
+                // already known to fail.
+                installationErrorKind = kind;
+                return;
             }
-            ensureChildren(pathToLoad, directories);
         }
     }
 
@@ -250,12 +274,17 @@
                     directories[0].thumbnailUrl = detectedIcon;
                 }
 
+                installationErrorKind = null;
+                loadedRoot = true;
                 isLoading = false;
                 expandedPaths = [...new Set([...expandedPaths, '/'])];
                 prefetchPath(rootDir || '/');
                 detectIconsForChildren('/');
             } catch (error) {
-                console.error('Failed to load root directory:', error);
+                installationErrorKind = getVcsInstallationErrorKind(error);
+                if (!installationErrorKind) {
+                    console.error('Failed to load root directory:', error);
+                }
                 isLoading = false;
             }
         })();
@@ -308,7 +337,12 @@
 
             expandedPaths = [...new Set([...expandedPaths, path])];
         } catch (error) {
-            console.error('Failed to load directory:', error);
+            const kind = getVcsInstallationErrorKind(error);
+            if (kind) {
+                installationErrorKind = kind;
+            } else {
+                console.error('Failed to load directory:', error);
+            }
         } finally {
             targetDir.loading = false;
             inFlightPaths.delete(path);
@@ -360,7 +394,9 @@
     }
 
     $effect(() => {
-        if (show && !initialized && !isLoading) {
+        // `loadedRoot` gates this: without a real tree, expanding walks paths
+        // that are not there and fires one doomed request per segment.
+        if (show && !initialized && !isLoading && loadedRoot) {
             initialized = true;
             const normalized = normalizePath(rootDir || '/');
             initialPath = normalized;
@@ -380,6 +416,18 @@
         loadPath(detail.fullPath);
     }
 
+    function retryLoad() {
+        installationErrorKind = null;
+        if (loadedRoot) {
+            // Only a deeper directory failed, so the tree is still usable.
+            loadPath(currentPath);
+            return;
+        }
+        // Re-runs the root effect, the only thing that can populate the tree.
+        initialized = false;
+        isLoading = true;
+    }
+
     function handleSubmit() {
         rootDir = currentPath;
         show = false;
@@ -390,16 +438,25 @@
     <span slot="description">
         Select the directory where your site code is located using the menu below.
     </span>
-    <DirectoryPicker
-        {directories}
-        {isLoading}
-        expanded={expandedStore}
-        bind:selected={currentPath}
-        openTo={initialPath}
-        onSelect={handleSelect} />
+    {#if installationErrorKind}
+        <InstallationError
+            kind={installationErrorKind}
+            provider={$installation?.provider}
+            organization={$installation?.organization}
+            onRetry={retryLoad} />
+    {/if}
+    {#if loadedRoot || !installationErrorKind}
+        <DirectoryPicker
+            {directories}
+            {isLoading}
+            expanded={expandedStore}
+            bind:selected={currentPath}
+            openTo={initialPath}
+            onSelect={handleSelect} />
+    {/if}
 
     <svelte:fragment slot="footer">
         <Button secondary on:click={() => (show = false)}>Cancel</Button>
-        <Button submit disabled={isLoading || !hasChanges}>Save</Button>
+        <Button submit disabled={isLoading || !hasChanges || !loadedRoot}>Save</Button>
     </svelte:fragment>
 </Modal>

--- a/src/lib/helpers/vcsError.test.ts
+++ b/src/lib/helpers/vcsError.test.ts
@@ -1,0 +1,73 @@
+import { getVcsInstallationErrorKind } from '$lib/helpers/vcsError';
+import { describe, expect, it } from 'vitest';
+
+describe('getVcsInstallationErrorKind', () => {
+    it('returns null for values that are not error-like objects', () => {
+        expect(getVcsInstallationErrorKind(null)).toBe(null);
+        expect(getVcsInstallationErrorKind(undefined)).toBe(null);
+        expect(getVcsInstallationErrorKind('general_provider_failure')).toBe(null);
+        expect(getVcsInstallationErrorKind(400)).toBe(null);
+    });
+
+    it('returns null for unrelated error types', () => {
+        expect(getVcsInstallationErrorKind({ type: 'general_unknown', message: 'reconnect' })).toBe(
+            null
+        );
+        expect(getVcsInstallationErrorKind({ message: 'Please reconnect the installation.' })).toBe(
+            null
+        );
+    });
+
+    it('classifies a held refresh lock as locked', () => {
+        expect(getVcsInstallationErrorKind({ type: 'general_resource_locked' })).toBe('locked');
+        expect(
+            getVcsInstallationErrorKind({
+                type: 'general_resource_locked',
+                message: 'The resource is currently locked.',
+                status: 409
+            })
+        ).toBe('locked');
+    });
+
+    it('classifies a dead installation token as reconnect', () => {
+        expect(
+            getVcsInstallationErrorKind({
+                type: 'general_provider_failure',
+                message: 'This installation has no refresh token on file. Please reconnect it.',
+                status: 400
+            })
+        ).toBe('reconnect');
+
+        expect(
+            getVcsInstallationErrorKind({
+                type: 'general_provider_failure',
+                message: 'Failed to refresh OAuth2 access token. Please reconnect the installation.'
+            })
+        ).toBe('reconnect');
+    });
+
+    it('matches the reconnect hint regardless of case', () => {
+        expect(
+            getVcsInstallationErrorKind({
+                type: 'general_provider_failure',
+                message: 'Please RECONNECT the installation.'
+            })
+        ).toBe('reconnect');
+    });
+
+    it('classifies any other provider failure as provider', () => {
+        expect(
+            getVcsInstallationErrorKind({
+                type: 'general_provider_failure',
+                message: 'GitHub API rate limit exceeded.'
+            })
+        ).toBe('provider');
+    });
+
+    it('falls back to provider when the failure carries no usable message', () => {
+        expect(getVcsInstallationErrorKind({ type: 'general_provider_failure' })).toBe('provider');
+        expect(
+            getVcsInstallationErrorKind({ type: 'general_provider_failure', message: undefined })
+        ).toBe('provider');
+    });
+});

--- a/src/lib/helpers/vcsError.ts
+++ b/src/lib/helpers/vcsError.ts
@@ -1,48 +1,28 @@
 /**
- * Classifying failures that come from the VCS installation itself rather than
- * from the repository, branch or directory being genuinely empty.
+ * Classifies failures coming from the VCS installation itself rather than from
+ * a repository, branch or directory being genuinely empty. Every VCS read
+ * endpoint refreshes the installation's OAuth token first, so a dead token
+ * surfaces as a failure on an ordinary list call.
  *
- * Every VCS read endpoint (list repositories, list branches, list namespaces,
- * get repository contents) refreshes the installation's OAuth token first, so
- * a dead token surfaces as a failure on an otherwise ordinary list call. Left
- * unclassified these all render as a successful empty result ("No repositories
- * found", "No branches available", a spinner that never resolves), which is the
- * opposite of what happened.
- */
-
-/**
- * How a failed VCS call should be explained to the user.
- *
- * - `reconnect` - the installation's stored OAuth token is dead and cannot be
- *   refreshed. Only the user can fix it, by re-authorizing the installation.
- * - `locked` - a concurrent token refresh holds the lock. Transient; retrying
- *   works. The installation is fine, so never lead with a reconnect here.
- * - `provider` - the provider itself failed (outage, rate limit). Also
- *   transient, but a dead token can land here too (see below), so a reconnect
- *   stays available as a secondary action.
+ * - `reconnect` - the stored token is dead, only re-authorizing fixes it.
+ * - `locked` - a concurrent refresh holds the lock, retrying works.
+ * - `provider` - the provider failed (outage, rate limit), retry first.
  */
 export type VcsInstallationErrorKind = 'reconnect' | 'locked' | 'provider';
 
 /**
- * Classify an error thrown by a VCS endpoint that refreshes the installation
- * token. Returns `null` for anything that is not an installation-level failure,
- * so callers can fall through to their normal error handling.
+ * Returns `null` for anything that is not an installation-level failure, so
+ * callers fall through to their normal error handling.
  *
- * The API reports both a dead installation token and a genuine provider outage
- * as `general_provider_failure`, so the message substring is the only
- * discriminator we get: the token failures are the ones whose copy asks the
- * user to reconnect ("Please reconnect it.", "Please reconnect the
- * installation."). That copy is authored in the backend's
- * `Appwrite\Vcs\InstallationTokens` (`refresh()` and `exchange()`, see
- * `src/Appwrite/Vcs/InstallationTokens.php` in appwrite/appwrite); if it is
- * ever reworded this falls back to `provider`, which still shows a real error
- * and still offers a reconnect, just with outage-first wording.
+ * The API reports a dead token and a provider outage identically as
+ * `general_provider_failure`, so the message is the only discriminator: the
+ * token failures are the ones asking the user to reconnect. That copy lives in
+ * `Appwrite\Vcs\InstallationTokens` (appwrite/appwrite); reword it there and
+ * this degrades to `provider`, which still shows a real error.
  *
- * Deliberately a structural cast and not an `instanceof AppwriteException`
- * check: `hooks.client.ts` unwraps thrown SDK errors into plain
- * `{ message, status, type }` objects before they reach `page.error`, so an
- * `instanceof` check would miss exactly the load-function failures this exists
- * to catch.
+ * Structural cast rather than `instanceof AppwriteException`, because
+ * `hooks.client.ts` unwraps SDK errors into plain objects before they reach
+ * `page.error`.
  */
 export function getVcsInstallationErrorKind(error: unknown): VcsInstallationErrorKind | null {
     if (!error || typeof error !== 'object') return null;

--- a/src/lib/helpers/vcsError.ts
+++ b/src/lib/helpers/vcsError.ts
@@ -1,0 +1,57 @@
+/**
+ * Classifying failures that come from the VCS installation itself rather than
+ * from the repository, branch or directory being genuinely empty.
+ *
+ * Every VCS read endpoint (list repositories, list branches, list namespaces,
+ * get repository contents) refreshes the installation's OAuth token first, so
+ * a dead token surfaces as a failure on an otherwise ordinary list call. Left
+ * unclassified these all render as a successful empty result ("No repositories
+ * found", "No branches available", a spinner that never resolves), which is the
+ * opposite of what happened.
+ */
+
+/**
+ * How a failed VCS call should be explained to the user.
+ *
+ * - `reconnect` - the installation's stored OAuth token is dead and cannot be
+ *   refreshed. Only the user can fix it, by re-authorizing the installation.
+ * - `locked` - a concurrent token refresh holds the lock. Transient; retrying
+ *   works. The installation is fine, so never lead with a reconnect here.
+ * - `provider` - the provider itself failed (outage, rate limit). Also
+ *   transient, but a dead token can land here too (see below), so a reconnect
+ *   stays available as a secondary action.
+ */
+export type VcsInstallationErrorKind = 'reconnect' | 'locked' | 'provider';
+
+/**
+ * Classify an error thrown by a VCS endpoint that refreshes the installation
+ * token. Returns `null` for anything that is not an installation-level failure,
+ * so callers can fall through to their normal error handling.
+ *
+ * The API reports both a dead installation token and a genuine provider outage
+ * as `general_provider_failure`, so the message substring is the only
+ * discriminator we get: the token failures are the ones whose copy asks the
+ * user to reconnect ("Please reconnect it.", "Please reconnect the
+ * installation."). That copy is authored in the backend's
+ * `Appwrite\Vcs\InstallationTokens` (`refresh()` and `exchange()`, see
+ * `src/Appwrite/Vcs/InstallationTokens.php` in appwrite/appwrite); if it is
+ * ever reworded this falls back to `provider`, which still shows a real error
+ * and still offers a reconnect, just with outage-first wording.
+ *
+ * Deliberately a structural cast and not an `instanceof AppwriteException`
+ * check: `hooks.client.ts` unwraps thrown SDK errors into plain
+ * `{ message, status, type }` objects before they reach `page.error`, so an
+ * `instanceof` check would miss exactly the load-function failures this exists
+ * to catch.
+ */
+export function getVcsInstallationErrorKind(error: unknown): VcsInstallationErrorKind | null {
+    if (!error || typeof error !== 'object') return null;
+
+    const { type, message } = error as { type?: string; message?: string };
+
+    if (type === 'general_resource_locked') return 'locked';
+    if (type !== 'general_provider_failure') return null;
+
+    const text = typeof message === 'string' ? message.toLowerCase() : '';
+    return text.includes('reconnect') ? 'reconnect' : 'provider';
+}

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/+page.svelte
@@ -23,32 +23,40 @@
     import { Button } from '$lib/elements/forms';
     import { getIconFromRuntime } from '$lib/stores/runtimes';
     import { regionalConsoleVariables } from '../../store';
+    import type { VcsInstallationErrorKind } from '$lib/helpers/vcsError';
 
-    export let data;
+    let { data } = $props();
 
     const isVcsEnabled = $regionalConsoleVariables?._APP_VCS_ENABLED === true;
     const wizardBase = resolveRoute('/(console)/project-[region]-[project]/functions', page.params);
 
-    let selectedRepository: string;
+    let selectedRepository: string = $state(null);
+    // Set by <Repositories> when the list failed because the installation is
+    // broken. The permissions link below is the wrong advice then: the
+    // repositories are not hidden by scopes, Appwrite cannot read any of them.
+    let installationErrorKind = $state<VcsInstallationErrorKind | null>(null);
 
-    const featuredTemplates = data.templates
-        .filter((template) => template.id !== 'starter')
-        .slice(0, 4);
-
-    const starterTemplate = data.templates.find((template) => template.id === 'starter');
-
-    const latestRuntimesByKey = new Map<string, Models.Runtime>();
-    for (const runtime of data.runtimesList.runtimes) {
-        latestRuntimesByKey.set(runtime.key, runtime);
-    }
-
-    const starterTemplateRuntimeIds = new Set<string>(
-        starterTemplate?.runtimes.map((runtime) => runtime.name) ?? []
+    const featuredTemplates = $derived(
+        data.templates.filter((template) => template.id !== 'starter').slice(0, 4)
     );
 
-    const starterTemplateRuntimes = [...latestRuntimesByKey.values()].filter((runtime) =>
-        starterTemplateRuntimeIds.has(runtime.$id)
-    );
+    const starterTemplate = $derived(data.templates.find((template) => template.id === 'starter'));
+
+    const starterTemplateRuntimes = $derived.by(() => {
+        const starterRuntimeIds = new Set<string>(
+            starterTemplate?.runtimes.map((runtime) => runtime.name) ?? []
+        );
+
+        // Keyed by `key` so only the newest version of each runtime survives.
+        const latestRuntimesByKey = new Map<string, Models.Runtime>();
+        for (const runtime of data.runtimesList.runtimes) {
+            latestRuntimesByKey.set(runtime.key, runtime);
+        }
+
+        return [...latestRuntimesByKey.values()].filter((runtime) =>
+            starterRuntimeIds.has(runtime.$id)
+        );
+    });
 
     function connect(e: Models.ProviderRepository) {
         trackEvent(Click.ConnectRepositoryClick, { from: 'cover' });
@@ -103,6 +111,7 @@
 
                             <Repositories
                                 bind:selectedRepository
+                                bind:installationErrorKind
                                 action="button"
                                 callbackState={{
                                     from: 'github',
@@ -110,7 +119,7 @@
                                 }}
                                 {connect} />
                         </Layout.Stack>
-                        {#if $installation}
+                        {#if $installation && !installationErrorKind}
                             <Layout.Stack gap="l">
                                 <Divider />
                                 <Link

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
     import { invalidate } from '$app/navigation';
     import { Modal, Card } from '$lib/components';
-    import { Repositories, BranchSelector } from '$lib/components/git';
+    import { Repositories, BranchSelector, InstallationError } from '$lib/components/git';
     import { Dependencies } from '$lib/constants';
     import { Link } from '$lib/elements';
     import { Button, InputCheckbox } from '$lib/elements/forms';
     import { timeFromNow } from '$lib/helpers/date';
+    import {
+        getVcsInstallationErrorKind,
+        type VcsInstallationErrorKind
+    } from '$lib/helpers/vcsError';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
@@ -20,22 +24,40 @@
     import { func } from '../store';
     import { page } from '$app/state';
 
-    export let show = false;
+    let {
+        show = $bindable(false),
+        installations
+    }: {
+        show?: boolean;
+        installations: Models.InstallationList;
+    } = $props();
 
-    export let installations: Models.InstallationList;
-    let hasRepository = !!$func?.providerRepositoryId;
-    let selectedRepository: string = $func.providerRepositoryId;
-    let branch: string = null;
-    let commit: string = null;
-    let activate = true;
-    let error = '';
+    let hasRepository = $state(!!$func?.providerRepositoryId);
+    let selectedRepository: string = $state($func.providerRepositoryId);
+    let branch: string = $state(null);
+    let commit: string = $state(null);
+    let activate = $state(true);
+    let error = $state('');
+    let isLoadingRepository = $state(true);
+    /**
+     * Looking the repository up refreshes the installation token first, so a
+     * dead token fails here rather than on anything to do with the repository.
+     * Without this the modal renders a repository card with nothing in it and a
+     * branch picker that can never fill, while "Create" stays live for a
+     * deployment that cannot be created.
+     */
+    let installationErrorKind = $state<VcsInstallationErrorKind | null>(null);
 
-    async function loadInstallations() {
+    // Deliberately not `$state`: a guard so opening the modal loads once, not
+    // something the template reads.
+    let loadStarted = false;
+
+    function loadInstallations() {
         if (!$func?.installationId && installations?.total > 0) {
             installation.set(installations.installations[0]);
         }
         $installation = installations.installations.find(
-            (installation) => installation.$id === $func.installationId
+            (entry) => entry.$id === $func.installationId
         );
         if (!$installation?.$id) {
             $installation = installations.installations[0];
@@ -43,8 +65,10 @@
     }
 
     async function load() {
+        isLoadingRepository = true;
+        installationErrorKind = null;
         try {
-            await loadInstallations();
+            loadInstallations();
             if (!$repository?.id && hasRepository) {
                 $repository = await sdk
                     .forProject(page.params.region, page.params.project)
@@ -56,8 +80,13 @@
             selectedRepository = $repository?.id;
 
             branch = $func.providerBranch || 'main';
-        } catch {
-            return;
+        } catch (e) {
+            installationErrorKind = getVcsInstallationErrorKind(e);
+            if (!installationErrorKind) {
+                error = e.message;
+            }
+        } finally {
+            isLoadingRepository = false;
         }
     }
 
@@ -118,13 +147,22 @@
         }
     }
 
-    $: if (!show) {
+    $effect(() => {
+        if (!show || !hasRepository || loadStarted) return;
+        loadStarted = true;
+        load();
+    });
+
+    $effect(() => {
+        if (show) return;
         error = '';
         branch = null;
         commit = null;
         activate = true;
         hasRepository = !!$func?.providerRepositoryId;
-    }
+        installationErrorKind = null;
+        loadStarted = false;
+    });
 </script>
 
 <Modal title="Create Git deployment" bind:show onSubmit={createDeployment} bind:error>
@@ -134,7 +172,7 @@
             external>Learn more</Link>
     </span>
     {#if hasRepository}
-        {#await load()}
+        {#if isLoadingRepository}
             <Card padding="xs" radius="s" variant="secondary">
                 <Layout.Stack
                     direction="row"
@@ -151,7 +189,13 @@
                 <Skeleton variant="line" width={100} height={19.6} />
                 <Skeleton variant="line" width={350} height={31} />
             </Layout.Stack>
-        {:then}
+        {:else if installationErrorKind}
+            <InstallationError
+                kind={installationErrorKind}
+                provider={$installation?.provider}
+                organization={$installation?.organization}
+                onRetry={load} />
+        {:else}
             <Card padding="xs" radius="s" variant="secondary">
                 <Layout.Stack
                     direction="row"
@@ -193,10 +237,11 @@
                 unchecked, it will remain inactive, and you can activate it manually later."
                     bind:checked={activate} />
             {/if}
-        {/await}
+        {/if}
     {:else}
         <Repositories
             bind:selectedRepository
+            bind:installationErrorKind
             installationList={installations}
             product="functions"
             action="button"
@@ -210,7 +255,15 @@
     {/if}
     <svelte:fragment slot="footer">
         <Button text size="s" on:click={() => (show = false)}>Cancel</Button>
-        <Button submit size="s" disabled={!$installation?.$id || !selectedRepository || !branch}>
+        <!-- A broken installation fails every call this needs, so offer the
+             reconnect above instead of a submit that cannot succeed. -->
+        <Button
+            submit
+            size="s"
+            disabled={!!installationErrorKind ||
+                !$installation?.$id ||
+                !selectedRepository ||
+                !branch}>
             Create
         </Button>
     </svelte:fragment>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRepository.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/settings/updateRepository.svelte
@@ -7,17 +7,19 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Query, Runtime, type Models, type ProjectKeyScopes } from '@appwrite.io/console';
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import DisconnectRepo from './disconnectRepo.svelte';
     import { installation, repository as repositoryStore, sortBranches } from '$lib/stores/vcs';
     import {
+        Alert,
         Empty,
         Fieldset,
         Icon,
         Layout,
         Skeleton,
         Card as PinkCard,
-        Selector
+        Selector,
+        Typography
     } from '@appwrite.io/pink-svelte';
     import Card from '$lib/components/card.svelte';
     import { IconGithub } from '@appwrite.io/pink-icons-svelte';
@@ -25,53 +27,127 @@
         ConnectGit,
         ConnectRepoModal,
         RepositoryCard,
-        BranchSelector
+        BranchSelector,
+        InstallationError
     } from '$lib/components/git';
+    import {
+        getVcsInstallationErrorKind,
+        type VcsInstallationErrorKind
+    } from '$lib/helpers/vcsError';
     import { isValueOfStringEnum } from '$lib/helpers/types';
     import { page } from '$app/state';
     import SelectRootModal from '$lib/components/git/selectRootModal.svelte';
 
-    export let func: Models.Function;
-    export let installations: Models.InstallationList;
+    type Props = {
+        func: Models.Function;
+        installations: Models.InstallationList;
+    };
 
-    let selectedBranch = func?.providerBranch;
-    let silentMode = func?.providerSilentMode ?? false;
-    let selectedDir = func?.providerRootDirectory;
-    let showDisconnect = false;
-    let showConnectRepo = false;
-    let showSelectRoot = false;
-    let repository: Models.ProviderRepository | null | false = false;
+    let { func, installations }: Props = $props();
+
+    /**
+     * Four states, deliberately not three.
+     *
+     * `disconnected` means the function has no repository. `error` means it has
+     * one we could not read. This used to be a single `null` repository, so a
+     * repository that could not be fetched rendered as "No repository is
+     * connected to this function yet" and invited the user to connect a
+     * repository that is already connected. The failure is almost always the
+     * Git installation's OAuth token, which is what the user actually has to
+     * fix.
+     */
+    type RepositoryStatus = 'loading' | 'connected' | 'disconnected' | 'error';
+
+    let status = $state<RepositoryStatus>('loading');
+    let repository = $state<Models.ProviderRepository | null>(null);
+    /** Populated only while `status === 'error'`; never conflated with "no repository". */
+    let repositoryError = $state<{
+        kind: VcsInstallationErrorKind | null;
+        message: string;
+    } | null>(null);
+
+    // Seeded from the function once: these are the user's in-progress edits, so
+    // they must not silently track the prop while the form is being filled in.
+    let selectedBranch = $state(untrack(() => func?.providerBranch));
+    let silentMode = $state(untrack(() => func?.providerSilentMode ?? false));
+    let selectedDir = $state(untrack(() => func?.providerRootDirectory));
+    let showDisconnect = $state(false);
+    let showConnectRepo = $state(false);
+    let showSelectRoot = $state(false);
+
+    /**
+     * The installation the failed lookup actually used, so the alert can name
+     * the account that needs reconnecting rather than whichever installation
+     * happens to be selected.
+     */
+    const errorInstallation = $derived(
+        installations?.installations?.find((item) => item.$id === func?.installationId) ??
+            $installation
+    );
+
+    /**
+     * The function document stores the provider's repository id but never its
+     * name, so this is as much identity as we can show without a successful
+     * lookup. Showing it keeps the card honest about still being connected.
+     */
+    const connectedRepositoryLabel = $derived(
+        func?.providerRepositoryId
+            ? `Repository ID: ${func.providerRepositoryId}`
+            : 'Connected repository'
+    );
+
+    const connectedRepositoryDetails = $derived(
+        [
+            func?.providerBranch ? `Branch: ${func.providerBranch}` : null,
+            func?.providerRootDirectory ? `Root directory: ${func.providerRootDirectory}` : null
+        ]
+            .filter(Boolean)
+            .join(' • ')
+    );
 
     onMount(() => {
         selectedBranch = func?.providerBranch;
         silentMode = func?.providerSilentMode ?? false;
         selectedDir = func?.providerRootDirectory;
-        const inst = installations?.installations.find(
-            (installation) => installation.$id === func?.installationId
-        );
+        const inst = installations?.installations.find((item) => item.$id === func?.installationId);
         installation.set(inst ?? installations?.installations[0]);
         loadRepository();
     });
 
     async function loadRepository() {
+        if (!func?.installationId || !func?.providerRepositoryId) {
+            repository = null;
+            repositoryError = null;
+            status = 'disconnected';
+            return;
+        }
+
+        status = 'loading';
+        repositoryError = null;
+
         try {
-            if (func.installationId && func.providerRepositoryId) {
-                repository = await sdk
-                    .forProject(page.params.region, page.params.project)
-                    .vcs.getRepository({
-                        installationId: func.installationId,
-                        providerRepositoryId: func.providerRepositoryId
-                    });
-                repositoryStore.set(repository);
-            }
-        } catch (err) {
-            console.warn(err);
-        } finally {
-            if (repository === false) {
-                repository = null;
-            }
+            const loaded = await sdk
+                .forProject(page.params.region, page.params.project)
+                .vcs.getRepository({
+                    installationId: func.installationId,
+                    providerRepositoryId: func.providerRepositoryId
+                });
+            repository = loaded;
+            repositoryStore.set(loaded);
+            status = 'connected';
+        } catch (error) {
+            // The function still points at a repository, so this is not a
+            // disconnection. Report the lookup failure and keep the connection
+            // visible instead of blanking the card.
+            repository = null;
+            repositoryError = {
+                kind: getVcsInstallationErrorKind(error),
+                message: error?.message ?? ''
+            };
+            status = 'error';
         }
     }
+
     async function updateConfiguration() {
         try {
             if (!isValueOfStringEnum(Runtime, func.runtime)) {
@@ -112,14 +188,18 @@
             trackError(error, Submit.FunctionUpdateConfiguration);
         }
     }
-    $: if (func?.installationId && func?.providerRepositoryId) {
-        selectedBranch = func?.providerBranch ?? 'main';
-    }
 
-    $: isUpdateButtonEnabled =
+    $effect(() => {
+        if (func?.installationId && func?.providerRepositoryId) {
+            selectedBranch = func?.providerBranch ?? 'main';
+        }
+    });
+
+    const isUpdateButtonEnabled = $derived(
         selectedBranch !== func?.providerBranch ||
-        silentMode !== func?.providerSilentMode ||
-        selectedDir !== func?.providerRootDirectory;
+            silentMode !== func?.providerSilentMode ||
+            selectedDir !== func?.providerRootDirectory
+    );
 
     async function connect(selectedInstallationId: string, selectedRepository: string) {
         let nextBranch = func?.providerBranch ?? 'main';
@@ -178,11 +258,11 @@
 </script>
 
 <Form onSubmit={updateConfiguration}>
-    <CardGrid hideFooter={!repository}>
+    <CardGrid hideFooter={status !== 'connected'}>
         <svelte:fragment slot="title">Git repository</svelte:fragment>
         Automatically deploy changes for every commit pushed to your Git repository.
         <svelte:fragment slot="aside">
-            {#if repository === false}
+            {#if status === 'loading'}
                 <Layout.Stack gap="xl">
                     <Card padding="xs" radius="s" variant="secondary">
                         <Layout.Stack
@@ -218,7 +298,7 @@
                         </Layout.Stack>
                     </Fieldset>
                 </Layout.Stack>
-            {:else if repository}
+            {:else if status === 'connected'}
                 <Layout.Stack gap="xl">
                     <RepositoryCard {repository} on:disconnect={() => (showDisconnect = true)} />
                     <Fieldset legend="Branch">
@@ -246,6 +326,44 @@
                                 bind:checked={silentMode} />
                         </Layout.Stack>
                     </Fieldset>
+                </Layout.Stack>
+            {:else if status === 'error'}
+                <Layout.Stack gap="xl">
+                    <Card padding="xs" radius="s" variant="secondary">
+                        <Layout.Stack direction="row" alignItems="flex-start" gap="s">
+                            <Icon icon={IconGithub} color="--fgcolor-neutral-primary" />
+                            <Layout.Stack gap="xxxs">
+                                <Typography.Text variant="m-400" color="--fgcolor-neutral-primary">
+                                    {connectedRepositoryLabel}
+                                </Typography.Text>
+                                {#if connectedRepositoryDetails}
+                                    <Typography.Caption
+                                        variant="400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        {connectedRepositoryDetails}
+                                    </Typography.Caption>
+                                {/if}
+                            </Layout.Stack>
+                        </Layout.Stack>
+                    </Card>
+
+                    {#if repositoryError?.kind}
+                        <InstallationError
+                            kind={repositoryError.kind}
+                            provider={errorInstallation?.provider}
+                            organization={errorInstallation?.organization}
+                            onRetry={loadRepository} />
+                    {:else}
+                        <Alert.Inline
+                            status="warning"
+                            title="Could not load the connected repository">
+                            {repositoryError?.message ||
+                                'This function is still connected to a Git repository, but its details could not be loaded.'}
+                            <svelte:fragment slot="actions">
+                                <Button compact on:click={loadRepository}>Try again</Button>
+                            </svelte:fragment>
+                        </Alert.Inline>
+                    {/if}
                 </Layout.Stack>
             {:else if func.installationId || installations?.total}
                 <PinkCard.Base padding="none" border="dashed">

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte
@@ -8,12 +8,17 @@
     import { Wizard } from '$lib/layout';
     import { resolveRoute } from '$lib/stores/navigation.js';
     import { installation, repository } from '$lib/stores/vcs.js';
+    import type { VcsInstallationErrorKind } from '$lib/helpers/vcsError';
     import type { Models } from '@appwrite.io/console';
     import { Fieldset, Layout, Typography } from '@appwrite.io/pink-svelte';
 
     let { data } = $props();
 
     let selectedRepository: string = $state(null);
+    // Set by <Repositories> when the list failed because the installation is
+    // broken. The "Missing a repository?" aside then points at the wrong fix:
+    // the repositories are not missing, Appwrite cannot read any of them.
+    let installationErrorKind = $state<VcsInstallationErrorKind | null>(null);
 
     function onConnect(e: Models.ProviderRepository) {
         trackEvent(Click.ConnectRepositoryClick, {
@@ -40,55 +45,67 @@
         <Fieldset legend="Git repository">
             <Repositories
                 bind:selectedRepository
+                bind:installationErrorKind
                 product="sites"
                 action="button"
                 connect={onConnect} />
         </Fieldset>
     {:else}
-        <Repositories bind:selectedRepository product="sites" action="button" connect={onConnect} />
+        <Repositories
+            bind:selectedRepository
+            bind:installationErrorKind
+            product="sites"
+            action="button"
+            connect={onConnect} />
     {/if}
 
     <svelte:fragment slot="aside">
-        <Card radius="s" padding="s">
-            <Layout.Stack gap="l">
-                {#if !data?.installations?.total}
-                    <Layout.Stack gap="xxs">
-                        <Typography.Text variation="m-400">
-                            Don't have a repository set up yet? Explore our templates, available in
-                            all your favorite frameworks, and deploy in seconds.
-                        </Typography.Text>
-                    </Layout.Stack>
-                    <Button
-                        href={resolveRoute(
-                            '/(console)/project-[region]-[project]/sites/create-site/templates',
-                            page.params
-                        )}
-                        secondary>View templates</Button>
-                {:else}
-                    <Layout.Stack gap="s">
-                        <Typography.Text variation="m-500" color="--fgcolor-neutral-primary">
-                            Missing a repository?
-                        </Typography.Text>
-                        <Typography.Text variation="m-400">
-                            Make sure Appwrite has access to your GitHub repositories. If you chose
-                            specific repos, you may need to update your permissions to include the
-                            missing one.
-                        </Typography.Text>
-                    </Layout.Stack>
-                    <Layout.Stack gap="s" direction="row">
+        <!-- Both halves of this aside are wrong once the installation is broken:
+             the templates pitch assumes there is nothing connected yet, and the
+             permissions copy assumes Appwrite can still read the account. The
+             error rendered in the main column carries the real fix. -->
+        {#if !installationErrorKind}
+            <Card radius="s" padding="s">
+                <Layout.Stack gap="l">
+                    {#if !data?.installations?.total}
+                        <Layout.Stack gap="xxs">
+                            <Typography.Text variation="m-400">
+                                Don't have a repository set up yet? Explore our templates, available
+                                in all your favorite frameworks, and deploy in seconds.
+                            </Typography.Text>
+                        </Layout.Stack>
                         <Button
-                            href="https://appwrite.io/docs/products/sites/deploy-from-git"
-                            external
-                            secondary>Docs</Button>
-                        {#if $installation}
+                            href={resolveRoute(
+                                '/(console)/project-[region]-[project]/sites/create-site/templates',
+                                page.params
+                            )}
+                            secondary>View templates</Button>
+                    {:else}
+                        <Layout.Stack gap="s">
+                            <Typography.Text variation="m-500" color="--fgcolor-neutral-primary">
+                                Missing a repository?
+                            </Typography.Text>
+                            <Typography.Text variation="m-400">
+                                Make sure Appwrite has access to your GitHub repositories. If you
+                                chose specific repos, you may need to update your permissions to
+                                include the missing one.
+                            </Typography.Text>
+                        </Layout.Stack>
+                        <Layout.Stack gap="s" direction="row">
                             <Button
-                                href={`https://github.com/settings/installations/${$installation.providerInstallationId}`}
+                                href="https://appwrite.io/docs/products/sites/deploy-from-git"
                                 external
-                                text>Go to GitHub</Button>
-                        {/if}
-                    </Layout.Stack>
-                {/if}
-            </Layout.Stack>
-        </Card>
+                                secondary>Docs</Button>
+                            {#if $installation}
+                                <Button
+                                    href={`https://github.com/settings/installations/${$installation.providerInstallationId}`}
+                                    external
+                                    text>Go to GitHub</Button>
+                            {/if}
+                        </Layout.Stack>
+                    {/if}
+                </Layout.Stack>
+            </Card>
+        {/if}
     </svelte:fragment>
 </Wizard>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
@@ -2,11 +2,15 @@
     import { invalidate } from '$app/navigation';
     import { page } from '$app/state';
     import { Modal, Card } from '$lib/components';
-    import { Repositories, BranchSelector } from '$lib/components/git';
+    import { Repositories, BranchSelector, InstallationError } from '$lib/components/git';
     import { Dependencies } from '$lib/constants';
     import { Link } from '$lib/elements';
     import { Button, InputCheckbox } from '$lib/elements/forms';
     import { timeFromNow } from '$lib/helpers/date';
+    import {
+        getVcsInstallationErrorKind,
+        type VcsInstallationErrorKind
+    } from '$lib/helpers/vcsError';
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
@@ -19,24 +23,46 @@
     } from '@appwrite.io/console';
     import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Skeleton, Typography } from '@appwrite.io/pink-svelte';
+    import { untrack } from 'svelte';
 
-    export let show = false;
-    export let site: Models.Site;
+    let {
+        show = $bindable(false),
+        site,
+        installations
+    }: {
+        show?: boolean;
+        site: Models.Site;
+        installations: Models.InstallationList;
+    } = $props();
 
-    export let installations: Models.InstallationList;
-    let hasRepository = !!site?.providerRepositoryId;
-    let selectedRepository: string = site.providerRepositoryId;
-    let branch: string = null;
-    let commit: string = null;
-    let activate = true;
-    let error = '';
+    // Seeded from the site once, then owned locally: connecting a repository in
+    // the modal flips `hasRepository` before the site itself has been updated.
+    let hasRepository = $state(untrack(() => !!site?.providerRepositoryId));
+    let selectedRepository: string = $state(untrack(() => site.providerRepositoryId));
+    let branch: string = $state(null);
+    let commit: string = $state(null);
+    let activate = $state(true);
+    let error = $state('');
+    let isLoadingRepository = $state(true);
+    /**
+     * Looking the repository up refreshes the installation token first, so a
+     * dead token fails here rather than on anything to do with the repository.
+     * Without this the modal renders a repository card with nothing in it and a
+     * branch picker that can never fill, while "Create" stays live for a
+     * deployment that cannot be created.
+     */
+    let installationErrorKind = $state<VcsInstallationErrorKind | null>(null);
 
-    async function loadInstallations() {
+    // Deliberately not `$state`: a guard so opening the modal loads once, not
+    // something the template reads.
+    let loadStarted = false;
+
+    function loadInstallations() {
         if (!site?.installationId && installations?.total > 0) {
             installation.set(installations.installations[0]);
         }
         $installation = installations.installations.find(
-            (installation) => installation.$id === site.installationId
+            (entry) => entry.$id === site.installationId
         );
         if (!$installation?.$id) {
             $installation = installations.installations[0];
@@ -44,8 +70,10 @@
     }
 
     async function load() {
+        isLoadingRepository = true;
+        installationErrorKind = null;
         try {
-            await loadInstallations();
+            loadInstallations();
             if (!$repository?.id && hasRepository) {
                 $repository = await sdk
                     .forProject(page.params.region, page.params.project)
@@ -57,8 +85,13 @@
             selectedRepository = $repository?.id;
 
             branch = site.providerBranch || 'main';
-        } catch {
-            return;
+        } catch (e) {
+            installationErrorKind = getVcsInstallationErrorKind(e);
+            if (!installationErrorKind) {
+                error = e.message;
+            }
+        } finally {
+            isLoadingRepository = false;
         }
     }
 
@@ -119,13 +152,22 @@
         }
     }
 
-    $: if (!show) {
+    $effect(() => {
+        if (!show || !hasRepository || loadStarted) return;
+        loadStarted = true;
+        load();
+    });
+
+    $effect(() => {
+        if (show) return;
         error = '';
         branch = null;
         commit = null;
         activate = true;
         hasRepository = !!site?.providerRepositoryId;
-    }
+        installationErrorKind = null;
+        loadStarted = false;
+    });
 </script>
 
 <Modal title="Create Git deployment" bind:show onSubmit={createDeployment} bind:error>
@@ -135,7 +177,7 @@
             external>Learn more</Link>
     </span>
     {#if hasRepository}
-        {#await load()}
+        {#if isLoadingRepository}
             <Card padding="xs" radius="s" variant="secondary">
                 <Layout.Stack
                     direction="row"
@@ -152,7 +194,13 @@
                 <Skeleton variant="line" width={100} height={19.6} />
                 <Skeleton variant="line" width={350} height={31} />
             </Layout.Stack>
-        {:then}
+        {:else if installationErrorKind}
+            <InstallationError
+                kind={installationErrorKind}
+                provider={$installation?.provider}
+                organization={$installation?.organization}
+                onRetry={load} />
+        {:else}
             <Card padding="xs" radius="s" variant="secondary">
                 <Layout.Stack
                     direction="row"
@@ -194,10 +242,11 @@
                 unchecked, it will remain inactive, and you can activate it manually later."
                     bind:checked={activate} />
             {/if}
-        {/await}
+        {/if}
     {:else}
         <Repositories
             bind:selectedRepository
+            bind:installationErrorKind
             installationList={installations}
             product="sites"
             action="button"
@@ -211,7 +260,15 @@
     {/if}
     <svelte:fragment slot="footer">
         <Button text size="s" on:click={() => (show = false)}>Cancel</Button>
-        <Button submit size="s" disabled={!$installation?.$id || !selectedRepository || !branch}>
+        <!-- A broken installation fails every call this needs, so offer the
+             reconnect above instead of a submit that cannot succeed. -->
+        <Button
+            submit
+            size="s"
+            disabled={!!installationErrorKind ||
+                !$installation?.$id ||
+                !selectedRepository ||
+                !branch}>
             Create
         </Button>
     </svelte:fragment>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRepository.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateRepository.svelte
@@ -7,17 +7,19 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, Query, type Models } from '@appwrite.io/console';
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import DisconnectRepo from './disconnectRepo.svelte';
     import { installation, repository as repositoryStore, sortBranches } from '$lib/stores/vcs';
     import {
+        Alert,
         Empty,
         Fieldset,
         Icon,
         Layout,
         Skeleton,
         Card as PinkCard,
-        Selector
+        Selector,
+        Typography
     } from '@appwrite.io/pink-svelte';
     import Card from '$lib/components/card.svelte';
     import { IconGithub } from '@appwrite.io/pink-icons-svelte';
@@ -25,47 +27,119 @@
         ConnectGit,
         ConnectRepoModal,
         RepositoryCard,
-        BranchSelector
+        BranchSelector,
+        InstallationError
     } from '$lib/components/git';
+    import {
+        getVcsInstallationErrorKind,
+        type VcsInstallationErrorKind
+    } from '$lib/helpers/vcsError';
     import { showConnectRepo } from './store';
     import { page } from '$app/state';
     import SelectRootModal from '$lib/components/git/selectRootModal.svelte';
 
-    export let site: Models.Site;
-    export let installations: Models.InstallationList;
+    type Props = {
+        site: Models.Site;
+        installations: Models.InstallationList;
+    };
 
-    let selectedBranch = site?.providerBranch;
-    let silentMode = site?.providerSilentMode ?? false;
-    let selectedDir = site?.providerRootDirectory;
-    let showDisconnect = false;
-    let showSelectRoot = false;
-    let repository: Models.ProviderRepository | null | false = false;
+    let { site, installations }: Props = $props();
+
+    /**
+     * Four states, deliberately not three.
+     *
+     * `disconnected` means the site has no repository. `error` means it has one
+     * we could not read. This used to be a single `null` repository, so a
+     * repository that could not be fetched rendered as "No repository is
+     * connected to this site yet" and invited the user to connect a repository
+     * that is already connected. The failure is almost always the Git
+     * installation's OAuth token, which is what the user actually has to fix.
+     */
+    type RepositoryStatus = 'loading' | 'connected' | 'disconnected' | 'error';
+
+    let status = $state<RepositoryStatus>('loading');
+    let repository = $state<Models.ProviderRepository | null>(null);
+    /** Populated only while `status === 'error'`; never conflated with "no repository". */
+    let repositoryError = $state<{
+        kind: VcsInstallationErrorKind | null;
+        message: string;
+    } | null>(null);
+
+    // Seeded from the site once: these are the user's in-progress edits, so they
+    // must not silently track the prop while the form is being filled in.
+    let selectedBranch = $state(untrack(() => site?.providerBranch));
+    let silentMode = $state(untrack(() => site?.providerSilentMode ?? false));
+    let selectedDir = $state(untrack(() => site?.providerRootDirectory));
+    let showDisconnect = $state(false);
+    let showSelectRoot = $state(false);
+
+    /**
+     * The installation the failed lookup actually used, so the alert can name
+     * the account that needs reconnecting rather than whichever installation
+     * happens to be selected.
+     */
+    const errorInstallation = $derived(
+        installations?.installations?.find((item) => item.$id === site?.installationId) ??
+            $installation
+    );
+
+    /**
+     * The site document stores the provider's repository id but never its name,
+     * so this is as much identity as we can show without a successful lookup.
+     * Showing it keeps the card honest about still being connected.
+     */
+    const connectedRepositoryLabel = $derived(
+        site?.providerRepositoryId
+            ? `Repository ID: ${site.providerRepositoryId}`
+            : 'Connected repository'
+    );
+
+    const connectedRepositoryDetails = $derived(
+        [
+            site?.providerBranch ? `Branch: ${site.providerBranch}` : null,
+            site?.providerRootDirectory ? `Root directory: ${site.providerRootDirectory}` : null
+        ]
+            .filter(Boolean)
+            .join(' • ')
+    );
 
     onMount(() => {
-        const inst = installations?.installations.find(
-            (installation) => installation.$id === site?.installationId
-        );
+        const inst = installations?.installations.find((item) => item.$id === site?.installationId);
         installation.set(inst ?? installations?.installations[0]);
         loadRepository();
     });
 
     async function loadRepository() {
+        if (!site?.installationId || !site?.providerRepositoryId) {
+            repository = null;
+            repositoryError = null;
+            status = 'disconnected';
+            return;
+        }
+
+        status = 'loading';
+        repositoryError = null;
+
         try {
-            if (site.installationId && site.providerRepositoryId) {
-                repository = await sdk
-                    .forProject(page.params.region, page.params.project)
-                    .vcs.getRepository({
-                        installationId: site.installationId,
-                        providerRepositoryId: site.providerRepositoryId
-                    });
-                repositoryStore.set(repository);
-            }
-        } catch (err) {
-            console.warn(err);
-        } finally {
-            if (repository === false) {
-                repository = null;
-            }
+            const loaded = await sdk
+                .forProject(page.params.region, page.params.project)
+                .vcs.getRepository({
+                    installationId: site.installationId,
+                    providerRepositoryId: site.providerRepositoryId
+                });
+            repository = loaded;
+            repositoryStore.set(loaded);
+            status = 'connected';
+        } catch (error) {
+            // The site still points at a repository, so this is not a
+            // disconnection. Report the lookup failure and keep the connection
+            // visible instead of blanking the card.
+            repository = null;
+            repositoryError = {
+                kind: getVcsInstallationErrorKind(error),
+                message: error?.message ?? ''
+            };
+            status = 'error';
         }
     }
 
@@ -162,22 +236,25 @@
         invalidate(Dependencies.SITE);
     }
 
-    $: if (site?.installationId && site?.providerRepositoryId) {
-        selectedBranch = site?.providerBranch ?? 'main';
-    }
+    $effect(() => {
+        if (site?.installationId && site?.providerRepositoryId) {
+            selectedBranch = site?.providerBranch ?? 'main';
+        }
+    });
 
-    $: isUpdateButtonEnabled =
+    const isUpdateButtonEnabled = $derived(
         selectedBranch !== site?.providerBranch ||
-        silentMode !== site?.providerSilentMode ||
-        selectedDir !== site?.providerRootDirectory;
+            silentMode !== site?.providerSilentMode ||
+            selectedDir !== site?.providerRootDirectory
+    );
 </script>
 
 <Form onSubmit={updateConfiguration}>
-    <CardGrid hideFooter={!repository}>
+    <CardGrid hideFooter={status !== 'connected'}>
         <svelte:fragment slot="title">Git repository</svelte:fragment>
         Automatically deploy changes for every commit pushed to your Git repository.
         <svelte:fragment slot="aside">
-            {#if repository === false}
+            {#if status === 'loading'}
                 <Layout.Stack gap="xl">
                     <Card padding="xs" radius="s" variant="secondary">
                         <Layout.Stack
@@ -213,7 +290,7 @@
                         </Layout.Stack>
                     </Fieldset>
                 </Layout.Stack>
-            {:else if repository}
+            {:else if status === 'connected'}
                 <Layout.Stack gap="xl">
                     <RepositoryCard {repository} on:disconnect={() => (showDisconnect = true)} />
 
@@ -242,6 +319,44 @@
                                 bind:checked={silentMode} />
                         </Layout.Stack>
                     </Fieldset>
+                </Layout.Stack>
+            {:else if status === 'error'}
+                <Layout.Stack gap="xl">
+                    <Card padding="xs" radius="s" variant="secondary">
+                        <Layout.Stack direction="row" alignItems="flex-start" gap="s">
+                            <Icon icon={IconGithub} color="--fgcolor-neutral-primary" />
+                            <Layout.Stack gap="xxxs">
+                                <Typography.Text variant="m-400" color="--fgcolor-neutral-primary">
+                                    {connectedRepositoryLabel}
+                                </Typography.Text>
+                                {#if connectedRepositoryDetails}
+                                    <Typography.Caption
+                                        variant="400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        {connectedRepositoryDetails}
+                                    </Typography.Caption>
+                                {/if}
+                            </Layout.Stack>
+                        </Layout.Stack>
+                    </Card>
+
+                    {#if repositoryError?.kind}
+                        <InstallationError
+                            kind={repositoryError.kind}
+                            provider={errorInstallation?.provider}
+                            organization={errorInstallation?.organization}
+                            onRetry={loadRepository} />
+                    {:else}
+                        <Alert.Inline
+                            status="warning"
+                            title="Could not load the connected repository">
+                            {repositoryError?.message ||
+                                'This site is still connected to a Git repository, but its details could not be loaded.'}
+                            <svelte:fragment slot="actions">
+                                <Button compact on:click={loadRepository}>Try again</Button>
+                            </svelte:fragment>
+                        </Alert.Inline>
+                    {/if}
                 </Layout.Stack>
             {:else if site.installationId || installations?.total}
                 <PinkCard.Base padding="none" border="dashed">


### PR DESCRIPTION
## Problem

When a VCS installation's OAuth token can no longer be refreshed, the API fails every repository / branch / contents call with `general_provider_failure` (`Appwrite\Vcs\InstallationTokens`). None of the Git surfaces read that error, so a dead installation was presented as a **successful empty result**:

| Surface | What the user saw |
| --- | --- |
| `repositories.svelte` | `loadRepositories()` had no `try`/`catch` at all, so the empty state claimed the org has no repositories. Used by 7 call sites |
| `branchSelector.svelte`, `productionBranchFieldset.svelte` | No error field at all: "No branches available", and the production branch fieldset stuck on its loading state forever |
| `selectRootModal.svelte` | A spinner that never resolved, or an empty tree reading as "this repository has no directories" |
| Both `updateRepository.svelte` cards | Fell back to "no repository connected" for a repository that **is** still connected, inviting the user to reconnect the repo when the installation is the problem |
| `connectRepoModal`, the create-deployment modals | Empty repo list plus a "Missing a repository? check your permissions" hint that blames scope |

## Change

`src/lib/helpers/vcsError.ts` classifies the failure into three kinds, because the remediation genuinely differs:

- **`reconnect`** - the token is dead, only re-authorizing helps
- **`locked`** (`general_resource_locked`) - a concurrent refresh holds the lock, retrying works. Deliberately **never** offers a reconnect: the installation is fine
- **`provider`** - the provider itself failed, retry first, reconnect demoted to secondary

`src/lib/components/git/installationError.svelte` renders all three with `Alert.Inline` and the reconnect link from the existing `$lib/stores/git` helpers. Reconnecting is a redirect to the **existing** authorize URL; the callback upserts the same installation row, so it is repaired in place.

Notable details:

- **The repository cards gain an explicit fourth state** rather than overloading the existing `null` sentinel, which already means "no repository connected" and is exactly the state being confused today.
- `createGitDeploymentModal.svelte` and `(modals)/createGit.svelte` are **migrated Svelte 4 -> runes**, per AGENTS.md, since they had to be touched. The `{#await load()}` in both was replaced with an explicit effect-driven load, which also avoids the runes hazard where `{#await}` re-evaluates when a signal read inside it changes.
- Modals whose primary action creates a deployment now disable that action on a non-null kind, since the call cannot succeed.

## Notes for review

- **The message substring is the only discriminator.** `general_provider_failure` covers both a dead token and a genuine provider outage; only the backend's "Please reconnect it." wording separates them. If reworded, this degrades to the `provider` branch, which still shows a real error and still offers a reconnect.
- **GitLab reconnect is not reachable from this console.** `$lib/stores/git` exports `connectGitHub` and `connectGitea` but no `connectGitLab`, so the CTA is scoped to the providers the store supports.
- **Detection is reactive only.** `listInstallations` never refreshes tokens, so a broken installation still looks healthy in the installations table until you use it.

## Unrelated backend finding, noted in passing

Not a blocker for this PR, and not introduced by it. Recording it for whoever owns VCS.

In `appwrite`, `GitHub/Callback/Get.php` initialises the token variables to `null` and only fills them inside `if (!empty($code))`, then writes them over the stored credentials unconditionally on the update path. `code` is an optional param defaulting to `''` and is never checked before that write, and the three token attributes are `required => false, default => null` in `platform.php`, so a null write succeeds silently rather than erroring. It then fails quietly afterwards, because `isExpired(null)` returns `false`.

If GitHub can return a callback with `installation_id` and no `code` (an App without "Request user authorization (OAuth) during installation", or a `setup_action=update` repository-access reconfigure), that blanks working credentials. That is a GitHub behaviour I have not verified, so treat the reachability as unconfirmed.

Worth stressing: this is reachable today through the **existing** "Configure" / "check your permissions" links, which use the same authorize and callback flow. This PR adds another entry point to it, it does not create it. GitLab and Gitea are unaffected, since their callback requires a `code`.

## Verification

- `bun run check`: **0 errors, 87 warnings** - byte-identical to the baseline on `main`
- `vitest src/lib/helpers/vcsError.test.ts`: 7/7 pass
- `eslint` and `prettier --check` clean on every changed file
