### PR TITLE
fix(sites): generate mobile QR through console project

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/sites/(components)/openOnMobileModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/(components)/openOnMobileModal.svelte
@@ -33,9 +33,7 @@
     let tooltipMessage = $state('Copy');
 
     function getImage(url: string) {
-        return sdk
-            .forProject(page.params.region, page.params.project)
-            .avatars.getQR({ text: url, size: 352 });
+        return sdk.forConsoleIn(page.params.region).avatars.getQR({ text: url, size: 352 });
     }
 </script>
 


### PR DESCRIPTION
## Summary

- generate the Sites "Open on mobile" QR code through the regional console project
- keep QR rendering independent of the selected project's Avatars service setting

## Problem

The modal currently calls `avatars.getQR()` with the selected project. If that project has Avatars disabled, the image request returns `403 general_service_disabled` and the modal shows a broken QR image even though Sites is enabled.

The QR code is a Console UI asset rather than a project Avatars operation, so it should use the console project, consistent with other Console-owned QR generation.

## Validation

- `bun run format`
- `bun run check`
- `bun run lint` (passes with existing warnings)
- `bun run test:unit` (265 tests)
- `bun run build`
