### PR TITLE
fix(billing): stop a zero seat limit turning free orgs read-only

### DIFF
--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -277,7 +277,10 @@ export function getServiceLimit(
 
     if (serviceId === 'members') {
         if (!plan?.addons?.seats) return Infinity;
-        return plan.addons.seats?.limit ?? 1;
+        // Plans that don't cap seats omit `limit` in the plan config, and the API
+        // serializes the missing value as `0`. That means "no seat cap", not
+        // "no members allowed" — an organization always has at least one member.
+        return plan.addons.seats?.limit || Infinity;
     }
 
     if (serviceId === 'projects') {
@@ -474,7 +477,11 @@ export async function checkForUsageLimit(organization: Models.Organization) {
 
     const members = organization.total;
     const memberLimit = getServiceLimit('members');
-    const membersOverflow = memberLimit === Infinity ? 0 : Math.max(0, members - memberLimit);
+    // Only a real, positive cap can be exceeded. Without this guard an unknown or
+    // zero limit turns every organization read-only, which silently disables
+    // project creation, member invites and every other write action.
+    const membersOverflow =
+        Number.isFinite(memberLimit) && memberLimit > 0 ? Math.max(0, members - memberLimit) : 0;
 
     if (resources.some((r) => r.value >= 100) || membersOverflow > 0) {
         readOnly.set(true);

--- a/src/lib/stores/billing.ts
+++ b/src/lib/stores/billing.ts
@@ -277,9 +277,7 @@ export function getServiceLimit(
 
     if (serviceId === 'members') {
         if (!plan?.addons?.seats) return Infinity;
-        // Plans that don't cap seats omit `limit` in the plan config, and the API
-        // serializes the missing value as `0`. That means "no seat cap", not
-        // "no members allowed" — an organization always has at least one member.
+        // plans that don't cap seats omit `limit`, which the API serializes as `0`
         return plan.addons.seats?.limit || Infinity;
     }
 
@@ -477,9 +475,6 @@ export async function checkForUsageLimit(organization: Models.Organization) {
 
     const members = organization.total;
     const memberLimit = getServiceLimit('members');
-    // Only a real, positive cap can be exceeded. Without this guard an unknown or
-    // zero limit turns every organization read-only, which silently disables
-    // project creation, member invites and every other write action.
     const membersOverflow =
         Number.isFinite(memberLimit) && memberLimit > 0 ? Math.max(0, members - memberLimit) : 0;
 


### PR DESCRIPTION
## What

`getServiceLimit('members')` returned `plan.addons.seats.limit ?? 1`. The Appwrite starter plan's seats addon omits `limit`:

```php
// cloud/app/config/plans.php — BILLING_PLAN_STARTER
'seats' => ['supported' => false, 'planIncluded' => 1]   // no 'limit'
```

…and `Response/Model/Billing/Plan/Addon/Details.php` defaults `limit` to `0`. Since `0` isn't nullish, the `?? 1` fallback never applied and the limit came back as `0`.

`checkForUsageLimit` then read that as "no members allowed":

```ts
membersOverflow = Math.max(0, organization.total - 0)  // always >= 1
```

so **every free-plan organization is flipped to read-only**, which silently disables project creation, member invites, and the other write actions gated on `readOnly`.

## Why it's invisible to the user

The explanatory banner never renders either: `limitReached.svelte` is gated on `!$organization?.billingPlanDetails.usage`, and the starter plan's `usage` serializes to a truthy object. The result is a greyed-out **Create project** button that does nothing, with no reason given.

## Scope

- Only the appwrite **starter** plan is affected. Pro, Scale and Education declare no `seats` addon and already returned `Infinity`; the Imagine plans set an explicit `limit => 1` and keep working.
- Symptom reported in support: a free-tier user with 1 project could not create a 2nd, despite the plan allowing 2. The project-limit check was never the cause — the backend (`TeamsLimit.php`) counts only `active` + `paused` projects and would have accepted the create. The block was entirely client-side.

## Regression origin

49ad4256b replaced `members - (limit || members)` — where the `|| members` neutralised a zero limit — with `Math.max(0, members - limit)`. Three days later the cloud config added the `seats` entry without a `limit`. Every UI call site already works around this with `getServiceLimit('members', ...) || Infinity`; `checkForUsageLimit` was the only consumer that didn't.

## Fix

Normalise a zero limit to `Infinity` in `getServiceLimit` so every caller agrees, and only treat a real, positive cap as exceedable so a bad limit can't take an organization read-only again.

## Testing

`bun run format && bun run check && bun run lint && bun run test:unit && bun run build` — check 0 errors, lint 0 errors, 239 unit tests pass, build succeeds.

No regression test: `billing.ts`'s import graph reaches `$lib/actions/analytics`, and `@plausible-analytics/tracker` declares only `module` (no `main`/`exports`), so Vitest can't resolve it in either test project. Worth fixing separately.

## Follow-up for whoever owns billing config

The console now reads a missing `seats.limit` as "uncapped", which matches the intent of "revert member limits on free-tier projects". If free-tier seats are ever meant to be capped, `plans.php` should say so explicitly rather than relying on the serializer's `0` default.