### PR TITLE
fix(databases): render array column items with their element type

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     "devalue": "^5.8.1",
     "flatted": "^3.4.2",
     "immutable": "^5.1.8",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "minimatch": "10.2.3",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.18",
@@ -1024,7 +1024,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "vite": "npm:rolldown-vite@latest",
         "minimatch": "10.2.3",
         "brace-expansion": ">=5.0.9",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "immutable": "^5.1.8",
         "flatted": "^3.4.2",
         "devalue": "^5.8.1",

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/column.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/rows/columns/column.svelte
@@ -88,7 +88,7 @@
     {:else}
         <!-- the `on:click` is from string > array mode for advanced edit button -->
         <svelte:component
-            this={column.array || (isSpatialType(column) && limited)
+            this={array || (isSpatialType(column) && limited)
                 ? columnsTypeMap['string']
                 : columnsTypeMap[column.type]}
             {id}


### PR DESCRIPTION
## What does this PR do?

Fixes array columns being rendered as `string` inputs in the row create/edit form, regardless of the column's actual element type.

Reported against 1.9.6: a `Boolean[]` column renders a text field ("Enter string") for each item instead of a boolean select.

| Before | |
| --- | --- |
| Empty state shows the correct `Boolean[]` hint... | ...but `+ Add item` produces a string input |

### Root cause

`column.svelte` decided the input component like this:

```svelte
this={column.array || (isSpatialType(column) && limited)
    ? columnsTypeMap['string']
    : columnsTypeMap[column.type]}
```

The string fallback exists for the **spreadsheet inline cell editor**, where an entire array is edited as one comma-separated textarea. But it keyed off `column.array` (the column *definition*) instead of the `array` prop (the *render mode*).

In the full row form, `columnItem.svelte` renders one `<Column>` per array element and deliberately does **not** pass `array`, so each item should get its element-type input. Because `column.array` was still `true`, every item collapsed to the string input.

This also explains the intermittent save failures in the report. The string component still runs `parseValue()` against `column.type`, so typing literally `true`/`false`/`1`/`0` coerced correctly and saved — anything else returned `null`, and a `null` inside a typed array is rejected by the API.

### The fix

One line — key off the `array` prop:

```svelte
this={array || (isSpatialType(column) && limited)
    ? columnsTypeMap['string']
    : columnsTypeMap[column.type]}
```

Array items now render their proper inputs: boolean select (True/False/NULL), number input with `min`/`max`, date picker, etc.

### Scope

- `array` is only ever passed by the two `fromSpreadsheet` branches in `columnItem.svelte`, so the compact comma-separated cell editor and its "Advanced edit" link are unchanged.
- `Column` is used nowhere outside `columnItem.svelte`.
- Enum/URL/IP/email arrays were already unaffected — the `format` branch short-circuits above this.
- No database-type branching in this path, so it applies to `tablesdb` and `documentsdb` alike.

## Test Plan

- Create a table with `Boolean[]`, `Integer[]`, and `Datetime[]` columns.
- Create a row: each `+ Add item` now yields the correct typed input; saving succeeds.
- Edit an existing row: existing values populate correctly.
- Spreadsheet view: inline cell editing of an array column still shows the comma-separated textarea with "Advanced edit".

Verified locally: `bun run check` (0 errors), `bun run lint` (0 errors), `bun run test:unit` (239 passed), `bun run build` (compiles clean; the Sentry source-map upload step needs a token and is skipped locally).

## Related PRs and Issues

Reported in Discord (1.9.6 console, MongoDB-backed database).

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.