### PR TITLE
fix(spreadsheet): show false/0/empty string values instead of N/A badge

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/spreadsheet.svelte
@@ -809,7 +809,7 @@
                                         {/if}
                                     {:else}
                                         {@const value = document[columnId]}
-                                        {#if value}
+                                        {#if value !== null && value !== undefined}
                                             <Typography.Text truncate>{value}</Typography.Text>
                                         {:else}
                                             <Badge variant="secondary" size="xs" content="N/A" />


### PR DESCRIPTION
## What changed

In the collection spreadsheet view, the cell renderer used a bare truthiness check (`{#if value}`) to decide whether to display the value or the N/A badge. JavaScript falsy values — `false`, `0`, `""` — are all valid attribute values but were incorrectly rendered as N/A, making them visually indistinguishable from null/missing data.

## Fix

Changed the condition to `{#if value !== null && value !== undefined}` so only truly absent values get the badge.

Fixes #2146.