### PR TITLE
chore(deploy): push image bumps to application-configuration

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,8 +11,10 @@ concurrency:
 
 env:
     ENVIRONMENT: production
+    PROJECT: cloud
+    APPLICATION: cloud
     DECLARATIVE_OWNER: appwrite-labs
-    DECLARATIVE_REPOSITORY: cloud-applications
+    DECLARATIVE_REPOSITORY: application-configuration
     DECLARATIVE_ALIAS: cloud-console
     IMAGE_NAME: appwrite/console-cloud
     TAG: ${{ github.event.release.tag_name || github.sha }}
@@ -54,7 +56,7 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         # Shared across the staging and production workflows so their deploy
-        # jobs never push to cloud-applications at the same time.
+        # jobs never push to application-configuration at the same time.
         concurrency:
             group: declarative-deploy
             cancel-in-progress: false
@@ -77,7 +79,7 @@ jobs:
                   persist-credentials: false
 
             - name: Update image tag
-              run: yq -i '.[strenv(DECLARATIVE_ALIAS)].image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/cloud/default.yaml
+              run: yq -i '.[strenv(DECLARATIVE_ALIAS)].image.tag = strenv(TAG)' ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
 
             - name: Open pull request
               # The release author reviews; falls back to the dispatcher for
@@ -90,7 +92,7 @@ jobs:
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add ${{ env.ENVIRONMENT }}/cloud/default.yaml
+                  git add ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
                     exit 0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,8 +12,10 @@ concurrency:
 
 env:
     ENVIRONMENT: staging
+    PROJECT: cloud
+    APPLICATION: cloud
     DECLARATIVE_OWNER: appwrite-labs
-    DECLARATIVE_REPOSITORY: cloud-applications
+    DECLARATIVE_REPOSITORY: application-configuration
     DECLARATIVE_ALIAS: cloud-console
     IMAGE_NAME: appwrite/console-cloud-stage
     TAG: ${{ github.sha }}
@@ -54,7 +56,7 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         # Shared across the staging and production workflows so their deploy
-        # jobs never push to cloud-applications at the same time.
+        # jobs never push to application-configuration at the same time.
         concurrency:
             group: declarative-deploy
             cancel-in-progress: false
@@ -77,7 +79,7 @@ jobs:
                   persist-credentials: false
 
             - name: Update image tag
-              run: yq -i '.[strenv(DECLARATIVE_ALIAS)].image.tag = strenv(TAG)' ${{ env.ENVIRONMENT }}/cloud/default.yaml
+              run: yq -i '.[strenv(DECLARATIVE_ALIAS)].image.tag = strenv(TAG)' ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
 
             - name: Commit and push
               env:
@@ -85,7 +87,7 @@ jobs:
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add ${{ env.ENVIRONMENT }}/cloud/default.yaml
+                  git add ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
                   if git diff --cached --quiet; then
                     echo "No changes to commit"
                   else


### PR DESCRIPTION
## What

The cloud values moved out of [`cloud-applications`](https://github.com/appwrite-labs/cloud-applications) into [`application-configuration`](https://github.com/appwrite-labs/application-configuration) (appwrite-labs/application-configuration#15), laid out as `<project>/<env>/<app>` instead of `<env>/<app>`.

```diff
+    PROJECT: cloud
+    APPLICATION: cloud
-    DECLARATIVE_REPOSITORY: cloud-applications
+    DECLARATIVE_REPOSITORY: application-configuration

-  ${{ env.ENVIRONMENT }}/cloud/default.yaml
+  ${{ env.PROJECT }}/${{ env.ENVIRONMENT }}/${{ env.APPLICATION }}/default.yaml
```

The path was hardcoded; it now builds from the env vars like every other deploy workflow. The tag still lands on the `cloud-console` alias inside the cloud release, and production still opens a reviewed PR against the declarative repo rather than pushing to main.

Verified: both write targets resolve to real files in the new repo and carry a `cloud-console.image.tag` key.

## Merge order

**Last.** ArgoCD has to be reading the new repo first: appwrite-labs/application-configuration#15 → appwrite-labs/cluster-configuration-generator#163 (plus its generated PR into `cluster-configuration`) → this.