### PR TITLE
feat(permissions): support the member role in the permission picker

### DIFF
--- a/src/lib/components/permissions/actions.svelte
+++ b/src/lib/components/permissions/actions.svelte
@@ -2,6 +2,7 @@
     import { createEventDispatcher } from 'svelte';
     import Label from './label.svelte';
     import Custom from './custom.svelte';
+    import Member from './member.svelte';
     import Team from './team.svelte';
     import User from './user.svelte';
     import type { Permission } from './permissions.svelte';
@@ -10,6 +11,7 @@
 
     export let showUser: boolean;
     export let showTeam: boolean;
+    export let showMember: boolean;
     export let showLabel: boolean;
     export let showCustom: boolean;
     export let groups: Writable<Map<string, Permission>>;
@@ -57,6 +59,11 @@
                 }}>Select teams</ActionMenu.Item.Button>
             <ActionMenu.Item.Button
                 on:click={(e) => {
+                    showMember = true;
+                    hide(e);
+                }}>Select memberships</ActionMenu.Item.Button>
+            <ActionMenu.Item.Button
+                on:click={(e) => {
                     showLabel = true;
                     hide(e);
                 }}>Label</ActionMenu.Item.Button>
@@ -81,6 +88,9 @@
             showCustom = true;
         }}
         {groups} />
+{/if}
+{#if showMember}
+    <Member bind:show={showMember} on:create {groups} />
 {/if}
 {#if showLabel}
     <Label bind:show={showLabel} on:create {groups} />

--- a/src/lib/components/permissions/custom.svelte
+++ b/src/lib/components/permissions/custom.svelte
@@ -34,8 +34,8 @@
         required
         id="custom-permission"
         label="Role"
-        placeholder="user:[USER_ID] or team:[TEAM_ID]/[ROLE]"
-        helper="A permission should be formatted as: user:[USER_ID] or team:[TEAM_ID]/[ROLE]¸"
+        placeholder="user:[USER_ID], team:[TEAM_ID]/[ROLE] or member:[MEMBERSHIP_ID]"
+        helper="A permission should be formatted as: user:[USER_ID], team:[TEAM_ID]/[ROLE] or member:[MEMBERSHIP_ID]"
         bind:value />
 
     <svelte:fragment slot="footer">

--- a/src/lib/components/permissions/member.svelte
+++ b/src/lib/components/permissions/member.svelte
@@ -49,6 +49,10 @@
     // order; only the newest request is allowed to write to the list or clear the spinner.
     let latestRequest = 0;
 
+    // Held separately from the lists: an empty list and a failed lookup both leave nothing to
+    // show, and reporting a failure as "none found" would be a lie the operator cannot act on.
+    let loadError = '';
+
     function clearUser() {
         user = null;
         memberships = undefined;
@@ -72,6 +76,7 @@
         if (!show || user) return;
         const requestId = ++latestRequest;
         isLoading = true;
+        loadError = '';
         try {
             const response = await sdk
                 .forProject(page.params.region, page.params.project)
@@ -83,6 +88,7 @@
             users = response;
         } catch (error) {
             if (requestId !== latestRequest) return;
+            loadError = error.message;
             addNotification({ type: 'error', message: error.message });
         } finally {
             if (requestId === latestRequest) isLoading = false;
@@ -94,6 +100,7 @@
         const requestedUserId = user.$id;
         const requestId = ++latestRequest;
         isLoading = true;
+        loadError = '';
         try {
             const response = await sdk
                 .forProject(page.params.region, page.params.project)
@@ -107,6 +114,7 @@
             memberships = response;
         } catch (error) {
             if (requestId !== latestRequest) return;
+            loadError = error.message;
             addNotification({ type: 'error', message: error.message });
         } finally {
             if (requestId === latestRequest) isLoading = false;
@@ -210,6 +218,15 @@
             <div style:margin-inline="auto" style:min-height="275px" style:align-content="center">
                 <Spinner size="m" />
             </div>
+        {:else if loadError}
+            <Card.Base padding="none">
+                <Empty title="Could not load memberships." type="secondary">
+                    <Typography.Text slot="description">{loadError}</Typography.Text>
+                    <svelte:fragment slot="actions">
+                        <Button secondary on:click={requestMemberships}>Retry</Button>
+                    </svelte:fragment>
+                </Empty>
+            </Card.Base>
         {:else}
             <Card.Base padding="none">
                 <Empty title="This user is not a member of any team." type="secondary">
@@ -271,6 +288,20 @@
                 hidePages
                 on:change={requestUsers} />
         </Layout.Stack>
+    {:else if loadError}
+        <InputSearch
+            autofocus
+            placeholder="Search by name, email, phone or ID"
+            bind:value={search} />
+
+        <Card.Base padding="none">
+            <Empty title="Could not load users." type="secondary">
+                <Typography.Text slot="description">{loadError}</Typography.Text>
+                <svelte:fragment slot="actions">
+                    <Button secondary on:click={requestUsers}>Retry</Button>
+                </svelte:fragment>
+            </Empty>
+        </Card.Base>
     {:else if search}
         <InputSearch
             autofocus

--- a/src/lib/components/permissions/member.svelte
+++ b/src/lib/components/permissions/member.svelte
@@ -2,6 +2,7 @@
     import { Button, InputSearch } from '$lib/elements/forms';
     import { createEventDispatcher } from 'svelte';
     import { AvatarInitials, EmptySearch, Modal, PaginationInline } from '..';
+    import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Query, Role, type Models } from '@appwrite.io/console';
     import type { Writable } from 'svelte/store';
@@ -44,6 +45,10 @@
     let memberships: Models.MembershipList;
     let membershipOffset = 0;
 
+    // Searching and stepping between users both re-request, so responses can land out of
+    // order; only the newest request is allowed to write to the list or clear the spinner.
+    let latestRequest = 0;
+
     function clearUser() {
         user = null;
         memberships = undefined;
@@ -65,24 +70,47 @@
 
     async function requestUsers() {
         if (!show || user) return;
+        const requestId = ++latestRequest;
         isLoading = true;
-        users = await sdk.forProject(page.params.region, page.params.project).users.list({
-            queries: [Query.limit(5), Query.offset(offset)],
-            search: search || undefined
-        });
-        isLoading = false;
+        try {
+            const response = await sdk
+                .forProject(page.params.region, page.params.project)
+                .users.list({
+                    queries: [Query.limit(5), Query.offset(offset)],
+                    search: search || undefined
+                });
+            if (requestId !== latestRequest) return;
+            users = response;
+        } catch (error) {
+            if (requestId !== latestRequest) return;
+            addNotification({ type: 'error', message: error.message });
+        } finally {
+            if (requestId === latestRequest) isLoading = false;
+        }
     }
 
     async function requestMemberships() {
         if (!show || !user) return;
+        const requestedUserId = user.$id;
+        const requestId = ++latestRequest;
         isLoading = true;
-        memberships = await sdk
-            .forProject(page.params.region, page.params.project)
-            .users.listMemberships({
-                userId: user.$id,
-                queries: [Query.limit(5), Query.offset(membershipOffset)]
-            });
-        isLoading = false;
+        try {
+            const response = await sdk
+                .forProject(page.params.region, page.params.project)
+                .users.listMemberships({
+                    userId: requestedUserId,
+                    queries: [Query.limit(5), Query.offset(membershipOffset)]
+                });
+            // Going back and picking someone else while this was in flight must not file
+            // one user's memberships under another's name.
+            if (requestId !== latestRequest || user?.$id !== requestedUserId) return;
+            memberships = response;
+        } catch (error) {
+            if (requestId !== latestRequest) return;
+            addNotification({ type: 'error', message: error.message });
+        } finally {
+            if (requestId === latestRequest) isLoading = false;
+        }
     }
 
     function onSelection(role: string) {

--- a/src/lib/components/permissions/member.svelte
+++ b/src/lib/components/permissions/member.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+    import { Button, InputSearch } from '$lib/elements/forms';
+    import { createEventDispatcher } from 'svelte';
+    import { AvatarInitials, EmptySearch, Modal, PaginationInline } from '..';
+    import { sdk } from '$lib/stores/sdk';
+    import { Query, Role, type Models } from '@appwrite.io/console';
+    import type { Writable } from 'svelte/store';
+    import type { Permission } from './permissions.svelte';
+    import {
+        Avatar,
+        Card,
+        Empty,
+        Icon,
+        Layout,
+        Link,
+        Selector,
+        Spinner,
+        Table,
+        Typography
+    } from '@appwrite.io/pink-svelte';
+    import {
+        IconAnonymous,
+        IconArrowNarrowLeft,
+        IconMinusSm,
+        IconUsers
+    } from '@appwrite.io/pink-icons-svelte';
+    import { page } from '$app/state';
+
+    export let show: boolean;
+    export let groups: Writable<Map<string, Permission>>;
+
+    const dispatch = createEventDispatcher();
+
+    let search = '';
+    let offset = 0;
+    let isLoading = false;
+    let hasSelection = false;
+    let selected: Set<string> = new Set();
+    let users: Models.UserList<Record<string, unknown>>;
+
+    // A member role keys on a membership rather than a user, and memberships are searchable
+    // only by their own ID, so the user is resolved first and their memberships listed after.
+    let user: Models.User<Record<string, unknown>> = null;
+    let memberships: Models.MembershipList;
+    let membershipOffset = 0;
+
+    function clearUser() {
+        user = null;
+        memberships = undefined;
+        membershipOffset = 0;
+    }
+
+    function reset() {
+        offset = 0;
+        search = '';
+        selected.clear();
+        clearUser();
+        show = false;
+    }
+
+    function create() {
+        dispatch('create', Array.from(selected));
+        reset();
+    }
+
+    async function requestUsers() {
+        if (!show || user) return;
+        isLoading = true;
+        users = await sdk.forProject(page.params.region, page.params.project).users.list({
+            queries: [Query.limit(5), Query.offset(offset)],
+            search: search || undefined
+        });
+        isLoading = false;
+    }
+
+    async function requestMemberships() {
+        if (!show || !user) return;
+        isLoading = true;
+        memberships = await sdk
+            .forProject(page.params.region, page.params.project)
+            .users.listMemberships({
+                userId: user.$id,
+                queries: [Query.limit(5), Query.offset(membershipOffset)]
+            });
+        isLoading = false;
+    }
+
+    function onSelection(role: string) {
+        const checked = selected.has(role);
+        if (checked) {
+            selected.delete(role);
+        } else {
+            selected.add(role);
+        }
+        selected = selected;
+
+        hasSelection = selected.size > 0;
+    }
+
+    $: if (show) {
+        requestUsers();
+    }
+    $: if (offset !== null) {
+        requestUsers();
+    }
+    $: if (search !== null) {
+        offset = 0;
+        requestUsers();
+    }
+    $: if (user) {
+        requestMemberships();
+    }
+    $: if (membershipOffset !== null) {
+        requestMemberships();
+    }
+</script>
+
+<Modal title="Select memberships" bind:show onSubmit={create} on:close={reset}>
+    <Typography.Text slot="description">
+        Grant access to a user through one of their team memberships. Access is revoked
+        automatically when they leave that team.
+    </Typography.Text>
+
+    {#if user}
+        <Layout.Stack direction="row" alignItems="center" gap="s">
+            <Button text size="s" on:click={clearUser}>
+                <Icon icon={IconArrowNarrowLeft} size="s" />
+                Back
+            </Button>
+            <Typography.Caption variant="400" color="--fgcolor-neutral-tertiary">
+                {user.name || user.email || user.phone || user.$id}
+            </Typography.Caption>
+        </Layout.Stack>
+
+        {#if memberships?.memberships?.length}
+            <Table.Root columns={[{ id: 'checkbox', width: 40 }, { id: 'team' }]} let:root>
+                {#each memberships.memberships as membership (membership.$id)}
+                    {@const role = Role.member(membership.$id)}
+                    {@const exists = $groups.has(role)}
+                    <Table.Row.Button {root} on:click={() => onSelection(role)} disabled={exists}>
+                        <Table.Cell column="checkbox" {root}>
+                            <div style:pointer-events="none">
+                                <Selector.Checkbox
+                                    size="s"
+                                    id={membership.$id}
+                                    disabled={exists}
+                                    checked={exists || selected.has(role)} />
+                            </div>
+                        </Table.Cell>
+                        <Table.Cell column="team" {root}>
+                            <Layout.Stack direction="row" alignItems="center" gap="s">
+                                <Avatar size="xs">
+                                    <Icon icon={IconUsers} size="s" />
+                                </Avatar>
+                                <Layout.Stack gap="none">
+                                    <Typography.Caption variant="400">
+                                        {membership.teamName || membership.teamId}
+                                    </Typography.Caption>
+                                    <Typography.Caption
+                                        variant="400"
+                                        color="--fgcolor-neutral-tertiary">
+                                        {membership.$id}
+                                    </Typography.Caption>
+                                </Layout.Stack>
+                            </Layout.Stack>
+                        </Table.Cell>
+                    </Table.Row.Button>
+                {/each}
+            </Table.Root>
+
+            <Layout.Stack direction="row" justifyContent="space-between" alignItems="center">
+                <p class="text">Total results: {memberships?.total}</p>
+                <PaginationInline
+                    limit={5}
+                    bind:offset={membershipOffset}
+                    total={memberships?.total}
+                    hidePages
+                    on:change={requestMemberships} />
+            </Layout.Stack>
+        {:else if isLoading}
+            <!-- 275px nearly matches the height of at-least 5 items in the table above -->
+            <div style:margin-inline="auto" style:min-height="275px" style:align-content="center">
+                <Spinner size="m" />
+            </div>
+        {:else}
+            <Card.Base padding="none">
+                <Empty title="This user is not a member of any team." type="secondary">
+                    <Typography.Text slot="description">
+                        Add them to a team to grant access this way, or learn more in our <Link.Anchor
+                            href="https://appwrite.io/docs/products/auth/teams"
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            documentation</Link.Anchor
+                        >.
+                    </Typography.Text>
+                </Empty>
+            </Card.Base>
+        {/if}
+    {:else if users?.users?.length}
+        <InputSearch
+            autofocus
+            placeholder="Search by name, email, phone or ID"
+            bind:value={search} />
+
+        <Table.Root columns={[{ id: 'user' }]} let:root>
+            {#each users.users as item (item.$id)}
+                <Table.Row.Button {root} on:click={() => (user = item)}>
+                    <Table.Cell column="user" {root}>
+                        <Layout.Stack direction="row" alignItems="center" gap="s">
+                            {#if item.name}
+                                <AvatarInitials size="xs" name={item.name} />
+                            {:else}
+                                <Avatar size="xs">
+                                    <Icon
+                                        icon={item.email || item.phone
+                                            ? IconMinusSm
+                                            : IconAnonymous}
+                                        size="s" />
+                                </Avatar>
+                            {/if}
+                            <Layout.Stack gap="none">
+                                <Typography.Caption variant="400">
+                                    {item.name || item.email || item.phone || '-'}
+                                </Typography.Caption>
+                                <Typography.Caption
+                                    variant="400"
+                                    color="--fgcolor-neutral-tertiary">
+                                    {item.$id}
+                                </Typography.Caption>
+                            </Layout.Stack>
+                        </Layout.Stack>
+                    </Table.Cell>
+                </Table.Row.Button>
+            {/each}
+        </Table.Root>
+
+        <Layout.Stack direction="row" justifyContent="space-between" alignItems="center">
+            <p class="text">Total results: {users?.total}</p>
+            <PaginationInline
+                limit={5}
+                bind:offset
+                total={users?.total}
+                hidePages
+                on:change={requestUsers} />
+        </Layout.Stack>
+    {:else if search}
+        <InputSearch
+            autofocus
+            placeholder="Search by name, email, phone or ID"
+            bind:value={search} />
+
+        <EmptySearch bind:search target="users" hidePages>
+            <Button
+                external
+                href="https://appwrite.io/docs/products/auth/users"
+                text
+                event="empty_documentation"
+                size="s">Documentation</Button>
+            <Button secondary on:click={() => (search = '')}>Clear search</Button>
+        </EmptySearch>
+    {:else if isLoading}
+        <!-- 275px nearly matches the height of at-least 5 items in the table above -->
+        <div style:margin-inline="auto" style:min-height="275px" style:align-content="center">
+            <Spinner size="m" />
+        </div>
+    {:else}
+        <Card.Base padding="none">
+            <Empty title="No users yet. Create a user to see it here." type="secondary">
+                <Typography.Text slot="description">
+                    Need a hand? Learn more in our <Link.Anchor
+                        href="https://appwrite.io/docs/products/auth/users"
+                        target="_blank"
+                        rel="noopener noreferrer">
+                        documentation</Link.Anchor
+                    >.
+                </Typography.Text>
+            </Empty>
+        </Card.Base>
+    {/if}
+
+    <svelte:fragment slot="footer">
+        <Button submit disabled={!hasSelection}>Add</Button>
+    </svelte:fragment>
+</Modal>

--- a/src/lib/components/permissions/permissions.svelte
+++ b/src/lib/components/permissions/permissions.svelte
@@ -27,6 +27,7 @@
 
     let showUser = false;
     let showTeam = false;
+    let showMember = false;
     let showLabel = false;
     let showCustom = false;
 
@@ -182,6 +183,7 @@
             bind:showLabel
             bind:showCustom
             bind:showTeam
+            bind:showMember
             bind:showUser
             {groups}
             on:create={create}
@@ -199,6 +201,7 @@
                 bind:showLabel
                 bind:showCustom
                 bind:showTeam
+                bind:showMember
                 bind:showUser
                 {groups}
                 on:create={create}

--- a/src/lib/components/permissions/roles.svelte
+++ b/src/lib/components/permissions/roles.svelte
@@ -14,6 +14,7 @@
 
     let showUser = false;
     let showTeam = false;
+    let showMember = false;
     let showLabel = false;
     let showCustom = false;
 
@@ -102,6 +103,7 @@
             bind:showLabel
             bind:showCustom
             bind:showTeam
+            bind:showMember
             bind:showUser
             {groups}
             on:create={create}
@@ -121,6 +123,7 @@
                 bind:showLabel
                 bind:showCustom
                 bind:showTeam
+                bind:showMember
                 bind:showUser
                 {groups}
                 on:create={create}

--- a/src/lib/components/permissions/row.svelte
+++ b/src/lib/components/permissions/row.svelte
@@ -16,7 +16,7 @@
         Typography
     } from '@appwrite.io/pink-svelte';
     import Avatar from '../avatar.svelte';
-    import { IconAnonymous, IconMinusSm } from '@appwrite.io/pink-icons-svelte';
+    import { IconAnonymous, IconMinusSm, IconUsers } from '@appwrite.io/pink-icons-svelte';
     import { page } from '$app/state';
     import { menuOpen } from '$lib/components/menu/store';
     import { base } from '$app/paths';
@@ -39,8 +39,10 @@
 
     let { role, placement = 'bottom-start', children, onNotFound }: Props = $props();
 
+    const parsedRole = $derived(parsePermission(role));
+
     type ParsedPermission = {
-        type: 'user' | 'team' | 'other';
+        type: 'user' | 'team' | 'member' | 'other';
         id: string;
         roleName?: string;
         isValid: boolean;
@@ -58,9 +60,9 @@
                 return { type: 'other', id: permission, isValid: false };
             }
 
-            if (type === 'user' || type === 'team') {
+            if (type === 'user' || type === 'team' || type === 'member') {
                 return {
-                    type: type as 'user' | 'team',
+                    type: type as 'user' | 'team' | 'member',
                     id,
                     roleName,
                     isValid: true
@@ -76,6 +78,12 @@
     async function fetchPermissionData(parsed: ParsedPermission): Promise<PermissionData> {
         if (!parsed.isValid || parsed.type === 'other') {
             return { notFound: true, roleName: parsed.roleName, customName: parsed.id };
+        }
+
+        // A membership can only be read through its team or its user, neither of which the role
+        // carries, so the ID is shown as-is rather than reported as a role that no longer exists.
+        if (parsed.type === 'member') {
+            return { roleName: parsed.roleName, customName: parsed.id };
         }
 
         if (parsed.type === 'user') {
@@ -177,7 +185,7 @@
                             {role}
                         {:then data}
                             {formatName(
-                                data.name ?? data?.email ?? data?.phone ?? '-',
+                                data.name ?? data?.email ?? data?.phone ?? data?.customName ?? '-',
                                 $isSmallViewport ? 16 : 20
                             )}
                         {/await}
@@ -185,7 +193,11 @@
                     <Badge
                         size="xs"
                         variant="secondary"
-                        content={role.startsWith('user') ? 'User' : 'Team'} />
+                        content={parsedRole.type === 'member'
+                            ? 'Member'
+                            : parsedRole.type === 'user'
+                              ? 'User'
+                              : 'Team'} />
                 </Layout.Stack>
             {/if}
         </button>
@@ -205,7 +217,37 @@
                             <Spinner />
                         </Layout.Stack>
                     {:then data}
-                        {#if data.notFound}
+                        {#if parsedRole.type === 'member'}
+                            <Layout.Stack gap="s" alignItems="flex-start">
+                                <Layout.Stack
+                                    direction="row"
+                                    gap="s"
+                                    alignItems="center"
+                                    justifyContent="flex-start">
+                                    <Avatar alt="avatar" size="m">
+                                        <Icon icon={IconUsers} size="s" />
+                                    </Avatar>
+
+                                    <Layout.Stack alignItems="flex-start" gap="xxs">
+                                        <Layout.Stack style="padding-left: 0.25rem;">
+                                            <Typography.Text
+                                                size="m"
+                                                color="--fgcolor-neutral-primary">
+                                                Team membership
+                                            </Typography.Text>
+                                        </Layout.Stack>
+                                        <InteractiveText
+                                            isVisible
+                                            variant="copy"
+                                            text={formatName(
+                                                parsedRole.id,
+                                                $isSmallViewport ? 20 : 28
+                                            )}
+                                            value={parsedRole.id} />
+                                    </Layout.Stack>
+                                </Layout.Stack>
+                            </Layout.Stack>
+                        {:else if data.notFound}
                             <Layout.Stack gap="s" alignItems="flex-start">
                                 <Layout.Stack
                                     direction="row"


### PR DESCRIPTION
`Role.member([MEMBERSHIP_ID])` has been part of the permissions API since 1.0 and is [documented](https://appwrite.io/docs/advanced/security/permissions), but the console has never offered it. This adds it, and fixes how existing member roles are displayed.


