### PR TITLE
feat: add Origin (Cursor) as a git provider across the console

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,11 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@appwrite/console",
       "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@ed09983",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@56957ff",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",
@@ -130,7 +129,7 @@
 
     "@analytics/type-utils": ["@analytics/type-utils@0.6.4", "", {}, "sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw=="],
 
-    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@ed09983", { "dependencies": { "json-bigint": "1.0.0" } }],
+    "@appwrite.io/console": ["@appwrite.io/console@https://pkg.vc/-/@appwrite/@appwrite.io/console@56957ff", { "dependencies": { "json-bigint": "1.0.0" } }],
 
     "@appwrite.io/pink-icons": ["@appwrite.io/pink-icons@0.25.0", "", {}, "sha512-0O3i2oEuh5mWvjO80i+X6rbzrWLJ1m5wmv2/M3a1p2PyBJsFxN8xQMTEmTn3Wl/D26SsM7SpzbdW6gmfgoVU9Q=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@ai-sdk/svelte": "^1.1.24",
-        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@ed09983",
+        "@appwrite.io/console": "https://pkg.vc/-/@appwrite/@appwrite.io/console@56957ff",
         "@appwrite.io/pink-icons": "0.25.0",
         "@appwrite.io/pink-icons-svelte": "https://pkg.vc/-/@appwrite/@appwrite.io/pink-icons-svelte@bfe7ce3",
         "@appwrite.io/pink-legacy": "^1.0.3",

--- a/src/lib/components/git/IconOrigin.svelte
+++ b/src/lib/components/git/IconOrigin.svelte
@@ -1,0 +1,13 @@
+<!--
+    Origin (Cursor's git hosting) has no icon in @appwrite.io/pink-icons-svelte
+    yet, so this is kept local to the git-connect UI until a proper brand icon
+    lands in the shared icon package. The Cursor cube mark, taken from
+    cursor.com's own vector assets; fill is currentcolor to match the
+    convention of the other Icon* components (e.g. IconGithub) so it drops
+    into <Icon icon={IconOrigin} /> unchanged.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="63 63 386 386">
+    <path
+        fill="currentcolor"
+        d="m410.344 159.545-146.38-84.5111c-4.7-2.7145-10.5-2.7145-15.2 0l-146.373 84.5111c-3.9515 2.282-6.391 6.501-6.391 11.071v170.418c0 4.569 2.4395 8.789 6.391 11.07l146.379 84.512c4.701 2.714 10.501 2.714 15.201 0l146.38-84.512c3.951-2.281 6.391-6.501 6.391-11.07v-170.418c0-4.57-2.44-8.789-6.391-11.071zm-9.195 17.902-141.308 244.751c-.955 1.65-3.477.976-3.477-.934v-160.261c0-3.203-1.711-6.164-4.487-7.772l-138.786-80.127c-1.65-.956-.976-3.478.934-3.478h282.616c4.013 0 6.522 4.35 4.515 7.828h-.007z" />
+</svg>

--- a/src/lib/components/git/connectGit.svelte
+++ b/src/lib/components/git/connectGit.svelte
@@ -8,10 +8,7 @@
     export let callbackState: Record<string, string> = null;
 
     let isVcsEnabled = $regionalConsoleVariables?._APP_VCS_ENABLED === true;
-    // Not in the SDK's generated types yet -- server already returns it.
-    let vcsProviders = ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })
-        ?._APP_VCS_PROVIDERS;
-    let providers = enabledVcsProviders(vcsProviders);
+    let providers = enabledVcsProviders($regionalConsoleVariables?._APP_VCS_PROVIDERS);
 </script>
 
 <Layout.Stack>
@@ -38,7 +35,7 @@
             title="No installation was added to the project yet"
             description="Add an installation to connect repositories">
             <svelte:fragment slot="actions">
-                <Layout.Stack direction="row">
+                <Layout.Stack direction="row" justifyContent="center">
                     {#each providers as provider (provider.id)}
                         <Button
                             secondary

--- a/src/lib/components/git/connectGit.svelte
+++ b/src/lib/components/git/connectGit.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import { isSelfHosted } from '$lib/system';
-    import { connectGitHub, connectGitea } from '$lib/stores/git';
+    import { connectGitHub, connectGitea, connectOrigin } from '$lib/stores/git';
     import Button from '$lib/elements/forms/button.svelte';
     import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Alert, Card, Empty, Icon, Layout } from '@appwrite.io/pink-svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import IconGitea from './IconGitea.svelte';
+    import IconOrigin from './IconOrigin.svelte';
 
     export let callbackState: Record<string, string> = null;
 
@@ -15,6 +16,8 @@
         ?._APP_VCS_PROVIDERS;
     // Gitea is a self-hosted-only feature, not offered on Appwrite Cloud.
     let isGiteaEnabled = isSelfHosted && (vcsProviders?.includes('gitea') ?? false);
+    // Origin (Cursor's git hosting) is a cloud service, so no self-hosted gate.
+    let isOriginEnabled = vcsProviders?.includes('origin') ?? false;
 </script>
 
 <Layout.Stack>
@@ -49,6 +52,15 @@
                         <Icon slot="start" icon={IconGithub} />
                         Connect to GitHub
                     </Button>
+                    {#if isOriginEnabled}
+                        <Button
+                            secondary
+                            href={connectOrigin(callbackState).toString()}
+                            disabled={!isVcsEnabled}>
+                            <Icon slot="start" icon={IconOrigin} />
+                            Connect to Origin
+                        </Button>
+                    {/if}
                     {#if isGiteaEnabled}
                         <Button
                             secondary

--- a/src/lib/components/git/connectGit.svelte
+++ b/src/lib/components/git/connectGit.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
     import { isSelfHosted } from '$lib/system';
-    import { connectGitHub, connectGitea, connectOrigin } from '$lib/stores/git';
+    import { connectVcsProvider, enabledVcsProviders } from '$lib/stores/git';
     import Button from '$lib/elements/forms/button.svelte';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Alert, Card, Empty, Icon, Layout } from '@appwrite.io/pink-svelte';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
-    import IconGitea from './IconGitea.svelte';
-    import IconOrigin from './IconOrigin.svelte';
 
     export let callbackState: Record<string, string> = null;
 
@@ -14,10 +11,7 @@
     // Not in the SDK's generated types yet -- server already returns it.
     let vcsProviders = ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })
         ?._APP_VCS_PROVIDERS;
-    // Gitea is a self-hosted-only feature, not offered on Appwrite Cloud.
-    let isGiteaEnabled = isSelfHosted && (vcsProviders?.includes('gitea') ?? false);
-    // Origin (Cursor's git hosting) is a cloud service, so no self-hosted gate.
-    let isOriginEnabled = vcsProviders?.includes('origin') ?? false;
+    let providers = enabledVcsProviders(vcsProviders);
 </script>
 
 <Layout.Stack>
@@ -45,31 +39,15 @@
             description="Add an installation to connect repositories">
             <svelte:fragment slot="actions">
                 <Layout.Stack direction="row">
-                    <Button
-                        secondary
-                        href={connectGitHub(callbackState).toString()}
-                        disabled={!isVcsEnabled}>
-                        <Icon slot="start" icon={IconGithub} />
-                        Connect to GitHub
-                    </Button>
-                    {#if isOriginEnabled}
+                    {#each providers as provider (provider.id)}
                         <Button
                             secondary
-                            href={connectOrigin(callbackState).toString()}
+                            href={connectVcsProvider(provider.id, callbackState).toString()}
                             disabled={!isVcsEnabled}>
-                            <Icon slot="start" icon={IconOrigin} />
-                            Connect to Origin
+                            <Icon slot="start" icon={provider.icon} />
+                            Connect to {provider.label}
                         </Button>
-                    {/if}
-                    {#if isGiteaEnabled}
-                        <Button
-                            secondary
-                            href={connectGitea(callbackState).toString()}
-                            disabled={!isVcsEnabled}>
-                            <Icon slot="start" icon={IconGitea} />
-                            Connect to Gitea
-                        </Button>
-                    {/if}
+                    {/each}
                 </Layout.Stack>
             </svelte:fragment>
         </Empty>

--- a/src/lib/components/git/connectRepoModal.svelte
+++ b/src/lib/components/git/connectRepoModal.svelte
@@ -12,8 +12,10 @@
     import { addNotification } from '$lib/stores/notifications';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import RepositoryBehaviour from '$lib/components/git/repositoryBehaviour.svelte';
+    import { Alert } from '@appwrite.io/pink-svelte';
     import { page } from '$app/state';
-    import { connectGitHub } from '$lib/stores/git';
+
+    import { connectVcsProvider, getVcsProvider } from '$lib/stores/git';
 
     let {
         show = $bindable(false),
@@ -37,6 +39,17 @@
     let selectedInstallationId = $state('');
     let selectedRepository = $state('');
     let installations = $state({ installations: [], total: 0 });
+    const selectedProvider = $derived(
+        getVcsProvider(
+            installations?.installations?.find((entry) => entry.$id === selectedInstallationId)
+                ?.provider ??
+                $installation?.provider ??
+                'github'
+        )
+    );
+    // Origin's partner API has no repository creation for apps; repositories
+    // made on cursor.com appear in the picker automatically.
+    const creationUnsupported = $derived(selectedProvider.id === 'origin');
     let error = $state('');
 
     onMount(async () => {
@@ -105,6 +118,14 @@
                     bind:repositoryPrivate
                     bind:selectedInstallationId
                     {installations} />
+                {#if creationUnsupported}
+                    <Alert.Inline status="info" title="Create the repository on Cursor">
+                        Origin does not allow apps to create repositories. Create it in the
+                        <Link external href="https://cursor.com/codebase"
+                            >Codebase section on cursor.com</Link>
+                        and it will appear in the repository list here.
+                    </Alert.Inline>
+                {/if}
             {:else}
                 <Repositories
                     bind:selectedRepository
@@ -143,16 +164,33 @@
     <svelte:fragment slot="footer">
         {#if repositoryBehaviour === 'existing'}
             <Layout.Stack>
-                <Link variant="quiet" href={connectGitHub(callbackState).toString()}>
-                    <Layout.Stack direction="row" gap="xs">
-                        Missing a repository? check your permissions <Icon
-                            icon={IconArrowSmRight} />
-                    </Layout.Stack>
-                </Link>
+                {#if $installation?.provider === 'origin'}
+                    <Link variant="quiet" external href="https://cursor.com/codebase/settings/apps">
+                        <Layout.Stack direction="row" gap="xs">
+                            Missing a repository? check your repository access <Icon
+                                icon={IconArrowSmRight} />
+                        </Layout.Stack>
+                    </Link>
+                {:else}
+                    <Link
+                        variant="quiet"
+                        href={connectVcsProvider(
+                            $installation?.provider ?? 'github',
+                            callbackState
+                        ).toString()}>
+                        <Layout.Stack direction="row" gap="xs">
+                            Missing a repository? check your permissions <Icon
+                                icon={IconArrowSmRight} />
+                        </Layout.Stack>
+                    </Link>
+                {/if}
             </Layout.Stack>
         {:else if repositoryBehaviour === 'new'}
             <Button text size="s" on:click={() => (show = false)}>Cancel</Button>
-            <Button size="s" submit disabled={!repositoryName || !$installation?.$id}>
+            <Button
+                size="s"
+                submit
+                disabled={!repositoryName || !$installation?.$id || creationUnsupported}>
                 Create
             </Button>
         {/if}

--- a/src/lib/components/git/connectRepoModal.svelte
+++ b/src/lib/components/git/connectRepoModal.svelte
@@ -12,10 +12,10 @@
     import { addNotification } from '$lib/stores/notifications';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import RepositoryBehaviour from '$lib/components/git/repositoryBehaviour.svelte';
-    import { Alert } from '@appwrite.io/pink-svelte';
     import { page } from '$app/state';
 
-    import { connectVcsProvider, getVcsProvider } from '$lib/stores/git';
+    import { connectVcsProvider, supportsRepositoryCreation } from '$lib/stores/git';
+    import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
 
     let {
         show = $bindable(false),
@@ -39,17 +39,11 @@
     let selectedInstallationId = $state('');
     let selectedRepository = $state('');
     let installations = $state({ installations: [], total: 0 });
-    const selectedProvider = $derived(
-        getVcsProvider(
-            installations?.installations?.find((entry) => entry.$id === selectedInstallationId)
-                ?.provider ??
-                $installation?.provider ??
-                'github'
+    const canCreateRepository = $derived(
+        installations.installations.some((entry) =>
+            supportsRepositoryCreation(entry.provider, $regionalConsoleVariables)
         )
     );
-    // Origin's partner API has no repository creation for apps; repositories
-    // made on cursor.com appear in the picker automatically.
-    const creationUnsupported = $derived(selectedProvider.id === 'origin');
     let error = $state('');
 
     onMount(async () => {
@@ -109,7 +103,7 @@
     </span>
     {#if !!installations?.total}
         <Layout.Stack gap="xl">
-            {#if !onlyExisting}
+            {#if !onlyExisting && canCreateRepository}
                 <RepositoryBehaviour bind:repositoryBehaviour />
             {/if}
             {#if repositoryBehaviour === 'new'}
@@ -118,14 +112,6 @@
                     bind:repositoryPrivate
                     bind:selectedInstallationId
                     {installations} />
-                {#if creationUnsupported}
-                    <Alert.Inline status="info" title="Create the repository on Cursor">
-                        Origin does not allow apps to create repositories. Create it in the
-                        <Link external href="https://cursor.com/codebase"
-                            >Codebase section on cursor.com</Link>
-                        and it will appear in the repository list here.
-                    </Alert.Inline>
-                {/if}
             {:else}
                 <Repositories
                     bind:selectedRepository
@@ -187,10 +173,7 @@
             </Layout.Stack>
         {:else if repositoryBehaviour === 'new'}
             <Button text size="s" on:click={() => (show = false)}>Cancel</Button>
-            <Button
-                size="s"
-                submit
-                disabled={!repositoryName || !$installation?.$id || creationUnsupported}>
+            <Button size="s" submit disabled={!repositoryName || !$installation?.$id}>
                 Create
             </Button>
         {/if}

--- a/src/lib/components/git/deploymentSource.svelte
+++ b/src/lib/components/git/deploymentSource.svelte
@@ -20,6 +20,7 @@
         Typography
     } from '@appwrite.io/pink-svelte';
     import Button from '$lib/elements/forms/button.svelte';
+    import IconOrigin from './IconOrigin.svelte';
 
     let {
         deployment,
@@ -34,6 +35,12 @@
     } = $props();
 
     let repository = $state<Models.ProviderRepository | null>(null);
+
+    // The deployment's server-supplied URLs carry the provider; the model has
+    // no provider field of its own.
+    const isOrigin = $derived(
+        (deployment?.providerRepositoryUrl ?? '').toLowerCase().includes('cursor.com')
+    );
 
     async function loadRepository() {
         if (!resource?.installationId || !resource?.providerRepositoryId || !region || !project) {
@@ -66,7 +73,11 @@
                             toggle(e);
                         }}>
                         <Layout.Stack direction="row" gap="xs" alignItems="center">
-                            <Icon icon={IconGithub} size="s" /> GitHub
+                            {#if isOrigin}
+                                <Icon icon={IconOrigin} size="s" /> Origin
+                            {:else}
+                                <Icon icon={IconGithub} size="s" /> GitHub
+                            {/if}
                         </Layout.Stack>
                     </Link>
                     {#if repository?.authorized === false}
@@ -82,8 +93,10 @@
                                     To enable, add the repository to the installation settings on <Link
                                         variant="muted"
                                         external
-                                        href={`https://github.com/settings/installations/${repository.providerInstallationId}`}>
-                                        GitHub
+                                        href={isOrigin
+                                            ? 'https://cursor.com/codebase/settings/apps'
+                                            : `https://github.com/settings/installations/${repository.providerInstallationId}`}>
+                                        {isOrigin ? 'Origin' : 'GitHub'}
                                     </Link>.
                                 </Typography.Text>
                             </svelte:fragment>
@@ -97,7 +110,7 @@
                 <ActionMenu.Item.Anchor
                     href={deployment.providerRepositoryUrl}
                     external
-                    leadingIcon={IconGithub}>
+                    leadingIcon={isOrigin ? IconOrigin : IconGithub}>
                     {deployment.providerRepositoryOwner}/{deployment.providerRepositoryName}
                 </ActionMenu.Item.Anchor>
                 <ActionMenu.Item.Anchor

--- a/src/lib/components/git/newRepository.svelte
+++ b/src/lib/components/git/newRepository.svelte
@@ -1,14 +1,55 @@
 <script lang="ts">
     import { InputCheckbox, InputSelect, InputText } from '$lib/elements/forms';
     import { installation } from '$lib/stores/vcs';
+    import { supportsPublicRepositories, supportsRepositoryCreation } from '$lib/stores/git';
+    import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import type { Models } from '@appwrite.io/console';
     import { Layout } from '@appwrite.io/pink-svelte';
 
-    export let selectedInstallationId: string;
-    export let installations: Models.InstallationList;
-    export let repositoryName: string;
-    export let repositoryPrivate = true;
-    export let disableFields = false;
+    let {
+        selectedInstallationId = $bindable(),
+        installations,
+        repositoryName = $bindable(),
+        repositoryPrivate = $bindable(true),
+        disableFields = false
+    }: {
+        selectedInstallationId: string;
+        installations: Models.InstallationList;
+        repositoryName: string;
+        repositoryPrivate?: boolean;
+        disableFields?: boolean;
+    } = $props();
+
+    // Only offer organizations whose provider can create repositories.
+    const creatableInstallations = $derived(
+        installations.installations.filter((entry) =>
+            supportsRepositoryCreation(entry.provider, $regionalConsoleVariables)
+        )
+    );
+
+    const supportsPublic = $derived(
+        supportsPublicRepositories(
+            creatableInstallations.find((entry) => entry.$id === selectedInstallationId)?.provider,
+            $regionalConsoleVariables
+        )
+    );
+
+    $effect(() => {
+        if (
+            creatableInstallations.length &&
+            !creatableInstallations.some((entry) => entry.$id === selectedInstallationId)
+        ) {
+            selectedInstallationId = creatableInstallations[0].$id;
+            $installation = creatableInstallations[0];
+        }
+    });
+
+    $effect(() => {
+        // Without public repository support every repository is private.
+        if (!supportsPublic) {
+            repositoryPrivate = true;
+        }
+    });
 </script>
 
 <Layout.Stack gap="xl">
@@ -18,14 +59,14 @@
                 id="installation"
                 label="Git organization"
                 disabled={disableFields}
-                options={installations.installations.map((entry) => {
+                options={creatableInstallations.map((entry) => {
                     return {
                         label: entry.organization,
                         value: entry.$id
                     };
                 })}
                 on:change={() => {
-                    $installation = installations.installations.find(
+                    $installation = creatableInstallations.find(
                         (entry) => entry.$id === selectedInstallationId
                     );
                 }}
@@ -38,9 +79,11 @@
             disabled={disableFields}
             bind:value={repositoryName} />
     </Layout.Stack>
-    <InputCheckbox
-        id="repositoryPrivate"
-        label="Keep repository private"
-        disabled={disableFields}
-        bind:checked={repositoryPrivate} />
+    {#if supportsPublic}
+        <InputCheckbox
+            id="repositoryPrivate"
+            label="Keep repository private"
+            disabled={disableFields}
+            bind:checked={repositoryPrivate} />
+    {/if}
 </Layout.Stack>

--- a/src/lib/components/git/repositories.svelte
+++ b/src/lib/components/git/repositories.svelte
@@ -19,13 +19,19 @@
     import SvgIcon from '../svgIcon.svelte';
     import { Query, VCSDetectionType, type Models } from '@appwrite.io/console';
     import { getFrameworkIcon } from '$lib/stores/sites';
-    import { connectGitHub } from '$lib/stores/git';
+    import { connectVcsProvider, enabledVcsProviders, getVcsProvider } from '$lib/stores/git';
+    import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { addNotification } from '$lib/stores/notifications';
     import { page } from '$app/state';
     import Card from '../card.svelte';
     import SkeletonRepoList from './skeletonRepoList.svelte';
     import { onMount, untrack, onDestroy } from 'svelte';
     import { debounce } from '$lib/helpers/debounce';
+
+    // Not in the SDK's generated types yet -- server already returns it.
+    const vcsProviders = enabledVcsProviders(
+        ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS
+    );
 
     let {
         action = $bindable('select'),
@@ -176,18 +182,27 @@
                             ...installationsMap.map((entry) => {
                                 return {
                                     label: entry.organization,
+                                    leadingIcon: getVcsProvider(entry.provider).icon,
                                     value: entry.$id
                                 };
                             }),
-                            {
-                                label: 'Add installation',
-                                leadingIcon: IconPlus,
-                                value: 'new'
-                            }
+                            ...vcsProviders.map((provider) => {
+                                return {
+                                    label:
+                                        vcsProviders.length > 1
+                                            ? `Add ${provider.label} installation`
+                                            : 'Add installation',
+                                    leadingIcon: IconPlus,
+                                    value: `new-${provider.id}`
+                                };
+                            })
                         ]}
                         on:change={() => {
-                            if (selectedInstallation === 'new') {
-                                window.location.href = connectGitHub(callbackState).toString();
+                            if (selectedInstallation?.startsWith('new-')) {
+                                window.location.href = connectVcsProvider(
+                                    selectedInstallation.slice('new-'.length),
+                                    callbackState
+                                ).toString();
                             }
                             search = '';
                             installation.set(

--- a/src/lib/components/git/repositories.svelte
+++ b/src/lib/components/git/repositories.svelte
@@ -28,10 +28,7 @@
     import { onMount, untrack, onDestroy } from 'svelte';
     import { debounce } from '$lib/helpers/debounce';
 
-    // Not in the SDK's generated types yet -- server already returns it.
-    const vcsProviders = enabledVcsProviders(
-        ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS
-    );
+    const vcsProviders = enabledVcsProviders($regionalConsoleVariables?._APP_VCS_PROVIDERS);
 
     let {
         action = $bindable('select'),

--- a/src/lib/components/git/repositoryCard.svelte
+++ b/src/lib/components/git/repositoryCard.svelte
@@ -16,6 +16,8 @@
 
     // ProviderRepository carries no provider, so read it off the owning installation.
     $: provider = $installation?.provider ?? 'github';
+    // '' when the provider's host is unknown client-side (e.g. Gitea).
+    $: organizationUrl = getProviderOrganizationUrl(provider, repository.organization);
 </script>
 
 <Card.Base padding="xs" radius="s" variant="secondary">
@@ -46,13 +48,15 @@
                     <Typography.Caption variant="400" color="--fgcolor-neutral-tertiary">
                         •
                     </Typography.Caption>
-                    <Link
-                        size="s"
-                        variant="muted"
-                        external
-                        href={getProviderOrganizationUrl(provider, repository.organization)}>
-                        <span class="repository-copy">{repository.organization}</span>
-                    </Link>
+                    {#if organizationUrl}
+                        <Link size="s" variant="muted" external href={organizationUrl}>
+                            <span class="repository-copy">{repository.organization}</span>
+                        </Link>
+                    {:else}
+                        <Typography.Caption variant="400" color="--fgcolor-neutral-tertiary">
+                            <span class="repository-copy">{repository.organization}</span>
+                        </Typography.Caption>
+                    {/if}
                 </Layout.Stack>
             </Layout.Stack>
         </Layout.Stack>

--- a/src/lib/components/git/repositoryCard.svelte
+++ b/src/lib/components/git/repositoryCard.svelte
@@ -6,10 +6,16 @@
     import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Card, Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
     import { createEventDispatcher } from 'svelte';
+    import { installation } from '$lib/stores/vcs';
+    import { getProviderOrganizationUrl } from '$lib/stores/git';
+    import IconOrigin from './IconOrigin.svelte';
 
     export let repository: Models.ProviderRepository;
 
     const dispatch = createEventDispatcher();
+
+    // ProviderRepository carries no provider, so read it off the owning installation.
+    $: provider = $installation?.provider ?? 'github';
 </script>
 
 <Card.Base padding="xs" radius="s" variant="secondary">
@@ -24,7 +30,9 @@
             alignItems="flex-start"
             gap="s"
             style="min-width: 0; flex: 1 1 16rem;">
-            <Icon icon={IconGithub} color="--fgcolor-neutral-primary" />
+            <Icon
+                icon={provider === 'origin' ? IconOrigin : IconGithub}
+                color="--fgcolor-neutral-primary" />
             <Layout.Stack gap="xxxs" style="min-width: 0; flex: 1 1 auto;">
                 <Typography.Text variant="m-400" color="--fgcolor-neutral-primary">
                     <span class="repository-copy">{repository.name}</span>
@@ -42,7 +50,7 @@
                         size="s"
                         variant="muted"
                         external
-                        href={`https://github.com/${repository.organization}`}>
+                        href={getProviderOrganizationUrl(provider, repository.organization)}>
                         <span class="repository-copy">{repository.organization}</span>
                     </Link>
                 </Layout.Stack>

--- a/src/lib/stores/git.ts
+++ b/src/lib/stores/git.ts
@@ -1,4 +1,5 @@
 import { page } from '$app/state';
+import type { Models } from '@appwrite.io/console';
 import type { ComponentType } from 'svelte';
 import { IconGithub } from '@appwrite.io/pink-icons-svelte';
 import IconGitea from '$lib/components/git/IconGitea.svelte';
@@ -42,7 +43,7 @@ export const VCS_PROVIDERS: Record<VcsProviderId, VcsProviderMeta> = {
         label: 'Origin',
         icon: IconOrigin as unknown as ComponentType,
         // Origin repositories are browsed in the Codebase section of cursor.com
-        organizationUrl: (organization) => `https://cursor.com/codebase/${organization}`,
+        organizationUrl: () => 'https://cursor.com/codebase',
         installationSettingsUrl: () => 'https://cursor.com/codebase/settings/apps'
     },
     gitea: {
@@ -72,6 +73,29 @@ export function enabledVcsProviders(vcsProviders: string[] | undefined): VcsProv
             ((vcsProviders?.includes(provider.id) ?? false) &&
                 (!provider.selfHostedOnly || isSelfHosted))
     );
+}
+
+/**
+ * Whether the console can create repositories on the provider. Servers that
+ * predate _APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION omit the list; keep the
+ * console's historical behavior (creation offered) for them.
+ */
+export function supportsRepositoryCreation(
+    provider: string,
+    variables: Models.ConsoleVariables
+): boolean {
+    return variables?._APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION?.includes(provider) ?? true;
+}
+
+/**
+ * Whether the provider can host public repositories. When it cannot, every
+ * repository is private and the public/private choice is meaningless.
+ */
+export function supportsPublicRepositories(
+    provider: string,
+    variables: Models.ConsoleVariables
+): boolean {
+    return variables?._APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES?.includes(provider) ?? true;
 }
 
 export function connectVcsProvider(provider: string, callbackState: Record<string, string> = null) {

--- a/src/lib/stores/git.ts
+++ b/src/lib/stores/git.ts
@@ -1,7 +1,7 @@
 import { page } from '$app/state';
 import { getApiEndpoint } from './sdk';
 
-function connectVcsProvider(provider: string, callbackState: Record<string, string> = null) {
+export function connectVcsProvider(provider: string, callbackState: Record<string, string> = null) {
     const redirect = new URL(page.url);
     if (callbackState) {
         Object.keys(callbackState).forEach((key) => {
@@ -22,6 +22,30 @@ export function connectGitHub(callbackState: Record<string, string> = null) {
 
 export function connectGitea(callbackState: Record<string, string> = null) {
     return connectVcsProvider('gitea', callbackState);
+}
+
+export function connectOrigin(callbackState: Record<string, string> = null) {
+    return connectVcsProvider('origin', callbackState);
+}
+
+/**
+ * Browser URL of an owner/organization on the provider. Origin repositories
+ * are browsed in the Codebase section of cursor.com.
+ */
+export function getProviderOrganizationUrl(provider: string, organization: string): string {
+    switch (provider) {
+        case 'origin':
+            return `https://cursor.com/codebase/${organization}`;
+        default:
+            return `https://github.com/${organization}`;
+    }
+}
+
+/**
+ * Browser URL of a repository on the provider.
+ */
+export function getProviderRepositoryUrl(provider: string, organization: string, name: string) {
+    return `${getProviderOrganizationUrl(provider, organization)}/${name}`;
 }
 
 export function deploymentStatusConverter(status: string) {

--- a/src/lib/stores/git.ts
+++ b/src/lib/stores/git.ts
@@ -1,5 +1,78 @@
 import { page } from '$app/state';
+import type { ComponentType } from 'svelte';
+import { IconGithub } from '@appwrite.io/pink-icons-svelte';
+import IconGitea from '$lib/components/git/IconGitea.svelte';
+import IconOrigin from '$lib/components/git/IconOrigin.svelte';
+import { isSelfHosted } from '$lib/system';
 import { getApiEndpoint } from './sdk';
+
+export type VcsProviderId = 'github' | 'origin' | 'gitea';
+
+export interface VcsProviderMeta {
+    id: VcsProviderId;
+    label: string;
+    icon: ComponentType;
+    /** Web URL of an owner/organization on the provider, or '' when the host is not knowable client-side. */
+    organizationUrl: (organization: string) => string;
+    /** Where the user manages the installation's repository access, or null when the provider has no such page. */
+    installationSettingsUrl: (providerInstallationId: string) => string | null;
+    /** GitHub predates the _APP_VCS_PROVIDERS variable, so it stays on unconditionally. */
+    alwaysEnabled?: boolean;
+    /** Gitea is a self-hosted-only feature, not offered on Appwrite Cloud. */
+    selfHostedOnly?: boolean;
+}
+
+/**
+ * Single source of truth for the console's git providers - icons, labels,
+ * provider URLs and the authorize redirects. Key order is display order:
+ * GitHub first, Origin second, then the rest.
+ */
+export const VCS_PROVIDERS: Record<VcsProviderId, VcsProviderMeta> = {
+    github: {
+        id: 'github',
+        label: 'GitHub',
+        icon: IconGithub,
+        organizationUrl: (organization) => `https://github.com/${organization}`,
+        installationSettingsUrl: (providerInstallationId) =>
+            `https://github.com/settings/installations/${providerInstallationId}`,
+        alwaysEnabled: true
+    },
+    origin: {
+        id: 'origin',
+        label: 'Origin',
+        icon: IconOrigin as unknown as ComponentType,
+        // Origin repositories are browsed in the Codebase section of cursor.com
+        organizationUrl: (organization) => `https://cursor.com/codebase/${organization}`,
+        installationSettingsUrl: () => 'https://cursor.com/codebase/settings/apps'
+    },
+    gitea: {
+        id: 'gitea',
+        label: 'Gitea',
+        icon: IconGitea as unknown as ComponentType,
+        // The Gitea host is per-deployment server configuration the client does not know
+        organizationUrl: () => '',
+        installationSettingsUrl: () => null,
+        selfHostedOnly: true
+    }
+};
+
+/** Provider metadata with a GitHub fallback for unknown ids (cosmetic use only). */
+export function getVcsProvider(provider?: string): VcsProviderMeta {
+    return VCS_PROVIDERS[provider as VcsProviderId] ?? VCS_PROVIDERS.github;
+}
+
+/**
+ * Providers the connect UI should offer, honoring the server's
+ * _APP_VCS_PROVIDERS list and each provider's own gates.
+ */
+export function enabledVcsProviders(vcsProviders: string[] | undefined): VcsProviderMeta[] {
+    return Object.values(VCS_PROVIDERS).filter(
+        (provider) =>
+            provider.alwaysEnabled ||
+            ((vcsProviders?.includes(provider.id) ?? false) &&
+                (!provider.selfHostedOnly || isSelfHosted))
+    );
+}
 
 export function connectVcsProvider(provider: string, callbackState: Record<string, string> = null) {
     const redirect = new URL(page.url);
@@ -29,16 +102,11 @@ export function connectOrigin(callbackState: Record<string, string> = null) {
 }
 
 /**
- * Browser URL of an owner/organization on the provider. Origin repositories
- * are browsed in the Codebase section of cursor.com.
+ * Browser URL of an owner/organization on the provider. Unknown providers
+ * fall back to GitHub, matching the console's historical behavior.
  */
 export function getProviderOrganizationUrl(provider: string, organization: string): string {
-    switch (provider) {
-        case 'origin':
-            return `https://cursor.com/codebase/${organization}`;
-        default:
-            return `https://github.com/${organization}`;
-    }
+    return getVcsProvider(provider).organizationUrl(organization);
 }
 
 /**

--- a/src/lib/stores/git.ts
+++ b/src/lib/stores/git.ts
@@ -134,10 +134,13 @@ export function getProviderOrganizationUrl(provider: string, organization: strin
 }
 
 /**
- * Browser URL of a repository on the provider.
+ * Browser URL of a repository on the provider, or '' when the provider's host
+ * is not knowable client-side. Callers must not render a link for ''; an empty
+ * or relative href would resolve against the console's own origin.
  */
 export function getProviderRepositoryUrl(provider: string, organization: string, name: string) {
-    return `${getProviderOrganizationUrl(provider, organization)}/${name}`;
+    const organizationUrl = getProviderOrganizationUrl(provider, organization);
+    return organizationUrl ? `${organizationUrl}/${name}` : '';
 }
 
 export function deploymentStatusConverter(status: string) {

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/(components)/aside.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/(components)/aside.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+    import { installation } from '$lib/stores/vcs';
+    import { getVcsProvider } from '$lib/stores/git';
     import { Card, SvgIcon } from '$lib/components';
     import { Icon, Layout, Skeleton, Typography } from '@appwrite.io/pink-svelte';
-    import { IconGithub, IconGitBranch } from '@appwrite.io/pink-icons-svelte';
+    import { IconGitBranch } from '@appwrite.io/pink-icons-svelte';
     import type { Models, Runtime } from '@appwrite.io/console';
 
     export let runtime: Runtime;
@@ -42,7 +44,10 @@
                     <Layout.Stack gap="xxxs">
                         <Typography.Caption variant="400">Git repository</Typography.Caption>
                         <Layout.Stack gap="xxs" alignItems="center" direction="row">
-                            <Icon size="s" icon={IconGithub} color="--fgcolor-neutral-primary" />
+                            <Icon
+                                size="s"
+                                icon={getVcsProvider($installation?.provider).icon}
+                                color="--fgcolor-neutral-primary" />
                             <Typography.Text variant="m-500" color="--fgcolor-neutral-primary">
                                 {repositoryName}
                             </Typography.Text>

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/+page.svelte
@@ -111,7 +111,7 @@
                                 }}
                                 {connect} />
                         </Layout.Stack>
-                        {#if $installation}
+                        {#if $installation && getVcsProvider($installation.provider).installationSettingsUrl($installation.providerInstallationId)}
                             <Layout.Stack gap="l">
                                 <Divider />
                                 <Link

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { SvgIcon } from '$lib/components';
     import { page } from '$app/state';
+    import { getVcsProvider } from '$lib/stores/git';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import type { Models } from '@appwrite.io/console';
     import { isSelfHosted } from '$lib/system';
@@ -116,7 +117,11 @@
                                 <Link
                                     variant="quiet"
                                     external
-                                    href={`https://github.com/settings/installations/${$installation.providerInstallationId}`}>
+                                    href={getVcsProvider(
+                                        $installation.provider
+                                    ).installationSettingsUrl(
+                                        $installation.providerInstallationId
+                                    )}>
                                     <Layout.Stack direction="row" gap="xs">
                                         Missing a repository? check your permissions <Icon
                                             icon={IconArrowSmRight} />

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/repoCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/repository-[repository]/repoCard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+    import { installation } from '$lib/stores/vcs';
+    import { getVcsProvider } from '$lib/stores/git';
     import { base } from '$app/paths';
     import { page } from '$app/state';
     import { Button } from '$lib/elements/forms';
     import type { Models } from '@appwrite.io/console';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Card, Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
     export let repository: Models.ProviderRepository;
@@ -12,7 +13,9 @@
 <Card.Base radius="s" padding="s">
     <Layout.Stack direction="row" justifyContent="space-between" alignItems="center" gap="xs">
         <Layout.Stack direction="row" alignItems="center" gap="xs">
-            <Icon icon={IconGithub} color="--fgcolor-neutral-primary" />
+            <Icon
+                icon={getVcsProvider($installation?.provider).icon}
+                color="--fgcolor-neutral-primary" />
             <Typography.Text variation="m-500" color="--fgcolor-neutral-primary">
                 {repository?.organization}/{repository?.name}
             </Typography.Text>

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
@@ -10,7 +10,6 @@
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
     import { Fieldset, Layout, Icon, Divider, Empty, Typography } from '@appwrite.io/pink-svelte';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { onMount, untrack } from 'svelte';
     import { writable } from 'svelte/store';
     import ProductionBranch from '$lib/components/git/productionBranchFieldset.svelte';
@@ -32,7 +31,7 @@
     import Aside from '../(components)/aside.svelte';
     import { iconPath } from '$lib/stores/app';
     import Permissions from './permissions.svelte';
-    import { connectGitHub } from '$lib/stores/git';
+    import { connectVcsProvider, enabledVcsProviders } from '$lib/stores/git';
     import RepoCard from './repoCard.svelte';
     import { Dependencies } from '$lib/constants';
     import { getIconFromRuntime } from '$lib/stores/runtimes';
@@ -358,10 +357,17 @@
                                 title="Connect Git repository"
                                 description="Create and deploy a Site with a connected git repository.">
                                 <svelte:fragment slot="actions">
-                                    <Button secondary href={connectGitHub().toString()} size="s">
-                                        <Icon icon={IconGithub} slot="start" />
-                                        Connect to GitHub
-                                    </Button>
+                                    <Layout.Stack direction="row">
+                                        {#each enabledVcsProviders(($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS) as provider (provider.id)}
+                                            <Button
+                                                secondary
+                                                href={connectVcsProvider(provider.id).toString()}
+                                                size="s">
+                                                <Icon icon={provider.icon} slot="start" />
+                                                Connect to {provider.label}
+                                            </Button>
+                                        {/each}
+                                    </Layout.Stack>
                                 </svelte:fragment>
                             </Empty>
                         </Card>

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/+page.svelte
@@ -31,7 +31,11 @@
     import Aside from '../(components)/aside.svelte';
     import { iconPath } from '$lib/stores/app';
     import Permissions from './permissions.svelte';
-    import { connectVcsProvider, enabledVcsProviders } from '$lib/stores/git';
+    import {
+        connectVcsProvider,
+        enabledVcsProviders,
+        supportsRepositoryCreation
+    } from '$lib/stores/git';
     import RepoCard from './repoCard.svelte';
     import { Dependencies } from '$lib/constants';
     import { getIconFromRuntime } from '$lib/stores/runtimes';
@@ -40,6 +44,12 @@
     import { validateVariables } from '$lib/helpers/variables';
 
     let { data }: { data: PageData } = $props();
+
+    const canCreateRepository = $derived(
+        data.installations.installations.some((entry) =>
+            supportsRepositoryCreation(entry.provider, $regionalConsoleVariables)
+        )
+    );
 
     const specificationOptions = $derived(
         (data.specificationsList?.specifications ?? []).map((size) => ({
@@ -240,6 +250,12 @@
     }
 
     $effect(() => {
+        if (!canCreateRepository) {
+            repositoryBehaviour = 'existing';
+        }
+    });
+
+    $effect(() => {
         if (repositoryBehaviour === 'new') {
             selectedInstallationId ??= $installation?.$id;
             repositoryName ??= name.split(' ').join('-').toLowerCase();
@@ -312,7 +328,9 @@
                     {#if !!data?.installations?.total}
                         <Fieldset legend="Git repository">
                             <Layout.Stack gap="xl">
-                                <RepositoryBehaviour bind:repositoryBehaviour />
+                                {#if canCreateRepository}
+                                    <RepositoryBehaviour bind:repositoryBehaviour />
+                                {/if}
                                 {#if repositoryBehaviour === 'new'}
                                     <NewRepository
                                         bind:selectedInstallationId
@@ -357,8 +375,8 @@
                                 title="Connect Git repository"
                                 description="Create and deploy a Site with a connected git repository.">
                                 <svelte:fragment slot="actions">
-                                    <Layout.Stack direction="row">
-                                        {#each enabledVcsProviders(($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS) as provider (provider.id)}
+                                    <Layout.Stack direction="row" justifyContent="center">
+                                        {#each enabledVcsProviders($regionalConsoleVariables?._APP_VCS_PROVIDERS) as provider (provider.id)}
                                             <Button
                                                 secondary
                                                 href={connectVcsProvider(provider.id).toString()}

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/repoCard.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/template-[template]/repoCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+    import { getVcsProvider } from '$lib/stores/git';
     import { Button } from '$lib/elements/forms';
-    import { repository } from '$lib/stores/vcs';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
+    import { repository, installation } from '$lib/stores/vcs';
 
     import { Card, Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
 
@@ -11,7 +11,7 @@
 <Card.Base padding="s" radius="s">
     <Layout.Stack direction="row" justifyContent="space-between" alignItems="center" gap="xs">
         <Layout.Stack direction="row" alignItems="center" gap="s">
-            <Icon size="s" icon={IconGithub} />
+            <Icon size="s" icon={getVcsProvider($installation?.provider).icon} />
             <Typography.Text variant="m-400" color="--fgcolor-neutral-primary">
                 {$repository.organization}/{$repository.name}
             </Typography.Text>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
@@ -9,15 +9,13 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
-    import { getProviderRepositoryUrl } from '$lib/stores/git';
-    import IconOrigin from '$lib/components/git/IconOrigin.svelte';
+    import { getProviderRepositoryUrl, getVcsProvider } from '$lib/stores/git';
     import {
         Runtime,
         VCSReferenceType,
         type Models,
         type ProjectKeyScopes
     } from '@appwrite.io/console';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Skeleton, Typography } from '@appwrite.io/pink-svelte';
     import { func } from '../store';
     import { page } from '$app/state';
@@ -144,7 +142,7 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s">
-                        <Icon size="s" icon={IconGithub} />
+                        <Icon size="s" icon={getVcsProvider($installation?.provider).icon} />
                         <Skeleton variant="line" width={100} height={19.6} />
                     </Layout.Stack>
                 </Layout.Stack>
@@ -161,8 +159,7 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s" inline>
-                        <Icon
-                            icon={$installation?.provider === 'origin' ? IconOrigin : IconGithub} />
+                        <Icon icon={getVcsProvider($installation?.provider).icon} />
                         <Link
                             external
                             href={getProviderRepositoryUrl(

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
@@ -30,6 +30,14 @@
     let activate = true;
     let error = '';
 
+    // '' when the provider's host is unknown client-side (e.g. Gitea), in which
+    // case the repository is shown as plain text rather than a broken link.
+    $: repositoryUrl = getProviderRepositoryUrl(
+        $installation?.provider ?? 'github',
+        $repository?.organization,
+        $repository?.name
+    );
+
     async function loadInstallations() {
         if (!$func?.installationId && installations?.total > 0) {
             installation.set(installations.installations[0]);
@@ -160,17 +168,17 @@
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s" inline>
                         <Icon icon={getVcsProvider($installation?.provider).icon} />
-                        <Link
-                            external
-                            href={getProviderRepositoryUrl(
-                                $installation?.provider ?? 'github',
-                                $repository?.organization,
-                                $repository?.name
-                            )}>
-                            <Layout.Stack direction="row" alignItems="center" gap="s" inline>
+                        {#if repositoryUrl}
+                            <Link external href={repositoryUrl}>
+                                <Layout.Stack direction="row" alignItems="center" gap="s" inline>
+                                    {$repository?.organization}/{$repository?.name}
+                                </Layout.Stack>
+                            </Link>
+                        {:else}
+                            <Typography.Text>
                                 {$repository?.organization}/{$repository?.name}
-                            </Layout.Stack>
-                        </Link>
+                            </Typography.Text>
+                        {/if}
                     </Layout.Stack>
                     <Typography.Caption variant="400" color="--fgcolor-neutral-tertiary">
                         Last updated {timeFromNow($repository?.pushedAt)}

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createGit.svelte
@@ -9,6 +9,8 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
+    import { getProviderRepositoryUrl } from '$lib/stores/git';
+    import IconOrigin from '$lib/components/git/IconOrigin.svelte';
     import {
         Runtime,
         VCSReferenceType,
@@ -159,10 +161,15 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s" inline>
-                        <Icon icon={IconGithub} />
+                        <Icon
+                            icon={$installation?.provider === 'origin' ? IconOrigin : IconGithub} />
                         <Link
                             external
-                            href={`https://github.com/${$repository?.organization}/${$repository?.name}`}>
+                            href={getProviderRepositoryUrl(
+                                $installation?.provider ?? 'github',
+                                $repository?.organization,
+                                $repository?.name
+                            )}>
                             <Layout.Stack direction="row" alignItems="center" gap="s" inline>
                                 {$repository?.organization}/{$repository?.name}
                             </Layout.Stack>

--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -43,10 +43,7 @@
     let selectedInstallation: Models.Installation;
     const isVcsEnabled = $regionalConsoleVariables?._APP_VCS_ENABLED === true;
 
-    // Not in the SDK's generated types yet -- server already returns it.
-    const providers = enabledVcsProviders(
-        ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS
-    );
+    const providers = enabledVcsProviders($regionalConsoleVariables?._APP_VCS_PROVIDERS);
 
     function getInstallationLink(installation: Models.Installation) {
         return (
@@ -213,7 +210,7 @@
                     title="No installation was added to the project yet"
                     description="Add an installation to connect repositories">
                     <svelte:fragment slot="actions">
-                        <Layout.Stack direction="row">
+                        <Layout.Stack direction="row" justifyContent="center">
                             {#each providers as provider (provider.id)}
                                 <FormButton
                                     secondary

--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -21,10 +21,12 @@
     import { Link as PinkLink } from '@appwrite.io/pink-svelte';
     import {
         IconExternalLink,
+        IconGit,
         IconGithub,
         IconPlus,
         IconXCircle
     } from '@appwrite.io/pink-icons-svelte';
+    import IconOrigin from '$lib/components/git/IconOrigin.svelte';
     import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import type { ComponentType } from 'svelte';
@@ -46,6 +48,8 @@
         switch (installation.provider) {
             case 'github':
                 return `https://github.com/${installation.organization}`;
+            case 'origin':
+                return `https://cursor.com/codebase/${installation.organization}`;
             default:
                 return '';
         }
@@ -55,13 +59,17 @@
         switch (provider) {
             case 'github':
                 return IconGithub;
+            case 'origin':
+                return IconOrigin as unknown as ComponentType;
+            default:
+                return IconGit;
         }
     }
 
-    function configureGitHub() {
+    function configureProvider(provider: string = 'github') {
         const redirect = new URL(page.url);
         redirect.searchParams.append('alert', 'installation-updated');
-        const target = new URL(`${getApiEndpoint(page.params.region)}/vcs/github/authorize`);
+        const target = new URL(`${getApiEndpoint(page.params.region)}/vcs/${provider}/authorize`);
         target.searchParams.set('project', page.params.project);
         target.searchParams.set('success', redirect.toString());
         target.searchParams.set('failure', redirect.toString());
@@ -89,7 +97,7 @@
                     <FormButton
                         secondary
                         disabled={!$canWriteProjects}
-                        href={configureGitHub()}
+                        href={configureProvider()}
                         on:click={() => {
                             trackEvent(Click.SettingsInstallProviderClick);
                         }}>
@@ -140,7 +148,7 @@
                                     </button>
                                     <ActionMenu.Root slot="tooltip">
                                         <ActionMenu.Item.Anchor
-                                            href={configureGitHub()}
+                                            href={configureProvider(installation.provider)}
                                             trailingIcon={IconExternalLink}
                                             on:click={() => (showInstallationDropdown[i] = false)}>
                                             Configure
@@ -192,7 +200,7 @@
                         <FormButton
                             secondary
                             disabled={!$canWriteProjects}
-                            href={configureGitHub()}
+                            href={configureProvider()}
                             external>
                             <Icon icon={IconGithub} size="s" slot="start" />
                             Connect to GitHub

--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -22,11 +22,10 @@
     import {
         IconExternalLink,
         IconGit,
-        IconGithub,
         IconPlus,
         IconXCircle
     } from '@appwrite.io/pink-icons-svelte';
-    import IconOrigin from '$lib/components/git/IconOrigin.svelte';
+    import { enabledVcsProviders, VCS_PROVIDERS } from '$lib/stores/git';
     import DualTimeView from '$lib/components/dualTimeView.svelte';
     import { Click, trackEvent } from '$lib/actions/analytics';
     import type { ComponentType } from 'svelte';
@@ -44,26 +43,19 @@
     let selectedInstallation: Models.Installation;
     const isVcsEnabled = $regionalConsoleVariables?._APP_VCS_ENABLED === true;
 
+    // Not in the SDK's generated types yet -- server already returns it.
+    const providers = enabledVcsProviders(
+        ($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS
+    );
+
     function getInstallationLink(installation: Models.Installation) {
-        switch (installation.provider) {
-            case 'github':
-                return `https://github.com/${installation.organization}`;
-            case 'origin':
-                return `https://cursor.com/codebase/${installation.organization}`;
-            default:
-                return '';
-        }
+        return (
+            VCS_PROVIDERS[installation.provider]?.organizationUrl(installation.organization) ?? ''
+        );
     }
 
     function getProviderIcon(provider: string): ComponentType {
-        switch (provider) {
-            case 'github':
-                return IconGithub;
-            case 'origin':
-                return IconOrigin as unknown as ComponentType;
-            default:
-                return IconGit;
-        }
+        return VCS_PROVIDERS[provider]?.icon ?? IconGit;
     }
 
     function configureProvider(provider: string = 'github') {
@@ -94,16 +86,40 @@
         {#if total > 0}
             <Layout.Stack gap="l">
                 <div class="installations-action-row">
-                    <FormButton
-                        secondary
-                        disabled={!$canWriteProjects}
-                        href={configureProvider()}
-                        on:click={() => {
-                            trackEvent(Click.SettingsInstallProviderClick);
-                        }}>
-                        <Icon icon={IconPlus} slot="start" size="s" />
-                        Add installation
-                    </FormButton>
+                    {#if providers.length <= 1}
+                        <FormButton
+                            secondary
+                            disabled={!$canWriteProjects}
+                            href={configureProvider(providers[0]?.id)}
+                            on:click={() => {
+                                trackEvent(Click.SettingsInstallProviderClick);
+                            }}>
+                            <Icon icon={IconPlus} slot="start" size="s" />
+                            Add installation
+                        </FormButton>
+                    {:else}
+                        <Popover let:toggle padding="none" placement="bottom-start">
+                            <FormButton
+                                secondary
+                                disabled={!$canWriteProjects}
+                                on:click={(event) => {
+                                    trackEvent(Click.SettingsInstallProviderClick);
+                                    toggle(event);
+                                }}>
+                                <Icon icon={IconPlus} slot="start" size="s" />
+                                Add installation
+                            </FormButton>
+                            <ActionMenu.Root slot="tooltip">
+                                {#each providers as provider (provider.id)}
+                                    <ActionMenu.Item.Anchor
+                                        href={configureProvider(provider.id)}
+                                        leadingIcon={provider.icon}>
+                                        Connect to {provider.label}
+                                    </ActionMenu.Item.Anchor>
+                                {/each}
+                            </ActionMenu.Root>
+                        </Popover>
+                    {/if}
                 </div>
 
                 <Table.Root
@@ -197,14 +213,18 @@
                     title="No installation was added to the project yet"
                     description="Add an installation to connect repositories">
                     <svelte:fragment slot="actions">
-                        <FormButton
-                            secondary
-                            disabled={!$canWriteProjects}
-                            href={configureProvider()}
-                            external>
-                            <Icon icon={IconGithub} size="s" slot="start" />
-                            Connect to GitHub
-                        </FormButton>
+                        <Layout.Stack direction="row">
+                            {#each providers as provider (provider.id)}
+                                <FormButton
+                                    secondary
+                                    disabled={!$canWriteProjects}
+                                    href={configureProvider(provider.id)}
+                                    external>
+                                    <Icon icon={provider.icon} size="s" slot="start" />
+                                    Connect to {provider.label}
+                                </FormButton>
+                            {/each}
+                        </Layout.Stack>
                     </svelte:fragment>
                 </Empty>
             </Card.Base>

--- a/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
+++ b/src/routes/(console)/project-[region]-[project]/settings/updateInstallations.svelte
@@ -16,7 +16,8 @@
         Layout,
         Popover,
         Table,
-        Button
+        Button,
+        Typography
     } from '@appwrite.io/pink-svelte';
     import { Link as PinkLink } from '@appwrite.io/pink-svelte';
     import {
@@ -140,9 +141,18 @@
                                             icon={getProviderIcon(installation.provider)}
                                             size="s" />
                                     </Avatar>
-                                    <Link href={getInstallationLink(installation)} external icon>
-                                        {installation.organization}
-                                    </Link>
+                                    {#if getInstallationLink(installation)}
+                                        <Link
+                                            href={getInstallationLink(installation)}
+                                            external
+                                            icon>
+                                            {installation.organization}
+                                        </Link>
+                                    {:else}
+                                        <Typography.Text>
+                                            {installation.organization}
+                                        </Typography.Text>
+                                    {/if}
                                 </Layout.Stack>
                             </Table.Cell>
                             <Table.Cell column="updated" {root}>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/aside.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/aside.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+    import { installation } from '$lib/stores/vcs';
+    import { getVcsProvider } from '$lib/stores/git';
     import { Card, SvgIcon, Trim } from '$lib/components';
     import { Icon, Layout, Typography } from '@appwrite.io/pink-svelte';
-    import { IconGithub, IconGitBranch } from '@appwrite.io/pink-icons-svelte';
+    import { IconGitBranch } from '@appwrite.io/pink-icons-svelte';
     import type { Models } from '@appwrite.io/console';
     import { getFrameworkIcon } from '$lib/stores/sites';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
@@ -22,7 +24,10 @@
                 <Layout.Stack gap="xxxs">
                     <Typography.Caption variant="400">Git repository</Typography.Caption>
                     <Layout.Stack gap="xxs" alignItems="center" direction="row">
-                        <Icon size="s" icon={IconGithub} color="--fgcolor-neutral-primary" />
+                        <Icon
+                            size="s"
+                            icon={getVcsProvider($installation?.provider).icon}
+                            color="--fgcolor-neutral-primary" />
                         <Typography.Text variant="m-500" color="--fgcolor-neutral-primary">
                             {repositoryName}
                         </Typography.Text>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { getVcsProvider } from '$lib/stores/git';
     import { goto } from '$app/navigation';
     import { page } from '$app/state';
     import { Click, trackEvent } from '$lib/actions/analytics.js';
@@ -70,9 +71,10 @@
                             Missing a repository?
                         </Typography.Text>
                         <Typography.Text variation="m-400">
-                            Make sure Appwrite has access to your GitHub repositories. If you chose
-                            specific repos, you may need to update your permissions to include the
-                            missing one.
+                            Make sure Appwrite has access to your {getVcsProvider(
+                                $installation?.provider
+                            ).label} repositories. If you chose specific repos, you may need to update
+                            your permissions to include the missing one.
                         </Typography.Text>
                     </Layout.Stack>
                     <Layout.Stack gap="s" direction="row">
@@ -80,11 +82,13 @@
                             href="https://appwrite.io/docs/products/sites/deploy-from-git"
                             external
                             secondary>Docs</Button>
-                        {#if $installation}
+                        {#if $installation && getVcsProvider($installation.provider).installationSettingsUrl($installation.providerInstallationId)}
                             <Button
-                                href={`https://github.com/settings/installations/${$installation.providerInstallationId}`}
+                                href={getVcsProvider(
+                                    $installation.provider
+                                ).installationSettingsUrl($installation.providerInstallationId)}
                                 external
-                                text>Go to GitHub</Button>
+                                text>Go to {getVcsProvider($installation.provider).label}</Button>
                         {/if}
                     </Layout.Stack>
                 {/if}

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/repositories/repository-[repository]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { getVcsProvider } from '$lib/stores/git';
     import { goto } from '$app/navigation';
     import { base } from '$app/paths';
     import { page } from '$app/state';
@@ -10,7 +11,6 @@
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
     import { Layout, Icon, Typography } from '@appwrite.io/pink-svelte';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { writable } from 'svelte/store';
     import Details from '../../details.svelte';
     import ProductionBranch from '$lib/components/git/productionBranchFieldset.svelte';
@@ -206,7 +206,9 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="xs">
-                        <Icon icon={IconGithub} color="--fgcolor-neutral-primary" />
+                        <Icon
+                            icon={getVcsProvider($installation?.provider).icon}
+                            color="--fgcolor-neutral-primary" />
                         <Typography.Text variation="m-500" color="--fgcolor-neutral-primary">
                             {data.repository?.organization}/{data.repository?.name}
                         </Typography.Text>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
@@ -41,7 +41,7 @@
     } from '$lib/components/git';
     import Domain from '../../domain.svelte';
     import { app, iconPath } from '$lib/stores/app';
-    import { connectGitHub } from '$lib/stores/git';
+    import { connectVcsProvider, enabledVcsProviders } from '$lib/stores/git';
     import { getFrameworkIcon } from '$lib/stores/sites';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { getTemplateSourceUrl } from '$lib/helpers/templateSource';
@@ -325,10 +325,17 @@
                                 title="Connect Git repository"
                                 description="Create and deploy a Site with a connected git repository.">
                                 <svelte:fragment slot="actions">
-                                    <Button secondary href={connectGitHub().toString()} size="s">
-                                        <Icon icon={IconGithub} slot="start" />
-                                        Connect to GitHub
-                                    </Button>
+                                    <Layout.Stack direction="row">
+                                        {#each enabledVcsProviders(($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS) as provider (provider.id)}
+                                            <Button
+                                                secondary
+                                                href={connectVcsProvider(provider.id).toString()}
+                                                size="s">
+                                                <Icon icon={provider.icon} slot="start" />
+                                                Connect to {provider.label}
+                                            </Button>
+                                        {/each}
+                                    </Layout.Stack>
                                 </svelte:fragment>
                             </Empty>
                         </Card>

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/templates/template-[template]/+page.svelte
@@ -41,7 +41,11 @@
     } from '$lib/components/git';
     import Domain from '../../domain.svelte';
     import { app, iconPath } from '$lib/stores/app';
-    import { connectVcsProvider, enabledVcsProviders } from '$lib/stores/git';
+    import {
+        connectVcsProvider,
+        enabledVcsProviders,
+        supportsRepositoryCreation
+    } from '$lib/stores/git';
     import { getFrameworkIcon } from '$lib/stores/sites';
     import { regionalConsoleVariables } from '$routes/(console)/project-[region]-[project]/store';
     import { getTemplateSourceUrl } from '$lib/helpers/templateSource';
@@ -201,6 +205,14 @@
         }
     }
 
+    $: canCreateRepository = data.installations.installations.some((entry) =>
+        supportsRepositoryCreation(entry.provider, $regionalConsoleVariables)
+    );
+
+    $: if (!canCreateRepository) {
+        repositoryBehaviour = 'existing';
+    }
+
     $: if (repositoryBehaviour === 'new') {
         selectedInstallationId = $installation?.$id;
         repositoryName ??= name.split(' ').join('-').toLowerCase();
@@ -278,7 +290,9 @@
                     {#if hasInstallations}
                         <Fieldset legend="Git repository">
                             <Layout.Stack gap="xl">
-                                <RepositoryBehaviour bind:repositoryBehaviour />
+                                {#if canCreateRepository}
+                                    <RepositoryBehaviour bind:repositoryBehaviour />
+                                {/if}
                                 {#if repositoryBehaviour === 'new'}
                                     <NewRepository
                                         bind:selectedInstallationId
@@ -325,8 +339,8 @@
                                 title="Connect Git repository"
                                 description="Create and deploy a Site with a connected git repository.">
                                 <svelte:fragment slot="actions">
-                                    <Layout.Stack direction="row">
-                                        {#each enabledVcsProviders(($regionalConsoleVariables as { _APP_VCS_PROVIDERS?: string[] })?._APP_VCS_PROVIDERS) as provider (provider.id)}
+                                    <Layout.Stack direction="row" justifyContent="center">
+                                        {#each enabledVcsProviders($regionalConsoleVariables?._APP_VCS_PROVIDERS) as provider (provider.id)}
                                             <Button
                                                 secondary
                                                 href={connectVcsProvider(provider.id).toString()}

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
@@ -10,6 +10,8 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
+    import { getProviderRepositoryUrl } from '$lib/stores/git';
+    import IconOrigin from '$lib/components/git/IconOrigin.svelte';
     import {
         Adapter,
         BuildRuntime,
@@ -160,10 +162,15 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s" inline>
-                        <Icon icon={IconGithub} />
+                        <Icon
+                            icon={$installation?.provider === 'origin' ? IconOrigin : IconGithub} />
                         <Link
                             external
-                            href={`https://github.com/${$repository?.organization}/${$repository?.name}`}>
+                            href={getProviderRepositoryUrl(
+                                $installation?.provider ?? 'github',
+                                $repository?.organization,
+                                $repository?.name
+                            )}>
                             <Layout.Stack direction="row" alignItems="center" gap="s" inline>
                                 {$repository?.organization}/{$repository?.name}
                             </Layout.Stack>

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
@@ -31,6 +31,14 @@
     let activate = true;
     let error = '';
 
+    // '' when the provider's host is unknown client-side (e.g. Gitea), in which
+    // case the repository is shown as plain text rather than a broken link.
+    $: repositoryUrl = getProviderRepositoryUrl(
+        $installation?.provider ?? 'github',
+        $repository?.organization,
+        $repository?.name
+    );
+
     async function loadInstallations() {
         if (!site?.installationId && installations?.total > 0) {
             installation.set(installations.installations[0]);
@@ -161,17 +169,17 @@
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s" inline>
                         <Icon icon={getVcsProvider($installation?.provider).icon} />
-                        <Link
-                            external
-                            href={getProviderRepositoryUrl(
-                                $installation?.provider ?? 'github',
-                                $repository?.organization,
-                                $repository?.name
-                            )}>
-                            <Layout.Stack direction="row" alignItems="center" gap="s" inline>
+                        {#if repositoryUrl}
+                            <Link external href={repositoryUrl}>
+                                <Layout.Stack direction="row" alignItems="center" gap="s" inline>
+                                    {$repository?.organization}/{$repository?.name}
+                                </Layout.Stack>
+                            </Link>
+                        {:else}
+                            <Typography.Text>
                                 {$repository?.organization}/{$repository?.name}
-                            </Layout.Stack>
-                        </Link>
+                            </Typography.Text>
+                        {/if}
                     </Layout.Stack>
                     <Typography.Caption variant="400" color="--fgcolor-neutral-tertiary">
                         Last updated {timeFromNow($repository?.pushedAt)}

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createGitDeploymentModal.svelte
@@ -10,8 +10,7 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { installation, repository } from '$lib/stores/vcs';
-    import { getProviderRepositoryUrl } from '$lib/stores/git';
-    import IconOrigin from '$lib/components/git/IconOrigin.svelte';
+    import { getProviderRepositoryUrl, getVcsProvider } from '$lib/stores/git';
     import {
         Adapter,
         BuildRuntime,
@@ -19,7 +18,6 @@
         VCSReferenceType,
         type Models
     } from '@appwrite.io/console';
-    import { IconGithub } from '@appwrite.io/pink-icons-svelte';
     import { Icon, Layout, Skeleton, Typography } from '@appwrite.io/pink-svelte';
 
     export let show = false;
@@ -145,7 +143,7 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s">
-                        <Icon size="s" icon={IconGithub} />
+                        <Icon size="s" icon={getVcsProvider($installation?.provider).icon} />
                         <Skeleton variant="line" width={100} height={19.6} />
                     </Layout.Stack>
                 </Layout.Stack>
@@ -162,8 +160,7 @@
                     alignItems="center"
                     gap="xs">
                     <Layout.Stack direction="row" alignItems="center" gap="s" inline>
-                        <Icon
-                            icon={$installation?.provider === 'origin' ? IconOrigin : IconGithub} />
+                        <Icon icon={getVcsProvider($installation?.provider).icon} />
                         <Link
                             external
                             href={getProviderRepositoryUrl(


### PR DESCRIPTION
## What does this PR do?

Adds Origin (Cursor) as a connectable git provider and makes the console honor the server's per-provider VCS capabilities.

- **SDK bump** — pins `@appwrite.io/console` to `56957ff`, which adds the two new `Models.ConsoleVariables` fields this feature reads: `_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION` and `_APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES`. No breaking changes against the previous `ed09983` pin, so it's a lockfile-only commit.
- **Origin provider support** — provider metadata, icon, authorize redirect, and Origin-specific links (cursor.com Codebase for organizations/repositories, app settings for installation access).
- **Provider choice across the console** — connect buttons, installation selects, and repository pickers now offer every provider enabled via `_APP_VCS_PROVIDERS` (GitHub always, Gitea self-hosted only) instead of being hardcoded to GitHub.
- **Respect the new console variables** — the new-repository form only offers organizations whose provider is listed in `_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION`, and hides the public/private toggle (forcing private) when the provider is not in `_APP_VCS_PROVIDERS_WITH_PUBLIC_REPOSITORIES`. The connect-repository modal and the function/site template wizards hide the "Create new repository" choice entirely when no installation supports creation, replacing the previous hardcoded Origin special case. Servers that predate the new variables keep the historical behavior.
- **UI fix** — the provider connect buttons in the git empty states are now centered.

Reviewing commit-by-commit is easiest: the first commit is the SDK pin, the rest are the feature.

## Test plan

- `bun run check` — 0 errors
- `bun run lint` — 0 errors
- `bun run test:unit` — all passing
- `bun run build` — passes

## Related PRs and issues

- Replaces #3168, rebased onto latest `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)