### PR TITLE
fix(sites): stop reading the framework start command

### DIFF
--- a/src/lib/stores/sites.ts
+++ b/src/lib/stores/sites.ts
@@ -1,9 +1,3 @@
-import type { Models } from '@appwrite.io/console';
-
-export type FrameworkAdapterWithStartCommand = Models.FrameworkAdapter & {
-    startCommand?: string;
-};
-
 export function getFrameworkIcon(framework: string) {
     switch (true) {
         case framework.toLocaleLowerCase().includes('sveltekit'):

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/configuration.svelte
@@ -3,22 +3,20 @@
     import { Fieldset, Layout, Accordion } from '@appwrite.io/pink-svelte';
     import type { Models } from '@appwrite.io/console';
     import { iconPath } from '$lib/stores/app';
-    import { getFrameworkIcon, type FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
+    import { getFrameworkIcon } from '$lib/stores/sites';
     import { EnvironmentVariables } from '$lib/components/variables';
 
     export let frameworks: Models.Framework[];
     export let selectedFramework: Models.Framework;
     $: frameworkData = frameworks.find((framework) => framework.key === selectedFramework?.key);
-    $: adapterData = (frameworkData?.adapters.find((adapter) => adapter.key === 'ssr') ??
-        frameworkData?.adapters.find(
-            (adapter) => adapter.key === 'static'
-        )) as FrameworkAdapterWithStartCommand;
+    $: adapterData =
+        frameworkData?.adapters.find((adapter) => adapter.key === 'ssr') ??
+        frameworkData?.adapters.find((adapter) => adapter.key === 'static');
 
     export let variables: Partial<Models.Variable>[] = [];
     export let isLoading = false;
     export let installCommand = '';
     export let buildCommand = '';
-    export let startCommand = '';
     export let outputDirectory = '';
 
     let frameworkId = selectedFramework.key;
@@ -28,7 +26,6 @@
     $: if (frameworkData && adapterDefaultsKey !== lastAdapterDefaultsKey) {
         installCommand = adapterData?.installCommand ?? '';
         buildCommand = adapterData?.buildCommand ?? '';
-        startCommand = adapterData?.startCommand ?? '';
         outputDirectory = adapterData?.outputDirectory ?? '';
         lastAdapterDefaultsKey = adapterDefaultsKey;
     }
@@ -86,24 +83,6 @@
                                 Reset
                             </Button>
                         </Layout.Stack>
-                        {#if adapterData?.key === 'ssr'}
-                            <Layout.Stack gap="s" direction="row" alignItems="flex-end">
-                                <InputText
-                                    id="startCommand"
-                                    label="Start command"
-                                    bind:value={startCommand}
-                                    placeholder={adapterData?.startCommand ||
-                                        'Enter start command'} />
-                                <Button
-                                    secondary
-                                    size="s"
-                                    disabled={(adapterData?.startCommand ?? '') ===
-                                        (startCommand ?? '')}
-                                    on:click={() => (startCommand = adapterData?.startCommand)}>
-                                    Reset
-                                </Button>
-                            </Layout.Stack>
-                        {/if}
                         <Layout.Stack gap="s" direction="row" alignItems="flex-end">
                             <InputText
                                 id="outputDirectory"

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
@@ -27,7 +27,6 @@
     import { writable } from 'svelte/store';
     import { getLatestTag } from '$lib/helpers/github';
     import Link from '$lib/elements/link.svelte';
-    import type { FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
 
     let {
         data
@@ -46,7 +45,6 @@
     let domain = $state('');
     let rootDir = $state(data.repository?.rootDirectory || '');
     let buildCommand = $state('');
-    let startCommand = $state('');
     let installCommand = $state('');
     let outputDirectory = $state('');
     let domainIsValid = $state(false);
@@ -82,11 +80,6 @@
         }))
     );
 
-    const primaryAdapter = $derived.by(
-        () => data.frameworks.frameworks.find((f) => f.key === framework)?.adapters?.[0]
-    );
-    const shouldShowStartCommand = $derived(primaryAdapter?.key === Adapter.Ssr);
-
     $effect(() => {
         if (framework && data.frameworks && !hasCustomCommands) {
             const fw = data.frameworks.frameworks.find((f) => f.key === framework);
@@ -94,7 +87,6 @@
                 const adapter = fw.adapters[0];
                 installCommand = adapter.installCommand || '';
                 buildCommand = adapter.buildCommand || '';
-                startCommand = (adapter as FrameworkAdapterWithStartCommand).startCommand || '';
                 outputDirectory = adapter.outputDirectory || '';
             }
         }
@@ -111,11 +103,10 @@
         // Build configuration - use from URL params or defaults
         installCommand = page.url.searchParams.get('install') || '';
         buildCommand = page.url.searchParams.get('build') || '';
-        startCommand = page.url.searchParams.get('start') || '';
         outputDirectory = page.url.searchParams.get('output') || '';
 
         // Check if custom commands were provided via URL
-        hasCustomCommands = !!(installCommand || buildCommand || startCommand || outputDirectory);
+        hasCustomCommands = !!(installCommand || buildCommand || outputDirectory);
 
         // If no custom commands, auto-fill from framework defaults
         if (!hasCustomCommands && data.frameworks) {
@@ -124,7 +115,6 @@
                 const adapter = fw.adapters[0];
                 installCommand = adapter.installCommand || '';
                 buildCommand = adapter.buildCommand || '';
-                startCommand = (adapter as FrameworkAdapterWithStartCommand).startCommand || '';
                 outputDirectory = adapter.outputDirectory || '';
             }
         }
@@ -155,7 +145,6 @@
                 buildRuntime: selectedFramework.buildRuntime,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
-                startCommand: shouldShowStartCommand ? startCommand || undefined : undefined,
                 outputDirectory: outputDirectory || undefined,
                 adapter: framework === Framework.Other ? Adapter.Static : undefined,
                 providerSilentMode: false
@@ -284,12 +273,6 @@
                         label="Build command"
                         placeholder={buildCommand || 'npm run build'}
                         bind:value={buildCommand} />
-                    {#if shouldShowStartCommand}
-                        <Input.Text
-                            label="Start command"
-                            placeholder={startCommand || 'npm run start'}
-                            bind:value={startCommand} />
-                    {/if}
                     <Input.Text
                         label="Output directory"
                         placeholder={outputDirectory || 'dist'}

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -26,7 +26,6 @@
     import { currentPlan } from '$lib/stores/organization';
     import Domain from '../domain.svelte';
     import { uploader } from '$lib/stores/uploader';
-    import type { FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
 
     export let data;
     let showExitModal = false;
@@ -41,10 +40,9 @@
     let framework: Models.Framework =
         data.frameworks.frameworks?.find((f) => f.key === 'other') ??
         data.frameworks.frameworks?.[0];
-    let adapter = framework?.adapters[0] as FrameworkAdapterWithStartCommand;
+    let adapter = framework?.adapters[0];
     let installCommand = adapter?.installCommand;
     let buildCommand = adapter?.buildCommand;
-    let startCommand = adapter?.startCommand;
     let outputDirectory = adapter?.outputDirectory;
     let variables: Partial<Models.Variable>[] = [];
     let files: FileList;
@@ -79,7 +77,6 @@
                 buildRuntime,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
-                startCommand: startCommand || undefined,
                 outputDirectory: outputDirectory || undefined
             });
 
@@ -254,7 +251,6 @@
             <Configuration
                 bind:installCommand
                 bind:buildCommand
-                bind:startCommand
                 bind:outputDirectory
                 bind:selectedFramework={framework}
                 bind:variables

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
@@ -28,7 +28,6 @@
     import Domain from '../../domain.svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { normalizeDetectedVariables, mergeVariables } from '$lib/helpers/variables';
-    import type { FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
 
     export let data;
     let showExitModal = false;
@@ -39,12 +38,11 @@
     let name = '';
     let id = ID.unique();
     let framework: Models.Framework = data.frameworks.frameworks.find((f) => f.key === 'other');
-    let adapter = framework?.adapters[0] as FrameworkAdapterWithStartCommand;
+    let adapter = framework?.adapters[0];
     let branch: string;
     let rootDir = './';
     let installCommand = adapter?.installCommand;
     let buildCommand = adapter?.buildCommand;
-    let startCommand = adapter?.startCommand;
     let outputDirectory = adapter?.outputDirectory;
     let variables: Partial<Models.Variable>[] = [];
     let silentMode = false;
@@ -83,10 +81,9 @@
             if (!framework) {
                 framework = data.frameworks.frameworks.find((f) => f.key === 'other');
             }
-            adapter = framework?.adapters[0] as FrameworkAdapterWithStartCommand;
+            adapter = framework?.adapters[0];
             installCommand = adapter?.installCommand;
             buildCommand = adapter?.buildCommand;
-            startCommand = adapter?.startCommand;
             outputDirectory = adapter?.outputDirectory;
             const detectedVariables = normalizeDetectedVariables(response?.variables);
             if (detectedVariables.length) {
@@ -124,7 +121,6 @@
                 buildRuntime,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
-                startCommand: startCommand || undefined,
                 outputDirectory: outputDirectory || undefined,
                 installationId: data.installation.$id,
                 providerRepositoryId: data.repository.id,
@@ -223,7 +219,6 @@
                 <Configuration
                     bind:installCommand
                     bind:buildCommand
-                    bind:startCommand
                     bind:outputDirectory
                     bind:selectedFramework={framework}
                     bind:variables

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -367,9 +367,8 @@
                         {#if adapter === Adapter.Ssr}
                             <Accordion title="Advanced">
                                 <Layout.Stack gap="l">
-                                    Leave empty to let your framework start the way Appwrite
-                                    expects. Set a command only if your site needs its own
-                                    entrypoint.
+                                    Command used to start your SSR server after a successful deploy.
+                                    Leave it empty to use the framework default.
                                     <InputText
                                         id="startCommand"
                                         label="Start command"

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -92,6 +92,7 @@
             outputDirectory = data.outputDirectory;
             adapter = data.key as Adapter;
             fallback = data.fallbackFile;
+            startCommand = '';
         } else if (hasFrameworkSelectionChanged) {
             const data =
                 selectedFramework.adapters.find((a) => a.key === adapter) ??
@@ -110,6 +111,7 @@
             fallback = isOriginalAdapter
                 ? (site?.fallbackFile ?? data.fallbackFile)
                 : data.fallbackFile;
+            startCommand = isOriginalAdapter ? (site?.startCommand ?? '') : '';
         }
 
         lastFrameworkAdapterKey = `${selectedFramework.key}:${adapter ?? ''}`;
@@ -167,7 +169,7 @@
                 timeout: site.timeout || undefined,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
-                startCommand: startCommand || undefined,
+                startCommand: adptr?.key === 'ssr' ? startCommand || undefined : undefined,
                 outputDirectory: outputDirectory || undefined,
                 buildRuntime: (site?.buildRuntime as BuildRuntime) || undefined,
                 adapter: (adptr?.key as Adapter) || undefined,

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -7,12 +7,20 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
-    import { Card, Fieldset, Icon, InlineCode, Layout, Tooltip } from '@appwrite.io/pink-svelte';
+    import {
+        Accordion,
+        Card,
+        Fieldset,
+        Icon,
+        InlineCode,
+        Layout,
+        Tooltip
+    } from '@appwrite.io/pink-svelte';
     import { iconPath } from '$lib/stores/app';
     import { Link } from '$lib/elements';
     import { IconInfo } from '@appwrite.io/pink-icons-svelte';
     import { adapterDataList } from './store';
-    import { getFrameworkIcon, type FrameworkAdapterWithStartCommand } from '$lib/stores/sites';
+    import { getFrameworkIcon } from '$lib/stores/sites';
     import { page } from '$app/state';
 
     let {
@@ -50,9 +58,8 @@
             (fallback ?? '') === (site?.fallbackFile ?? '') &&
             (adapter ?? '') === (site?.adapter ?? '')
     );
-    let frameworkAdapterData: FrameworkAdapterWithStartCommand = $derived(
-        (selectedFramework.adapters.find((a) => a.key === adapter) ??
-            selectedFramework.adapters[0]) as FrameworkAdapterWithStartCommand
+    let frameworkAdapterData = $derived(
+        selectedFramework.adapters.find((a) => a.key === adapter) ?? selectedFramework.adapters[0]
     );
 
     $effect(() => {
@@ -77,17 +84,18 @@
             }
 
             //Update values
-            const data = (selectedFramework.adapters.find((a) => a.key === adapter) ??
-                selectedFramework.adapters[0]) as FrameworkAdapterWithStartCommand;
+            const data =
+                selectedFramework.adapters.find((a) => a.key === adapter) ??
+                selectedFramework.adapters[0];
             installCommand = data.installCommand;
             buildCommand = data.buildCommand;
-            startCommand = data.startCommand;
             outputDirectory = data.outputDirectory;
             adapter = data.key as Adapter;
             fallback = data.fallbackFile;
         } else if (hasFrameworkSelectionChanged) {
-            const data = (selectedFramework.adapters.find((a) => a.key === adapter) ??
-                selectedFramework.adapters[0]) as FrameworkAdapterWithStartCommand;
+            const data =
+                selectedFramework.adapters.find((a) => a.key === adapter) ??
+                selectedFramework.adapters[0];
             const isOriginalAdapter = adapter === site.adapter;
 
             installCommand = isOriginalAdapter
@@ -96,9 +104,6 @@
             buildCommand = isOriginalAdapter
                 ? (site?.buildCommand ?? frameworkAdapterData.buildCommand)
                 : data.buildCommand;
-            startCommand = isOriginalAdapter
-                ? (site?.startCommand ?? frameworkAdapterData.startCommand)
-                : data.startCommand;
             outputDirectory = isOriginalAdapter
                 ? (site?.outputDirectory ?? frameworkAdapterData.outputDirectory)
                 : data.outputDirectory;
@@ -193,17 +198,13 @@
         }
     }
 
-    function reset(type: 'installCommand' | 'buildCommand' | 'startCommand' | 'outputDirectory') {
-        const data = selectedFramework.adapters.find(
-            (a) => a.key === adapter
-        ) as FrameworkAdapterWithStartCommand;
+    function reset(type: 'installCommand' | 'buildCommand' | 'outputDirectory') {
+        const data = selectedFramework.adapters.find((a) => a.key === adapter);
 
         if (type === 'installCommand') {
             installCommand = data.installCommand;
         } else if (type === 'buildCommand') {
             buildCommand = data.buildCommand;
-        } else if (type === 'startCommand') {
-            startCommand = data.startCommand;
         } else if (type === 'outputDirectory') {
             outputDirectory = data.outputDirectory;
         }
@@ -332,24 +333,6 @@
                                 Reset
                             </Button>
                         </Layout.Stack>
-                        {#if adapter === Adapter.Ssr}
-                            <Layout.Stack gap="s" direction="row" alignItems="flex-end">
-                                <InputText
-                                    id="startCommand"
-                                    label="Start command"
-                                    bind:value={startCommand}
-                                    placeholder={frameworkAdapterData?.startCommand ||
-                                        'Enter start command'} />
-                                <Button
-                                    secondary
-                                    size="s"
-                                    disabled={(startCommand ?? '') ===
-                                        (frameworkAdapterData?.startCommand ?? '')}
-                                    on:click={() => reset('startCommand')}>
-                                    Reset
-                                </Button>
-                            </Layout.Stack>
-                        {/if}
                         <Layout.Stack gap="s" direction="row" alignItems="flex-end">
                             <InputText
                                 id="outputDirectory"
@@ -380,6 +363,20 @@
                                     </span>
                                 </Tooltip>
                             </InputText>
+                        {/if}
+                        {#if adapter === Adapter.Ssr}
+                            <Accordion title="Advanced">
+                                <Layout.Stack gap="l">
+                                    Leave empty to let your framework start the way Appwrite
+                                    expects. Set a command only if your site needs its own
+                                    entrypoint.
+                                    <InputText
+                                        id="startCommand"
+                                        label="Start command"
+                                        bind:value={startCommand}
+                                        placeholder="Enter start command" />
+                                </Layout.Stack>
+                            </Accordion>
                         {/if}
                     </Layout.Stack>
                 </Fieldset>


### PR DESCRIPTION
## What

The UI is unchanged. This removes the code that read `startCommand` off a framework adapter — a field the SDK never declared and the API no longer sends — plus a bug where a start command survived a framework change.

Pairs with appwrite/appwrite#13194, which stops `listFrameworks` shipping the internal command. No SDK regeneration needed: `Models.FrameworkAdapter` already declares exactly `key`, `installCommand`, `buildCommand`, `outputDirectory`, `fallbackFile`, which is what the endpoint now returns.

## The dead reads

`src/lib/stores/sites.ts` declared:

```ts
export type FrameworkAdapterWithStartCommand = Models.FrameworkAdapter & {
    startCommand?: string;
};
```

Every create flow cast the adapter to that type and used `adapter.startCommand` to prefill the input and fill the placeholder. Once the API stops sending it, all of those resolve to `undefined` — the prefill silently does nothing and Reset restores a value that does not exist. Gone, along with the cast.

## The bug

Changing framework or adapter kept the previous framework's start command in state, and `update()` submitted it against the new runtime. Previously `startCommand = data.startCommand` masked this by resetting the field from adapter data; removing that read exposed it.

- cleared when the framework or adapter changes, restored from the site when switching back to its original adapter
- submitted only for the `ssr` adapter, matching the `fallbackFile` line beside it

## Not included

The earlier revision of this PR hid the field in the create flows and moved it under an Advanced section in settings. Dropped per Eldad — the UI stays exactly as it is.

## Verification

`npm run check` — 0 errors, 87 warnings (all pre-existing). Prettier clean.