### PR TITLE
fix(csv-import): fire notification and clear box for failed imports without error payload

### DIFF
--- a/src/lib/components/csvImportBox.svelte
+++ b/src/lib/components/csvImportBox.svelte
@@ -39,7 +39,7 @@
 
     async function showCompletionNotification(database: string, table: string, payload: Payload) {
         const isSuccess = payload.status === 'completed';
-        const isError = !isSuccess && !!payload.errors;
+        const isError = !isSuccess && payload.status === 'failed';
 
         if (!isSuccess && !isError) return;
 
@@ -118,6 +118,9 @@
 
         if (status === 'completed' || status === 'failed') {
             await showCompletionNotification(databaseId, tableId, importData);
+            const next = new Map(importItems);
+            next.delete(importData.$id);
+            importItems = next;
         }
     }
 


### PR DESCRIPTION
## What changed

Two bugs compounded to leave the CSV import notification box permanently visible after a failed import.

**Bug 1 — `isError` gate skipped on empty errors**

`showCompletionNotification` checked `const isError = !isSuccess && !!payload.errors`. If a failed import had `errors: null`, `undefined`, or `[]`, `isError` was falsy and the function returned early — no toast notification, no cleanup.

**Bug 2 — import item never removed from `importItems`**

`updateOrAddItem` called `showCompletionNotification` on terminal statuses but never removed the item from the `importItems` map. Since the box is only hidden when `importItems.size === 0`, it stayed open.

## Fix

1. Use `payload.status === 'failed'` instead of `!!payload.errors` to determine error state.
2. Delete the item from `importItems` after the notification fires on every terminal status.

Closes related open issue [#2877](https://github.com/appwrite/console/issues/2877).