### PR TITLE
fix(variables): validate variable keys before writing them

### DIFF
--- a/src/lib/components/variables/createVariableModal.svelte
+++ b/src/lib/components/variables/createVariableModal.svelte
@@ -8,6 +8,7 @@
     import { Link } from '$lib/elements';
     import { page } from '$app/state';
     import { IconPlus, IconX } from '@appwrite.io/pink-icons-svelte';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export type ProductLabel = 'site' | 'function';
 
@@ -39,13 +40,13 @@
                 newVariables = newVariables.map((variable) => ({ ...variable, secret: true }));
             }
 
-            newVariables.forEach((variable) => {
-                if (('' + variable.value).length > 8192) {
-                    throw new Error(
-                        `Variable ${variable.key} is longer than 8192 allowed characters`
-                    );
-                }
-            });
+            const validationError = validateVariables(
+                newVariables.filter((variable) => variable.key || variable.value)
+            );
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             const updatedVariables = [...variables];
             newVariables.forEach((newVar) => {
                 if (!newVar.key) {

--- a/src/lib/components/variables/environmentVariables.svelte
+++ b/src/lib/components/variables/environmentVariables.svelte
@@ -22,6 +22,7 @@
     import UpdateVariableModal from './updateVariableModal.svelte';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import { isSmallViewport } from '$lib/stores/viewport';
+    import { isValidVariableKey } from '$lib/helpers/variables';
 
     const DOCS_LINKS: Record<ProductLabel, string> = {
         site: 'https://appwrite.io/docs/products/sites/develop#accessing-environment-variables',
@@ -146,7 +147,28 @@
                             </svelte:fragment>
                             {#each paginatedItems as variable}
                                 <Table.Row.Base {root}>
-                                    <Table.Cell column="key" {root}>{variable.key}</Table.Cell>
+                                    <Table.Cell column="key" {root}>
+                                        <Layout.Stack
+                                            gap="xxs"
+                                            alignItems="center"
+                                            direction="row"
+                                            inline>
+                                            {#if !isValidVariableKey(variable.key)}
+                                                <Tooltip maxWidth="26rem">
+                                                    <span
+                                                        class="icon-exclamation u-color-text-danger"
+                                                        aria-hidden="true"></span>
+                                                    <svelte:fragment slot="tooltip">
+                                                        This key can't be used as an environment
+                                                        variable name. Rename it using only letters,
+                                                        digits and underscores, without starting
+                                                        with a digit.
+                                                    </svelte:fragment>
+                                                </Tooltip>
+                                            {/if}
+                                            {variable.key}
+                                        </Layout.Stack>
+                                    </Table.Cell>
                                     <Table.Cell column="value" {root}>
                                         <!-- TODO: fix max width -->
                                         <div style="max-width: 100%">

--- a/src/lib/components/variables/importVariablesModal.svelte
+++ b/src/lib/components/variables/importVariablesModal.svelte
@@ -7,6 +7,7 @@
     import { Icon, Layout, Selector, Tooltip, Typography, Upload } from '@appwrite.io/pink-svelte';
     import { parse } from '$lib/helpers/envfile';
     import { removeFile } from '$lib/helpers/files';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export let show = false;
     export let variables: Partial<Models.Variable>[];
@@ -37,10 +38,11 @@
             }
             const entries = Object.entries(uploaded);
 
-            for (const [key, value] of entries) {
-                if (value.length > 8192) {
-                    throw new Error(`Variable ${key} is longer than 8192 allowed characters`);
-                }
+            const validationError = validateVariables(
+                entries.map(([key, value]) => ({ key, value }))
+            );
+            if (validationError) {
+                throw new Error(validationError);
             }
 
             entries

--- a/src/lib/components/variables/importVariablesModal.svelte
+++ b/src/lib/components/variables/importVariablesModal.svelte
@@ -36,7 +36,9 @@
             if (!Object.keys(uploaded).length) {
                 throw new Error('No variables found');
             }
-            const entries = Object.entries(uploaded);
+            // Drop the valueless entries first. They are never written, so an
+            // invalid key on one of them must not reject the whole file.
+            const entries = Object.entries(uploaded).filter(([, value]) => !!value);
 
             const validationError = validateVariables(
                 entries.map(([key, value]) => ({ key, value }))
@@ -45,11 +47,9 @@
                 throw new Error(validationError);
             }
 
-            entries
-                .filter(([, value]) => !!value)
-                .forEach(([key, value]) => {
-                    variables.push({ key, value, secret });
-                });
+            entries.forEach(([key, value]) => {
+                variables.push({ key, value, secret });
+            });
 
             show = false;
         } catch (e) {

--- a/src/lib/components/variables/updateVariableModal.svelte
+++ b/src/lib/components/variables/updateVariableModal.svelte
@@ -7,6 +7,7 @@
     import { Layout, Selector } from '@appwrite.io/pink-svelte';
     import { Link } from '$lib/elements';
     import { page } from '$app/state';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export let show = false;
     export let selectedVar: Partial<Models.Variable>;
@@ -20,7 +21,15 @@
         secret: selectedVar?.secret
     };
 
+    let error = '';
+
     function handleVariable() {
+        const validationError = validateVariables([pair]);
+        if (validationError) {
+            error = validationError;
+            return;
+        }
+
         if (selectedVar) {
             variables = variables.map((variable) => {
                 const match = selectedVar.$id
@@ -39,7 +48,7 @@
     }
 </script>
 
-<Modal bind:show onSubmit={handleVariable} title="Update variable">
+<Modal bind:show onSubmit={handleVariable} title="Update variable" bind:error>
     <span slot="description">
         Update the environment variable for your {productLabel}. Global variables can be set in
         <Link

--- a/src/lib/components/variables/variableEditorModal.svelte
+++ b/src/lib/components/variables/variableEditorModal.svelte
@@ -5,6 +5,7 @@
     import Button from '$lib/elements/forms/button.svelte';
     import { addNotification } from '$lib/stores/notifications';
     import { parse } from '$lib/helpers/envfile';
+    import { validateVariables } from '$lib/helpers/variables';
     import { Alert, Icon, Layout, Tabs } from '@appwrite.io/pink-svelte';
     import { IconDownload, IconDuplicate } from '@appwrite.io/pink-icons-svelte';
     import { InputTextarea } from '$lib/elements/forms';
@@ -47,10 +48,11 @@
             const vars = tab === 'env' ? parse(envCode) : JSON.parse(jsonCode ? jsonCode : '{}');
             const entries = Object.entries(vars);
 
-            for (const [key, value] of entries) {
-                if (('' + value).length > 8192) {
-                    throw new Error(`Variable ${key} is longer than 8192 allowed characters`);
-                }
+            const validationError = validateVariables(
+                entries.map(([key, value]) => ({ key, value }))
+            );
+            if (validationError) {
+                throw new Error(validationError);
             }
 
             // Update or remove editable variables

--- a/src/lib/helpers/variables.test.ts
+++ b/src/lib/helpers/variables.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest';
+import {
+    getVariableKeyError,
+    isValidVariableKey,
+    validateVariables,
+    VARIABLE_KEY_MAX_LENGTH,
+    VARIABLE_VALUE_MAX_LENGTH
+} from '$lib/helpers/variables';
+
+test('accept keys that are valid environment variable names', () => {
+    expect(isValidVariableKey('APP_TEST')).toBe(true);
+    expect(isValidVariableKey('_PRIVATE')).toBe(true);
+    expect(isValidVariableKey('key1')).toBe(true);
+    expect(isValidVariableKey('a'.repeat(VARIABLE_KEY_MAX_LENGTH))).toBe(true);
+});
+
+test('reject keys that cannot be used as environment variable names', () => {
+    expect(isValidVariableKey('MY-KEY')).toBe(false);
+    expect(isValidVariableKey('MY.KEY')).toBe(false);
+    expect(isValidVariableKey('MY KEY')).toBe(false);
+    expect(isValidVariableKey('9KEY')).toBe(false);
+    expect(isValidVariableKey('KÉY')).toBe(false);
+    expect(isValidVariableKey('KEY\t')).toBe(false);
+    expect(isValidVariableKey('')).toBe(false);
+    expect(isValidVariableKey('a'.repeat(VARIABLE_KEY_MAX_LENGTH + 1))).toBe(false);
+});
+
+test('report a missing key separately from an invalid one', () => {
+    expect(getVariableKeyError('')).toEqual('Variable key is required');
+    expect(getVariableKeyError('MY-KEY')).toContain('is invalid');
+    expect(getVariableKeyError('a'.repeat(VARIABLE_KEY_MAX_LENGTH + 1))).toContain('longer than');
+    expect(getVariableKeyError('APP_TEST')).toBeNull();
+});
+
+test('validate a list of variables and name the offending key', () => {
+    expect(validateVariables([{ key: 'APP_TEST', value: 'value' }])).toBeNull();
+    expect(validateVariables([{ key: 'APP_TEST', value: '' }])).toBeNull();
+
+    expect(
+        validateVariables([
+            { key: 'APP_TEST', value: 'value' },
+            { key: 'MY-KEY', value: 'value' }
+        ])
+    ).toContain('MY-KEY');
+
+    expect(
+        validateVariables([{ key: 'APP_TEST', value: 'v'.repeat(VARIABLE_VALUE_MAX_LENGTH + 1) }])
+    ).toContain('APP_TEST');
+});

--- a/src/lib/helpers/variables.ts
+++ b/src/lib/helpers/variables.ts
@@ -1,5 +1,71 @@
 import type { Models } from '@appwrite.io/console';
 
+export const VARIABLE_KEY_MAX_LENGTH = 255;
+export const VARIABLE_VALUE_MAX_LENGTH = 8192;
+
+/**
+ * Variable keys become environment variable names at build and runtime, so the
+ * API only accepts C-style identifiers. Keys stored before that rule existed
+ * can still fail this check, which is why `isValidVariableKey` is also used to
+ * flag them in the variables table.
+ */
+const VARIABLE_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isValidVariableKey(key: string): boolean {
+    return (
+        typeof key === 'string' &&
+        key.length <= VARIABLE_KEY_MAX_LENGTH &&
+        VARIABLE_KEY_PATTERN.test(key)
+    );
+}
+
+export function getVariableKeyError(key: string): string | null {
+    if (!key) {
+        return 'Variable key is required';
+    }
+
+    if (key.length > VARIABLE_KEY_MAX_LENGTH) {
+        return `Variable key "${key}" is longer than ${VARIABLE_KEY_MAX_LENGTH} allowed characters`;
+    }
+
+    if (!VARIABLE_KEY_PATTERN.test(key)) {
+        return `Variable key "${key}" is invalid. Keys can only contain letters, digits and underscores, and cannot start with a digit`;
+    }
+
+    return null;
+}
+
+export function getVariableValueError(key: string, value: unknown): string | null {
+    if (('' + (value ?? '')).length > VARIABLE_VALUE_MAX_LENGTH) {
+        return `Variable ${key} is longer than ${VARIABLE_VALUE_MAX_LENGTH} allowed characters`;
+    }
+
+    return null;
+}
+
+/**
+ * Returns the first problem found, or null when every variable is accepted by
+ * the API. Call before submitting so a rejected key is reported against the
+ * file or row it came from instead of as a bare server error.
+ */
+export function validateVariables(
+    variables: Array<{ key?: string; value?: unknown }>
+): string | null {
+    for (const { key, value } of variables) {
+        const keyError = getVariableKeyError(key);
+        if (keyError) {
+            return keyError;
+        }
+
+        const valueError = getVariableValueError(key, value);
+        if (valueError) {
+            return valueError;
+        }
+    }
+
+    return null;
+}
+
 export function normalizeDetectedVariables(
     detected: Models.DetectionVariable[] = []
 ): Partial<Models.Variable>[] {

--- a/src/routes/(console)/project-[region]-[project]/createVariableModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/createVariableModal.svelte
@@ -9,12 +9,14 @@
     import { Alert, Layout, Selector, Button as PinkButton, Icon } from '@appwrite.io/pink-svelte';
     import { Link } from '$lib/elements';
     import { IconPlus, IconX } from '@appwrite.io/pink-icons-svelte';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export let isGlobal: boolean;
     export let product: 'function' | 'site' = 'function';
     export let showCreate = false;
     let newVariables: Partial<Models.Variable>[] = [{ key: '', value: '' }];
     let secret = false;
+    let error = '';
 
     const dispatch = createEventDispatcher();
 
@@ -26,12 +28,16 @@
         if (secret) {
             newVariables = newVariables.map((variable) => ({ ...variable, secret: true }));
         }
-        newVariables.forEach((variable) => {
-            if (('' + variable.value).length > 8192) {
-                throw new Error(`Variable ${variable.key} is longer than 8192 allowed characters`);
-            }
-        });
-        dispatch('created', newVariables);
+
+        const filled = newVariables.filter((variable) => variable.key || variable.value);
+
+        const validationError = validateVariables(filled);
+        if (validationError) {
+            error = validationError;
+            return;
+        }
+
+        dispatch('created', filled);
         close();
     }
 
@@ -48,6 +54,7 @@
 
 <Modal
     bind:show={showCreate}
+    bind:error
     onSubmit={handleVariable}
     title={`Create ${isGlobal ? 'global' : 'environment'} variables`}>
     <svelte:fragment slot="description">

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/deploy/+page.svelte
@@ -25,6 +25,7 @@
     import { getLatestTag } from '$lib/helpers/github';
     import { writable } from 'svelte/store';
     import Link from '$lib/elements/link.svelte';
+    import { validateVariables } from '$lib/helpers/variables';
 
     let {
         data
@@ -97,6 +98,13 @@
         $isSubmitting = true;
 
         try {
+            // Reject an unusable key before the resource is created, so a
+            // rejected variable can't leave a half-configured resource behind.
+            const validationError = validateVariables(variables);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             if (!latestTag) {
                 latestTag = await getLatestTag(data.repository.owner, data.repository.name);
             }

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
@@ -28,6 +28,7 @@
     import { humanFileSize } from '$lib/helpers/sizeConvertion';
     import { currentPlan } from '$lib/stores/organization';
     import { uploader } from '$lib/stores/uploader';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export let data;
 
@@ -69,6 +70,13 @@
         let func: Models.Function | null = null;
 
         try {
+            // Reject an unusable key before the resource is created, so a
+            // rejected variable can't leave a half-configured resource behind.
+            const validationError = validateVariables(variables);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             func = await sdk.forProject(page.params.region, page.params.project).functions.create({
                 functionId: id || ID.unique(),
                 name,

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/+page.svelte
@@ -22,7 +22,11 @@
     import RepoCard from './repoCard.svelte';
     import { getIconFromRuntime } from '$lib/stores/runtimes';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
-    import { normalizeDetectedVariables, mergeVariables } from '$lib/helpers/variables';
+    import {
+        normalizeDetectedVariables,
+        mergeVariables,
+        validateVariables
+    } from '$lib/helpers/variables';
 
     export let data;
 
@@ -104,6 +108,13 @@
 
     async function create() {
         try {
+            // Reject an unusable key before the resource is created, so a
+            // rejected variable can't leave a half-configured resource behind.
+            const validationError = validateVariables(variables);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             const func = await sdk
                 .forProject(page.params.region, page.params.project)
                 .functions.create({

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
@@ -38,6 +38,7 @@
     import { getIconFromRuntime } from '$lib/stores/runtimes';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import type { PageData } from './$types';
+    import { validateVariables } from '$lib/helpers/variables';
 
     let { data }: { data: PageData } = $props();
 
@@ -148,6 +149,15 @@
             return;
         } else {
             try {
+                // Reject an unusable key before the resource is created, so a
+                // rejected variable can't leave a half-configured resource behind.
+                const validationError = validateVariables(
+                    variables.map((variable) => ({ key: variable.name, value: variable.value }))
+                );
+                if (validationError) {
+                    throw new Error(validationError);
+                }
+
                 const rt = data.template.runtimes.find((r) => r.name === runtime);
 
                 const func = await sdk

--- a/src/routes/(console)/project-[region]-[project]/rawVariableEditor.svelte
+++ b/src/routes/(console)/project-[region]-[project]/rawVariableEditor.svelte
@@ -152,6 +152,11 @@
                 editableVariables.map(async (variable) => {
                     const newValue = vars[variable.key] ?? null;
 
+                    // Claim the key up front. A rejected write must not leave it
+                    // behind for the second pass, which would retry it as a new
+                    // variable and send the stored key along with it.
+                    delete vars[variable.key];
+
                     if (newValue === null) {
                         await sdkDeleteVariable(variable.$id);
                     } else if (newValue !== variable.value) {
@@ -159,7 +164,6 @@
                         // the API keep the stored one.
                         await sdkUpdateVariable(variable.$id, undefined, newValue, false);
                     }
-                    delete vars[variable.key];
                 })
             );
 

--- a/src/routes/(console)/project-[region]-[project]/rawVariableEditor.svelte
+++ b/src/routes/(console)/project-[region]-[project]/rawVariableEditor.svelte
@@ -6,6 +6,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import type { Models } from '@appwrite.io/console';
     import { parse } from '$lib/helpers/envfile';
+    import { validateVariables } from '$lib/helpers/variables';
     import { Icon, InlineCode, Layout, Tabs } from '@appwrite.io/pink-svelte';
     import { InputTextarea } from '$lib/elements/forms';
     import {
@@ -35,7 +36,7 @@
     ) => Promise<unknown>;
     export let sdkUpdateVariable: (
         variableId: string,
-        key: string,
+        key: string | undefined,
         value: string,
         secret?: boolean
     ) => Promise<unknown>;
@@ -74,10 +75,10 @@
     }
 
     function validateEntries(entries: DraftVariable[]) {
-        for (const { key, value } of entries) {
-            if (value.length > 8192) {
-                throw new Error(`Variable ${key} is longer than 8192 allowed characters`);
-            }
+        const validationError = validateVariables(entries);
+
+        if (validationError) {
+            throw new Error(validationError);
         }
     }
 
@@ -146,22 +147,26 @@
             const editableVariables = variableList.variables.filter((variable) => !variable.secret);
             const secretVariables = variableList.variables.filter((variable) => variable.secret);
 
-            await Promise.all(
+            const existingKeys = editableVariables.map((variable) => variable.key);
+            const existingResults = await Promise.allSettled(
                 editableVariables.map(async (variable) => {
                     const newValue = vars[variable.key] ?? null;
 
                     if (newValue === null) {
                         await sdkDeleteVariable(variable.$id);
                     } else if (newValue !== variable.value) {
-                        await sdkUpdateVariable(variable.$id, variable.key, newValue, false);
+                        // The key is unchanged here, so leave it out and let
+                        // the API keep the stored one.
+                        await sdkUpdateVariable(variable.$id, undefined, newValue, false);
                     }
                     delete vars[variable.key];
                 })
             );
 
             // Add new variables, skipping keys that exist in secret variables
-            await Promise.all(
-                Object.keys(vars).map(async (key) => {
+            const newKeys = Object.keys(vars);
+            const newResults = await Promise.allSettled(
+                newKeys.map(async (key) => {
                     const existingVariable = variableList.variables.find(
                         (variable) => variable.key === key
                     );
@@ -178,6 +183,22 @@
                     await sdkCreateVariable(key, vars[key], false);
                 })
             );
+
+            // Every variable is written on its own, so name the keys that
+            // failed rather than surfacing a single rejection.
+            const failed = [
+                ...existingResults.map((result, index) =>
+                    result.status === 'rejected' ? existingKeys[index] : null
+                ),
+                ...newResults.map((result, index) =>
+                    result.status === 'rejected' ? newKeys[index] : null
+                )
+            ].filter(Boolean);
+
+            if (failed.length) {
+                throw new Error(`Failed to update variables: ${failed.join(', ')}`);
+            }
+
             // Ensure secret variables are preserved
             variableList.variables = [
                 ...secretVariables,

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
@@ -28,6 +28,7 @@
     import { getLatestTag } from '$lib/helpers/github';
     import Link from '$lib/elements/link.svelte';
     import type { FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
+    import { validateVariables } from '$lib/helpers/variables';
 
     let {
         data
@@ -147,6 +148,13 @@
         $isSubmitting = true;
 
         try {
+            // Reject an unusable key before the resource is created, so a
+            // rejected variable can't leave a half-configured resource behind.
+            const validationError = validateVariables(variables);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             // Create site with build configuration
             let site = await sdk.forProject(page.params.region, page.params.project).sites.create({
                 siteId: id || ID.unique(),

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -27,6 +27,7 @@
     import Domain from '../domain.svelte';
     import { uploader } from '$lib/stores/uploader';
     import type { FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export let data;
     let showExitModal = false;
@@ -60,6 +61,13 @@
         let site: Models.Site | null = null;
 
         try {
+            // Reject an unusable key before the resource is created, so a
+            // rejected variable can't leave a half-configured resource behind.
+            const validationError = validateVariables(variables);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             if (!domainIsValid) {
                 addNotification({
                     type: 'error',

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
@@ -27,7 +27,11 @@
     import Configuration from '../../configuration.svelte';
     import Domain from '../../domain.svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
-    import { normalizeDetectedVariables, mergeVariables } from '$lib/helpers/variables';
+    import {
+        normalizeDetectedVariables,
+        mergeVariables,
+        validateVariables
+    } from '$lib/helpers/variables';
     import type { FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
 
     export let data;
@@ -113,6 +117,13 @@
             return;
         }
         try {
+            // Reject an unusable key before the resource is created, so a
+            // rejected variable can't leave a half-configured resource behind.
+            const validationError = validateVariables(variables);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             const fr = Object.values(Framework).find((f) => f === framework.key);
             const buildRuntime = Object.values(BuildRuntime).find(
                 (f) => f === framework.buildRuntime

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
@@ -45,6 +45,7 @@
     import { getFrameworkIcon } from '$lib/stores/sites';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { getTemplateSourceUrl } from '$lib/helpers/templateSource';
+    import { validateVariables } from '$lib/helpers/variables';
 
     export let data;
 
@@ -117,6 +118,15 @@
             return;
         } else {
             try {
+                // Reject an unusable key before the resource is created, so a
+                // rejected variable can't leave a half-configured resource behind.
+                const validationError = validateVariables(
+                    variables.map((variable) => ({ key: variable.name, value: variable.value }))
+                );
+                if (validationError) {
+                    throw new Error(validationError);
+                }
+
                 const fr = Object.values(Framework).find((f) => f === framework.key);
                 const buildRuntime = Object.values(BuildRuntime).find(
                     (f) => f === framework.buildRuntime

--- a/src/routes/(console)/project-[region]-[project]/updateVariables.svelte
+++ b/src/routes/(console)/project-[region]-[project]/updateVariables.svelte
@@ -5,6 +5,7 @@
     import { CardGrid, Empty, Output, PaginationInline } from '$lib/components';
     import UploadVariables from './uploadVariablesModal.svelte';
     import { variablesOperation, type VariablesOperationItem } from './variablesOperation';
+    import { isValidVariableKey, validateVariables } from '$lib/helpers/variables';
     import { goto, invalidate } from '$app/navigation';
     import { Click, Submit, trackError, trackEvent } from '$lib/actions/analytics';
     import { Dependencies } from '$lib/constants';
@@ -21,6 +22,7 @@
         Layout,
         Popover,
         Table,
+        Tooltip,
         Alert
     } from '@appwrite.io/pink-svelte';
     import {
@@ -55,7 +57,7 @@
     ) => Promise<unknown>;
     export let sdkUpdateVariable: (
         variableId: string,
-        key: string,
+        key: string | undefined,
         value: string,
         secret?: boolean
     ) => Promise<unknown>;
@@ -127,10 +129,24 @@
     async function handleVariableCreated(event: CustomEvent<Models.Variable[]>) {
         const variables = event.detail;
         try {
-            const promises = variables.map((variable) =>
-                sdkCreateVariable(variable.key, variable.value, variable?.secret || false)
+            const results = await Promise.allSettled(
+                variables.map((variable) =>
+                    sdkCreateVariable(variable.key, variable.value, variable?.secret || false)
+                )
             );
-            await Promise.all(promises);
+
+            // Each variable is created on its own, so name the keys that failed
+            // instead of reporting a single rejection for the whole batch.
+            const failed = results
+                .map((result, index) =>
+                    result.status === 'rejected' ? variables[index].key : null
+                )
+                .filter(Boolean);
+
+            if (failed.length) {
+                throw new Error(`Failed to create variables: ${failed.join(', ')}`);
+            }
+
             fullVariableList = undefined;
             showVariablesModal = false;
             addNotification({
@@ -174,7 +190,10 @@
     async function handleVariableSecret(event: CustomEvent<Models.Variable>) {
         const variable = event.detail;
         try {
-            await sdkUpdateVariable(variable.$id, variable.key, variable.value, variable.secret);
+            // Marking a variable secret never changes its key, so leave the key
+            // out and keep the stored one — including keys that predate the
+            // identifier rule.
+            await sdkUpdateVariable(variable.$id, undefined, variable.value, variable.secret);
             fullVariableList = undefined;
             selectedVar = null;
             showVariablesModal = false;
@@ -237,6 +256,14 @@
 
     async function handleVariablePromoted(variable: Models.Variable) {
         try {
+            // Promoting a conflicting key deletes the existing global variable
+            // before recreating it, so refuse a key the API would reject rather
+            // than deleting one and failing to create its replacement.
+            const validationError = validateVariables([variable]);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
             const globalVariable = globalVariableList
                 ? globalVariableList.variables.find(
                       (globalVariable) => globalVariable.key === variable.key
@@ -506,6 +533,19 @@
                                         <span
                                             class="icon-exclamation u-color-text-warning"
                                             aria-hidden="true"></span>
+                                    {/if}
+                                    {#if !isValidVariableKey(variable.key)}
+                                        <Tooltip>
+                                            <span
+                                                class="icon-exclamation u-color-text-danger"
+                                                aria-hidden="true"></span>
+                                            <svelte:fragment slot="tooltip">
+                                                This key can't be used as an environment variable
+                                                name, so it is ignored at build and runtime. Rename
+                                                it using only letters, digits and underscores,
+                                                without starting with a digit.
+                                            </svelte:fragment>
+                                        </Tooltip>
                                     {/if}
                                     <Copy value={variable.key} />
                                     <Output value={variable.key} hideCopyIcon>

--- a/src/routes/(console)/project-[region]-[project]/updateVariablesModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/updateVariablesModal.svelte
@@ -8,6 +8,7 @@
     import { base } from '$app/paths';
     import { Alert, Layout, Selector } from '@appwrite.io/pink-svelte';
     import { Link } from '$lib/elements';
+    import { getVariableValueError, validateVariables } from '$lib/helpers/variables';
 
     export let isGlobal: boolean;
     export let product: 'function' | 'site' = 'function';
@@ -21,6 +22,10 @@
         secret: selectedVar?.secret
     };
 
+    const originalKey = selectedVar?.key;
+
+    let error = '';
+
     const dispatch = createEventDispatcher();
 
     function close() {
@@ -29,7 +34,21 @@
     }
 
     function handleVariable() {
-        dispatch('updated', pair);
+        const keyChanged = pair.key !== originalKey;
+
+        // A key stored before the identifier rule existed is left untouched so
+        // its value stays editable; only a key the user actually changed has to
+        // satisfy the rule.
+        const validationError = keyChanged
+            ? validateVariables([pair])
+            : getVariableValueError(pair.key, pair.value);
+
+        if (validationError) {
+            error = validationError;
+            return;
+        }
+
+        dispatch('updated', { ...pair, key: keyChanged ? pair.key : undefined });
 
         close();
     }
@@ -41,6 +60,7 @@
 
 <Modal
     bind:show
+    bind:error
     onSubmit={handleVariable}
     title={`Update ${isGlobal ? 'global' : 'environment'} variable`}>
     <svelte:fragment slot="description">

--- a/src/routes/(console)/project-[region]-[project]/uploadVariablesModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/uploadVariablesModal.svelte
@@ -16,6 +16,7 @@
     } from '@appwrite.io/pink-svelte';
     import { parse } from '$lib/helpers/envfile';
     import { removeFile } from '$lib/helpers/files';
+    import { validateVariables } from '$lib/helpers/variables';
     import type { VariablesOperationItem } from './variablesOperation';
 
     export let show = false;
@@ -27,7 +28,7 @@
     ) => Promise<unknown>;
     export let sdkUpdateVariable: (
         variableId: string,
-        key: string,
+        key: string | undefined,
         value: string,
         secret?: boolean
     ) => Promise<unknown>;
@@ -64,16 +65,17 @@
 
             const entries = Object.entries(uploaded);
 
-            for (const [key, value] of entries) {
-                if (value.length > 8192) {
-                    throw new Error(`Variable ${key} is longer than 8192 allowed characters`);
-                }
-            }
-
             const filteredEntries = entries.filter(([, value]) => !!value);
 
             if (!filteredEntries.length) {
                 throw new Error('No variables found');
+            }
+
+            const validationError = validateVariables(
+                filteredEntries.map(([key, value]) => ({ key, value }))
+            );
+            if (validationError) {
+                throw new Error(validationError);
             }
 
             if (filteredEntries.length > 100) {
@@ -93,7 +95,7 @@
 
             show = false;
 
-            await Promise.all(
+            const results = await Promise.allSettled(
                 filteredEntries.map(([key, value]) => {
                     const found = variableList.variables.find((variable) => variable.key === key);
                     return found
@@ -101,6 +103,18 @@
                         : sdkCreateVariable(key, value, secret);
                 })
             );
+
+            // Each variable is written on its own, so report which keys failed
+            // instead of letting one rejection hide the ones that landed.
+            const failed = results
+                .map((result, index) =>
+                    result.status === 'rejected' ? filteredEntries[index][0] : null
+                )
+                .filter(Boolean);
+
+            if (failed.length) {
+                throw new Error(`Failed to upload variables: ${failed.join(', ')}`);
+            }
 
             onStatusChange({
                 id: importId,


### PR DESCRIPTION
## What

Adds variable key validation to the console, in every flow that writes one, and fixes three flows that handled a rejected key badly.

## Why

appwrite/appwrite#13181 makes the API reject variable keys that are not valid environment variable names (`^[A-Za-z_]\w*$`, max 255). The console had **no** key validation anywhere — only a value length check — so keys with hyphens, dots, spaces or a leading digit reached the API and returned a bare server error.

Three flows turn that error into real damage:

1. **Orphaned resources.** `create-function/*` and `create-site/*` create the function or site (and its proxy rule) *before* the variables. A rejected key aborts mid-flow and leaves a resource with no deployment.
2. **Legacy keys became uneditable.** The update modal resends the *stored* key on a value-only edit, so a key stored before the rule existed started failing on every save — the user could not even correct its value.
3. **Promote-to-global could destroy data.** The conflicting branch deletes the existing global variable before creating its replacement; if the create is rejected, the original is gone.

## Changes

**New** `src/lib/helpers/variables.ts` — `isValidVariableKey`, `getVariableKeyError`, `getVariableValueError`, `validateVariables` (+ unit tests). The existing `normalizeDetectedVariables` / `mergeVariables` are unchanged.

**Validation wired into all seven entry points:** both create modals, both update modals, the `.env` import modal, and both raw editors. The existing 8192-character value check is folded into the shared helper, so each call site keeps one check instead of two.

**Behaviour fixes:**
- `updateVariablesModal` validates the key only when it changed and omits it otherwise; `handleVariableSecret` never sends it. The endpoint treats `key` as sparse (`Update.php:107`) and the SDK drops `undefined`, so a value-only edit on a pre-existing `MY-KEY` now succeeds. `sdkUpdateVariable`'s key parameter widens to `string | undefined` in three components.
- All 8 create-function/create-site flows validate before the `create()` call, so an invalid key can no longer orphan a resource.
- Promote-to-global validates before the delete.
- Keys that fail the rule are flagged with a warning icon and tooltip in both variables tables — they are ignored at build and runtime today, silently.
- The batch writes use `allSettled` and name the keys that failed, instead of surfacing one rejection for the whole batch.

## Testing

`bun run check` (0 errors, 87 warnings — unchanged baseline), `bun run lint` (0 errors), `bun run test:unit` (243 passed), `bun run build` all pass.

`src/lib/helpers/oauth2-cimd.test.ts` fails to load locally on a missing `APPWRITE_ENDPOINT`; it arrives from 9dde99783 and is untouched here.