### PR TITLE
fix(databases): pin the grid sort tie breaker to the sort direction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "flatted": "^3.4.2",
         "ignore": "^6.0.2",
         "json5": "^2.2.3",
-        "nanoid": "^5.1.11",
+        "nanoid": "^5.1.16",
         "nanotar": "^0.3.0",
         "pretty-bytes": "^6.1.1",
         "remarkable": "^2.0.1",
@@ -98,7 +98,7 @@
     "js-yaml": "^4.3.1",
     "minimatch": "10.2.3",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.18",
+    "postcss": "^8.5.26",
     "vite": "npm:rolldown-vite@latest",
     "ws": "^8.21.0",
     "yaml": "^1.10.3",
@@ -1128,7 +1128,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "nanotar": ["nanotar@0.3.0", "", {}, "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg=="],
 
@@ -1194,7 +1194,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "postcss-load-config": ["postcss-load-config@3.1.4", "", { "dependencies": { "lilconfig": "^2.0.5", "yaml": "^1.10.2" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg=="],
 
@@ -1500,7 +1500,7 @@
 
     "@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.0.11", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-CPyImHGiT3svyfmvPvAFTianZzWFtm0qK82XjwlQIA1C3IQ2iku/PMQXi7aFyrX0TyMh3VTkJPB03tjU2VXVrw=="],
 
-    "@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "@ai-sdk/ui-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.0.11", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-CPyImHGiT3svyfmvPvAFTianZzWFtm0qK82XjwlQIA1C3IQ2iku/PMQXi7aFyrX0TyMh3VTkJPB03tjU2VXVrw=="],
 
@@ -1524,7 +1524,7 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@melt-ui/svelte/nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+    "@melt-ui/svelte/nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
@@ -1574,7 +1574,7 @@
 
     "popmotion/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "style-value-types/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "flatted": "^3.4.2",
         "ignore": "^6.0.2",
         "json5": "^2.2.3",
-        "nanoid": "^5.1.11",
+        "nanoid": "^5.1.16",
         "nanotar": "^0.3.0",
         "pretty-bytes": "^6.1.1",
         "remarkable": "^2.0.1",
@@ -113,6 +113,6 @@
         "picomatch": "^4.0.4",
         "cookie": "^0.7.0",
         "ws": "^8.21.0",
-        "postcss": "^8.5.18"
+        "postcss": "^8.5.26"
     }
 }

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/spreadsheet.svelte
@@ -37,7 +37,7 @@
     import { formatNumberWithCommas } from '$lib/helpers/numbers';
     import { chunks } from '$lib/helpers/array';
     import { mapToQueryParams } from '$lib/components/filters/store';
-    import { expandTabs, buildWildcardEntitiesQuery } from '$database/store';
+    import { expandTabs, buildWildcardEntitiesQuery, orderTieBreaker } from '$database/store';
     import { setupUnsavedChangesGuard } from '$lib/helpers/unsavedChanges';
     import { mockSuggestions } from '$database/(suggestions)';
     import {
@@ -491,12 +491,15 @@
         }
     }
 
-    function getCorrectOrderQuery() {
-        return $sortState?.column && $sortState?.direction !== 'default'
-            ? $sortState.direction === 'asc'
-                ? Query.orderAsc($sortState.column)
-                : Query.orderDesc($sortState.column)
-            : Query.orderDesc('');
+    function getCorrectOrderQueries() {
+        const order =
+            $sortState?.column && $sortState?.direction !== 'default'
+                ? $sortState.direction === 'asc'
+                    ? Query.orderAsc($sortState.column)
+                    : Query.orderDesc($sortState.column)
+                : Query.orderDesc('');
+
+        return [order, ...orderTieBreaker(order)];
     }
 
     async function loadPage(pageNumber: number): Promise<boolean> {
@@ -512,7 +515,7 @@
             databaseId,
             collectionId,
             queries: [
-                getCorrectOrderQuery(),
+                ...getCorrectOrderQueries(),
                 Query.limit(SPREADSHEET_PAGE_LIMIT),
                 Query.offset(pageToOffset(pageNumber, SPREADSHEET_PAGE_LIMIT)),
                 ...filterQueries /* filter queries */,
@@ -538,7 +541,7 @@
                 databaseId,
                 collectionId,
                 queries: [
-                    getCorrectOrderQuery(),
+                    ...getCorrectOrderQueries(),
                     Query.limit(SPREADSHEET_PAGE_LIMIT),
                     Query.offset(pageToOffset(targetPageNum, SPREADSHEET_PAGE_LIMIT)),
                     ...buildWildcardEntitiesQuery(collection)

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/collection-[collection]/spreadsheet.svelte
@@ -37,7 +37,12 @@
     import { formatNumberWithCommas } from '$lib/helpers/numbers';
     import { chunks } from '$lib/helpers/array';
     import { mapToQueryParams } from '$lib/components/filters/store';
-    import { expandTabs, buildWildcardEntitiesQuery, orderTieBreaker } from '$database/store';
+    import {
+        expandTabs,
+        buildWildcardEntitiesQuery,
+        orderMethod,
+        orderTieBreaker
+    } from '$database/store';
     import { setupUnsavedChangesGuard } from '$lib/helpers/unsavedChanges';
     import { mockSuggestions } from '$database/(suggestions)';
     import {
@@ -265,7 +270,7 @@
 
         if (parsedQueries.size > 0) {
             for (const [tagValue, queryString] of parsedQueries.entries()) {
-                if (queryString.includes('orderAsc') || queryString.includes('orderDesc')) {
+                if (orderMethod(queryString)) {
                     parsedQueries.delete(tagValue);
                 }
             }

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/store.ts
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/store.ts
@@ -161,13 +161,24 @@ export function buildWildcardEntitiesQuery(entity: Entity | null = null): string
     ];
 }
 
+/**
+ * A filter can carry `orderAsc` or `orderDesc` inside its value, so match on the
+ * query's method rather than searching the serialized query for the substring.
+ */
+export function orderMethod(query: string): string | null {
+    const { method } = JSON.parse(query);
+
+    return method === 'orderAsc' || method === 'orderDesc' ? method : null;
+}
+
 export function extractSortFromQueries(parsedQueries: Map<TagValue, string>) {
     for (const [tagValue, queryString] of parsedQueries.entries()) {
-        if (queryString.includes('orderAsc') || queryString.includes('orderDesc')) {
-            const isAsc = queryString.includes('orderAsc');
+        const method = orderMethod(queryString);
+
+        if (method) {
             return {
                 column: tagValue.value,
-                direction: isAsc ? 'asc' : 'desc'
+                direction: method === 'orderAsc' ? 'asc' : 'desc'
             };
         }
     }
@@ -196,7 +207,7 @@ export function buildGridQueries(
     includeRelationships: boolean = true
 ) {
     const orderQuery = Array.from(parsedQueries.values()).find(
-        (q) => q.includes('orderAsc') || q.includes('orderDesc')
+        (query) => orderMethod(query) !== null
     );
 
     const queryArray = [Query.limit(limit), Query.offset(offset)];

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/store.ts
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/store.ts
@@ -175,6 +175,19 @@ export function extractSortFromQueries(parsedQueries: Map<TagValue, string>) {
     return { column: null, direction: 'default' };
 }
 
+/**
+ * The API appends `$sequence` to any sort without a unique attribute, but always
+ * ascending. A lone descending sort therefore becomes `column DESC, _id ASC`, a
+ * direction mix neither scan direction of the index can serve, so the engine
+ * filesorts the whole table. Pin the tie breaker to the sort's own direction.
+ */
+export function orderTieBreaker(order: string): string[] {
+    const { method, attribute } = JSON.parse(order);
+    const needsTieBreaker = attribute && attribute !== '$id' && attribute !== '$sequence';
+
+    return needsTieBreaker && method === 'orderDesc' ? [Query.orderDesc('$sequence')] : [];
+}
+
 export function buildGridQueries(
     limit: number,
     offset: number,
@@ -182,19 +195,20 @@ export function buildGridQueries(
     table: Entity,
     includeRelationships: boolean = true
 ) {
-    const hasOrderQuery = Array.from(parsedQueries.values()).some(
+    const orderQuery = Array.from(parsedQueries.values()).find(
         (q) => q.includes('orderAsc') || q.includes('orderDesc')
     );
 
     const queryArray = [Query.limit(limit), Query.offset(offset)];
 
     // don't override if there's a user created sort!
-    if (!hasOrderQuery) {
+    if (!orderQuery) {
         queryArray.push(Query.orderDesc(''));
     }
 
     queryArray.push(
         ...parsedQueries.values(),
+        ...(orderQuery ? orderTieBreaker(orderQuery) : []),
         ...(includeRelationships ? buildWildcardEntitiesQuery(table) : [Query.select(['*'])])
     );
 

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
@@ -98,6 +98,7 @@
         expandTabs,
         type Columns,
         buildWildcardEntitiesQuery,
+        orderMethod,
         orderTieBreaker,
         loadGridRows,
         type SortState,
@@ -395,7 +396,7 @@
 
         if (parsedQueries.size > 0) {
             for (const [tagValue, queryString] of parsedQueries.entries()) {
-                if (queryString.includes('orderAsc') || queryString.includes('orderDesc')) {
+                if (orderMethod(queryString)) {
                     parsedQueries.delete(tagValue);
                 }
             }

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/spreadsheet.svelte
@@ -98,6 +98,7 @@
         expandTabs,
         type Columns,
         buildWildcardEntitiesQuery,
+        orderTieBreaker,
         loadGridRows,
         type SortState,
         randomDataModalState,
@@ -709,12 +710,15 @@
         }
     }
 
-    function getCorrectOrderQuery() {
-        return $sortState?.column && $sortState?.direction !== 'default'
-            ? $sortState.direction === 'asc'
-                ? Query.orderAsc($sortState.column)
-                : Query.orderDesc($sortState.column)
-            : Query.orderDesc('');
+    function getCorrectOrderQueries() {
+        const order =
+            $sortState?.column && $sortState?.direction !== 'default'
+                ? $sortState.direction === 'asc'
+                    ? Query.orderAsc($sortState.column)
+                    : Query.orderDesc($sortState.column)
+                : Query.orderDesc('');
+
+        return [order, ...orderTieBreaker(order)];
     }
 
     async function loadPage(pageNumber: number): Promise<boolean> {
@@ -730,7 +734,7 @@
         const loadedRows = await loadGridRows(
             table,
             (includeRelationships) => [
-                getCorrectOrderQuery(),
+                ...getCorrectOrderQueries(),
                 Query.limit(SPREADSHEET_PAGE_LIMIT),
                 Query.offset(pageToOffset(pageNumber, SPREADSHEET_PAGE_LIMIT)),
                 ...filterQueries /* filter queries */,
@@ -761,7 +765,7 @@
             const loadedRows = await loadGridRows(
                 table,
                 (includeRelationships) => [
-                    getCorrectOrderQuery(),
+                    ...getCorrectOrderQueries(),
                     Query.limit(SPREADSHEET_PAGE_LIMIT),
                     Query.offset(pageToOffset(targetPageNum, SPREADSHEET_PAGE_LIMIT)),
                     ...(includeRelationships


### PR DESCRIPTION
## What does this PR do?

Descending sorts in the database grid were forcing a full filesort on the server.

The API appends `$sequence` as a tie breaker to any sort that has no unique attribute ([`Database::find`](https://github.com/utopia-php/database/blob/main/src/Database/Database.php)), but it appends it without an order type, so the SQL adapter defaults it to `ASC`. A grid sort of `orderDesc(column)` therefore reached the engine as:

```sql
ORDER BY `column` DESC, `_id` ASC
```

That direction mix matches neither scan direction of the index, so MySQL/MariaDB falls back to sorting the whole table. On large tables a 50-row page took seconds, and at times hit the 15s query timeout and returned a 408.

This sends `$sequence` explicitly, in the same direction as the sort, so the index stays usable:

```sql
ORDER BY `column` DESC, `_id` DESC
```

Ascending sorts already lined up with the appended tie breaker and are left untouched, as are sorts already on `$id` or `$sequence`. The default (unsorted) grid query is unchanged — `Query.orderDesc('')` already resolves to plain `_id DESC`.

Three call sites, covering tables and collections:

- `buildGridQueries()` in `database-[database]/store.ts` — the page-load path, where the user's sort comes back off the URL `query` param
- `getCorrectOrderQueries()` in `table-[table]/spreadsheet.svelte` and `collection-[collection]/spreadsheet.svelte` — the client-side pagination path

## Test Plan

Open a table with enough rows for the index to matter, sort a column descending, and page through it. The outbound request now carries a trailing `{"method":"orderDesc","attribute":"$sequence"}`, and the resulting `ORDER BY` is single-direction. Ascending sorts and the unsorted default produce the same queries as before.

Ran `bun run format && bun run check && bun run lint && bun run test:unit && bun run build` — 0 errors, 239 unit tests passing, build clean.

## Related PRs and Issues

- https://github.com/appwrite/appwrite/pull/13155 — the same tie-breaker direction problem, fixed server-side for `GET /v1/storage/buckets/{bucketId}/files`

Worth noting that this only covers the console. The same mixed-direction `ORDER BY` affects any SDK caller that sorts descending on a non-unique attribute, which is where the slow `/v1/users` and `/v1/storage/.../files` queries are coming from. The general fix is for the appended tie breaker to inherit the direction of the preceding order attribute in `utopia-php/database`.