### PR TITLE
fix(permissions): drop the membership request when stepping back

### DIFF
--- a/src/lib/components/permissions/member.svelte
+++ b/src/lib/components/permissions/member.svelte
@@ -57,6 +57,12 @@
         user = null;
         memberships = undefined;
         membershipOffset = 0;
+
+        // Stepping back abandons the membership request. Leaving it live lets its rejection
+        // land on the user step and report the user list as the thing that failed.
+        latestRequest++;
+        loadError = '';
+        isLoading = false;
     }
 
     function reset() {
@@ -113,7 +119,7 @@
             if (requestId !== latestRequest || user?.$id !== requestedUserId) return;
             memberships = response;
         } catch (error) {
-            if (requestId !== latestRequest) return;
+            if (requestId !== latestRequest || user?.$id !== requestedUserId) return;
             loadError = error.message;
             addNotification({ type: 'error', message: error.message });
         } finally {


### PR DESCRIPTION
Follow-up to #3177, which merged before this Greptile P1 was addressed. The finding was correct.

**The path:** on step two with a membership request in flight, hit **Back**. `clearUser()` cleared the selected user but left the request live, and Back triggers no new request — so `latestRequest` never advanced and nothing invalidated it. On rejection the `requestId !== latestRequest` guard still matched, so `loadError` was set while the picker sat on step one. Result: **"Could not load users."** over a user list that had loaded fine, with a Retry wired to the wrong request.

**Fix:** `clearUser()` now advances the request counter and clears the error and spinner it owns, so stepping back abandons the request rather than leaving it able to report. The rejection path also checks the selected user, matching the success path instead of relying on the counter alone — that asymmetry is what Greptile flagged.

`check` 0 errors, `lint` 0 errors, 265 unit tests, `build` clean.