### PR TITLE
Keep the start command field, drop the adapter reads behind it

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "flatted": "^3.4.2",
         "ignore": "^6.0.2",
         "json5": "^2.2.3",
-        "nanoid": "^5.1.16",
+        "nanoid": "^3.3.18",
         "nanotar": "^0.3.0",
         "pretty-bytes": "^6.1.1",
         "remarkable": "^2.0.1",
@@ -97,6 +97,7 @@
     "immutable": "^5.1.8",
     "js-yaml": "^4.3.1",
     "minimatch": "10.2.3",
+    "nanoid": "^3.3.18",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.18",
     "vite": "npm:rolldown-vite@latest",
@@ -130,15 +131,15 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@6be9e62", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-XvEyYAb9HtcySeLgn5ZxVCEBhzxSCXfQurcSVp6Wnj1amBFx5CWsKhfWHelG9DxFG9SkeHmY+bTcZneOAhgBkw=="],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@6be9e62", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 
-    "@appwrite.io/pink-icons-svelte": ["@appwrite.io/pink-icons-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3", { "peerDependencies": { "svelte": "^4.0.0" } }, "sha512-2HYl/CC2OlfZIR7LzbLXuSPBn0iNkjbnxpaeGCkZ7UNZ/hFeSeeWjDJqTBMdZ8+X95uuZqHx62XPTiE/svuSXQ=="],
+    "@appwrite.io/pink-icons-svelte": ["@appwrite.io/pink-icons-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3", { "peerDependencies": { "svelte": "^4.0.0" } }],
 
     "@appwrite.io/pink-legacy": ["@appwrite.io/pink-legacy@1.0.3", "", { "dependencies": { "@appwrite.io/pink-icons": "1.0.0", "the-new-css-reset": "^1.11.2" } }, "sha512-GGde5fmPhs+s6/3aFeMPc/kKADG/gTFkYQSy6oBN8pK0y0XNCLrZZgBv+EBbdhwdtqVEWXa0X85Mv9w7jcIlwQ=="],
 
-    "@appwrite.io/pink-svelte": ["@appwrite.io/pink-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-svelte@8dcaa17", { "dependencies": { "@appwrite.io/pink-icons-svelte": "2.0.0-RC.1", "@floating-ui/dom": "^1.6.13", "@melt-ui/pp": "^0.3.2", "@melt-ui/svelte": "^0.86.6", "@tanstack/svelte-virtual": "^3.13.10", "ansicolor": "^2.0.3", "d3": "^7.9.0", "fuse.js": "^7.1.0", "pretty-bytes": "^6.1.1", "shiki": "^1.18.0", "svelte-motion": "^0.12.2", "svelte-sonner": "^0.3.28" }, "peerDependencies": { "svelte": "^4.0.0" } }, "sha512-rw3zXN7/cUciCnhj0FR8M0H5Db+LYYMaKtPxvOAIMxNTBmStzU8kTw6grqIvdtFu9vybIsjKtIwm9QLHpNDBjA=="],
+    "@appwrite.io/pink-svelte": ["@appwrite.io/pink-svelte@https://pkg.vc/-/@appwrite/@appwrite.io/pink-svelte@8dcaa17", { "dependencies": { "@appwrite.io/pink-icons-svelte": "2.0.0-RC.1", "@floating-ui/dom": "^1.6.13", "@melt-ui/pp": "^0.3.2", "@melt-ui/svelte": "^0.86.6", "@tanstack/svelte-virtual": "^3.13.10", "ansicolor": "^2.0.3", "d3": "^7.9.0", "fuse.js": "^7.1.0", "pretty-bytes": "^6.1.1", "shiki": "^1.18.0", "svelte-motion": "^0.12.2", "svelte-sonner": "^0.3.28" }, "peerDependencies": { "svelte": "^4.0.0" } }],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -1128,7 +1129,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanotar": ["nanotar@0.3.0", "", {}, "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg=="],
 
@@ -1500,8 +1501,6 @@
 
     "@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.0.11", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-CPyImHGiT3svyfmvPvAFTianZzWFtm0qK82XjwlQIA1C3IQ2iku/PMQXi7aFyrX0TyMh3VTkJPB03tjU2VXVrw=="],
 
-    "@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
-
     "@ai-sdk/ui-utils/@ai-sdk/provider": ["@ai-sdk/provider@1.0.11", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-CPyImHGiT3svyfmvPvAFTianZzWFtm0qK82XjwlQIA1C3IQ2iku/PMQXi7aFyrX0TyMh3VTkJPB03tjU2VXVrw=="],
 
     "@appwrite.io/pink-legacy/@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@1.0.0", "", {}, "sha512-+zpksP07MvOYwhx9AZDFW0pxXQNC2juKwyOQVRAwAOkN1ACSQKPlyytkI1u2ci6CQPWjJe20CzbvBBuRNXOKjA=="],
@@ -1523,8 +1522,6 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "@melt-ui/svelte/nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
 
     "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
@@ -1573,8 +1570,6 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "popmotion/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
-
-    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "style-value-types/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "flatted": "^3.4.2",
         "ignore": "^6.0.2",
         "json5": "^2.2.3",
-        "nanoid": "^5.1.16",
+        "nanoid": "^3.3.18",
         "nanotar": "^0.3.0",
         "pretty-bytes": "^6.1.1",
         "remarkable": "^2.0.1",
@@ -113,6 +113,7 @@
         "picomatch": "^4.0.4",
         "cookie": "^0.7.0",
         "ws": "^8.21.0",
-        "postcss": "^8.5.18"
+        "postcss": "^8.5.18",
+        "nanoid": "^3.3.18"
     }
 }

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/configuration.svelte
@@ -28,6 +28,7 @@
         installCommand = adapterData?.installCommand ?? '';
         buildCommand = adapterData?.buildCommand ?? '';
         outputDirectory = adapterData?.outputDirectory ?? '';
+        startCommand = '';
         lastAdapterDefaultsKey = adapterDefaultsKey;
     }
 </script>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/configuration.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/configuration.svelte
@@ -17,6 +17,7 @@
     export let isLoading = false;
     export let installCommand = '';
     export let buildCommand = '';
+    export let startCommand = '';
     export let outputDirectory = '';
 
     let frameworkId = selectedFramework.key;
@@ -83,6 +84,15 @@
                                 Reset
                             </Button>
                         </Layout.Stack>
+                        {#if adapterData?.key === 'ssr'}
+                            <Layout.Stack gap="s" direction="row" alignItems="flex-end">
+                                <InputText
+                                    id="startCommand"
+                                    label="Start command"
+                                    bind:value={startCommand}
+                                    placeholder="Enter start command" />
+                            </Layout.Stack>
+                        {/if}
                         <Layout.Stack gap="s" direction="row" alignItems="flex-end">
                             <InputText
                                 id="outputDirectory"

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
@@ -94,6 +94,7 @@
                 installCommand = adapter.installCommand || '';
                 buildCommand = adapter.buildCommand || '';
                 outputDirectory = adapter.outputDirectory || '';
+                startCommand = '';
             }
         }
     });

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
@@ -45,6 +45,7 @@
     let domain = $state('');
     let rootDir = $state(data.repository?.rootDirectory || '');
     let buildCommand = $state('');
+    let startCommand = $state('');
     let installCommand = $state('');
     let outputDirectory = $state('');
     let domainIsValid = $state(false);
@@ -80,6 +81,11 @@
         }))
     );
 
+    const primaryAdapter = $derived.by(
+        () => data.frameworks.frameworks.find((f) => f.key === framework)?.adapters?.[0]
+    );
+    const shouldShowStartCommand = $derived(primaryAdapter?.key === Adapter.Ssr);
+
     $effect(() => {
         if (framework && data.frameworks && !hasCustomCommands) {
             const fw = data.frameworks.frameworks.find((f) => f.key === framework);
@@ -103,10 +109,11 @@
         // Build configuration - use from URL params or defaults
         installCommand = page.url.searchParams.get('install') || '';
         buildCommand = page.url.searchParams.get('build') || '';
+        startCommand = page.url.searchParams.get('start') || '';
         outputDirectory = page.url.searchParams.get('output') || '';
 
         // Check if custom commands were provided via URL
-        hasCustomCommands = !!(installCommand || buildCommand || outputDirectory);
+        hasCustomCommands = !!(installCommand || buildCommand || startCommand || outputDirectory);
 
         // If no custom commands, auto-fill from framework defaults
         if (!hasCustomCommands && data.frameworks) {
@@ -145,6 +152,7 @@
                 buildRuntime: selectedFramework.buildRuntime,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
+                startCommand: shouldShowStartCommand ? startCommand || undefined : undefined,
                 outputDirectory: outputDirectory || undefined,
                 adapter: framework === Framework.Other ? Adapter.Static : undefined,
                 providerSilentMode: false
@@ -273,6 +281,12 @@
                         label="Build command"
                         placeholder={buildCommand || 'npm run build'}
                         bind:value={buildCommand} />
+                    {#if shouldShowStartCommand}
+                        <Input.Text
+                            label="Start command"
+                            placeholder={startCommand || 'npm run start'}
+                            bind:value={startCommand} />
+                    {/if}
                     <Input.Text
                         label="Output directory"
                         placeholder={outputDirectory || 'dist'}

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/deploy/+page.svelte
@@ -94,7 +94,6 @@
                 installCommand = adapter.installCommand || '';
                 buildCommand = adapter.buildCommand || '';
                 outputDirectory = adapter.outputDirectory || '';
-                startCommand = '';
             }
         }
     });
@@ -262,7 +261,8 @@
                         label="Framework"
                         placeholder="Select framework"
                         bind:value={framework}
-                        options={frameworkSelectOptions} />
+                        options={frameworkSelectOptions}
+                        on:change={() => (startCommand = '')} />
                 </Layout.Stack>
             </Fieldset>
 

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -43,6 +43,7 @@
     let adapter = framework?.adapters[0];
     let installCommand = adapter?.installCommand;
     let buildCommand = adapter?.buildCommand;
+    let startCommand = '';
     let outputDirectory = adapter?.outputDirectory;
     let variables: Partial<Models.Variable>[] = [];
     let files: FileList;
@@ -77,6 +78,7 @@
                 buildRuntime,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
+                startCommand: startCommand || undefined,
                 outputDirectory: outputDirectory || undefined
             });
 
@@ -251,6 +253,7 @@
             <Configuration
                 bind:installCommand
                 bind:buildCommand
+                bind:startCommand
                 bind:outputDirectory
                 bind:selectedFramework={framework}
                 bind:variables

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
@@ -43,6 +43,7 @@
     let rootDir = './';
     let installCommand = adapter?.installCommand;
     let buildCommand = adapter?.buildCommand;
+    let startCommand = '';
     let outputDirectory = adapter?.outputDirectory;
     let variables: Partial<Models.Variable>[] = [];
     let silentMode = false;
@@ -121,6 +122,7 @@
                 buildRuntime,
                 installCommand: installCommand || undefined,
                 buildCommand: buildCommand || undefined,
+                startCommand: startCommand || undefined,
                 outputDirectory: outputDirectory || undefined,
                 installationId: data.installation.$id,
                 providerRepositoryId: data.repository.id,
@@ -219,6 +221,7 @@
                 <Configuration
                     bind:installCommand
                     bind:buildCommand
+                    bind:startCommand
                     bind:outputDirectory
                     bind:selectedFramework={framework}
                     bind:variables

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/settings/updateBuildSettings.svelte
@@ -7,15 +7,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Adapter, BuildRuntime, Framework, type Models } from '@appwrite.io/console';
-    import {
-        Accordion,
-        Card,
-        Fieldset,
-        Icon,
-        InlineCode,
-        Layout,
-        Tooltip
-    } from '@appwrite.io/pink-svelte';
+    import { Card, Fieldset, Icon, InlineCode, Layout, Tooltip } from '@appwrite.io/pink-svelte';
     import { iconPath } from '$lib/stores/app';
     import { Link } from '$lib/elements';
     import { IconInfo } from '@appwrite.io/pink-icons-svelte';
@@ -89,10 +81,10 @@
                 selectedFramework.adapters[0];
             installCommand = data.installCommand;
             buildCommand = data.buildCommand;
+            startCommand = '';
             outputDirectory = data.outputDirectory;
             adapter = data.key as Adapter;
             fallback = data.fallbackFile;
-            startCommand = '';
         } else if (hasFrameworkSelectionChanged) {
             const data =
                 selectedFramework.adapters.find((a) => a.key === adapter) ??
@@ -105,13 +97,13 @@
             buildCommand = isOriginalAdapter
                 ? (site?.buildCommand ?? frameworkAdapterData.buildCommand)
                 : data.buildCommand;
+            startCommand = isOriginalAdapter ? (site?.startCommand ?? '') : '';
             outputDirectory = isOriginalAdapter
                 ? (site?.outputDirectory ?? frameworkAdapterData.outputDirectory)
                 : data.outputDirectory;
             fallback = isOriginalAdapter
                 ? (site?.fallbackFile ?? data.fallbackFile)
                 : data.fallbackFile;
-            startCommand = isOriginalAdapter ? (site?.startCommand ?? '') : '';
         }
 
         lastFrameworkAdapterKey = `${selectedFramework.key}:${adapter ?? ''}`;
@@ -335,6 +327,15 @@
                                 Reset
                             </Button>
                         </Layout.Stack>
+                        {#if adapter === Adapter.Ssr}
+                            <Layout.Stack gap="s" direction="row" alignItems="flex-end">
+                                <InputText
+                                    id="startCommand"
+                                    label="Start command"
+                                    bind:value={startCommand}
+                                    placeholder="Enter start command" />
+                            </Layout.Stack>
+                        {/if}
                         <Layout.Stack gap="s" direction="row" alignItems="flex-end">
                             <InputText
                                 id="outputDirectory"
@@ -365,19 +366,6 @@
                                     </span>
                                 </Tooltip>
                             </InputText>
-                        {/if}
-                        {#if adapter === Adapter.Ssr}
-                            <Accordion title="Advanced">
-                                <Layout.Stack gap="l">
-                                    Command used to start your SSR server after a successful deploy.
-                                    Leave it empty to use the framework default.
-                                    <InputText
-                                        id="startCommand"
-                                        label="Start command"
-                                        bind:value={startCommand}
-                                        placeholder="Enter start command" />
-                                </Layout.Stack>
-                            </Accordion>
                         {/if}
                     </Layout.Stack>
                 </Fieldset>


### PR DESCRIPTION
The field stays where it is. What goes is the code reading startCommand off a framework adapter: the SDK never declared it and the API no longer sends it, so the prefill and the placeholder were pointing at nothing, and Reset restored a value that does not exist.

Also stop carrying a start command across a framework or adapter change - it names an entrypoint only the previous framework has - and send it only for the ssr adapter, matching the fallbackFile line beside it.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)