### PR TITLE
chore(deps): bump @appwrite.io/console to 56957ff

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,11 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@ed09983",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@56957ff",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -130,7 +129,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@ed09983", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@56957ff", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@ed09983",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@56957ff",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",


### PR DESCRIPTION
## What does this PR do?

Bumps the console SDK pin from `ed09983` to `56957ff`.

The main reason for the bump is that `Models.ConsoleVariables` now reports per-provider VCS capabilities:

- `_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION` — providers the console can create repositories on
- `_APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES` — providers that can host public repositories

The earlier SDK breaking changes (Health service removal, `Models.CloudLocale` → `Models.Locale`, the `Embeddings` service split, migration `resourceId` → `databaseId`/`collectionId`, `DatabaseType` additions, usage model changes affecting payments/usage/billing) were already absorbed by the `16.0.0`/`ed09983` bump on main, so this pin change needs no code adjustments — `check`, `lint`, unit tests and the production build all pass unchanged.

Stacked PR: the VCS/Origin feature work building on this lands separately on top of this branch.

## Test plan

- `bun run check` — 0 errors
- `bun run lint` — 0 errors
- `bun run test:unit` — all passing
- `bun run build` — passes

## Related PRs and issues

- Split out of #3168 to keep review manageable

🤖 Generated with [Claude Code](https://claude.com/claude-code)