### PR TITLE
fix: truncate long database names in navigation

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/subNavigation.svelte
@@ -125,7 +125,7 @@
                 class="database-name u-flex u-cross-center body-text-2 u-gap-8 is-not-mobile u-padding-block-8 u-padding-inline-start-4">
                 <Icon icon={IconDatabase} size="s" color="--fgcolor-neutral-weak" />
 
-                {data.database?.name}
+                <span class="database-name-text">{data.database?.name}</span>
             </a>
             <div class="entity-content" style:padding-bottom={entityContentPadding}>
                 {#if loading}
@@ -295,12 +295,20 @@
         margin-block-end: 4px;
         font-size: var(--font-size-sm);
         color: var(--fgcolor-neutral-secondary);
+        overflow: hidden;
 
         &:hover {
             color: var(--fgcolor-neutral-primary);
             border-radius: var(--border-radius-s, 6px);
             background: var(--bgcolor-neutral-secondary);
         }
+    }
+
+    .database-name-text {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .entity-content {


### PR DESCRIPTION
## Description

Fixes long database names overflowing the database navigation item.

## Before & After
<img width="305" height="164" alt="Screenshot 2026-08-16 at 3 23 16 PM" src="https://github.com/user-attachments/assets/e9347fc2-cf40-495b-a535-f18d48d97426" />
---
<img width="305" height="164" alt="Screenshot 2026-08-16 at 3 23 31 PM" src="https://github.com/user-attachments/assets/343de2c4-fb79-47a5-aff0-83488e833ccd" />


### Changes

- Wrap the database name in a dedicated element.
- Add text truncation with an ellipsis for long database names.
- Prevent the database name from overflowing the navigation width.

### Testing

- Verified long database names are truncated with an ellipsis.
- Verified short database names remain unchanged.
- `bun run check` passes with 0 errors.
- `bun run lint` passes with 0 errors.
- `git diff --check` passes.