### PR TITLE
fix(auth): correct email and phone verification alert messages

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/user-[user]/updateStatus.svelte
@@ -15,6 +15,20 @@
 
     let showVerificationDropdown = false;
 
+    function getVerificationMessage(
+        type: 'email' | 'phone',
+        name: string | undefined,
+        verified: boolean
+    ): string {
+        const status = verified ? 'has been verified' : 'is no longer verified';
+
+        if (name?.trim()) {
+            return `The ${type} for ${name.trim()} ${status}`;
+        }
+
+        return `The ${type} ${status}`;
+    }
+
     async function updateVerificationEmail() {
         showVerificationDropdown = false;
         try {
@@ -26,9 +40,7 @@
                 });
             await invalidate(Dependencies.USER);
             addNotification({
-                message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
-                    !$user.emailVerification ? 'unverified' : 'verified'
-                }`,
+                message: getVerificationMessage('email', $user.name, $user.emailVerification),
                 type: 'success'
             });
             trackEvent(Submit.UserUpdateVerificationEmail);
@@ -51,9 +63,7 @@
                 });
             await invalidate(Dependencies.USER);
             addNotification({
-                message: `${$user.name || $user.email || $user.phone || 'The account'} has been ${
-                    $user.phoneVerification ? 'unverified' : 'verified'
-                }`,
+                message: getVerificationMessage('phone', $user.name, $user.phoneVerification),
                 type: 'success'
             });
             trackEvent(Submit.UserUpdateVerificationPhone);


### PR DESCRIPTION
## Summary

Fixes #1392 by updating verification success alerts on the user auth page so email and phone actions show the correct, field-specific message after verify/unverify.

- Phone alerts no longer use inverted verification state (missing negation after `invalidate()` refreshes the user store)
- Messages follow the maintainer guidance from https://github.com/appwrite/console/issues/1392#issuecomment-3120579639:
  - With name: `The email for XYZ has been verified` / `The phone for XYZ is no longer verified`
  - Without name: `The email has been verified` / `The phone is no longer verified`

## Test plan

- [ ] Start local Appwrite (`http://localhost:9520`) and console (`bun dev`)
- [ ] Create a user with both email and phone in Auth
- [ ] Verify email → alert says email verified (with/without user name)
- [ ] Unverify email → alert says email is no longer verified
- [ ] Verify phone → alert says phone verified (not inverted account message)
- [ ] Unverify phone → alert says phone is no longer verified