### PR TITLE
fix(auth): stop the users limit card silently blocking Update

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
@@ -7,8 +7,14 @@
     import { addNotification } from '$lib/stores/notifications';
     import { sdk } from '$lib/stores/sdk';
     import { Layout, Selector, Input, Badge } from '@appwrite.io/pink-svelte';
-    import { tick } from 'svelte';
     import type { Models } from '@appwrite.io/console';
+    import {
+        USERS_LIMIT_MAX,
+        USERS_LIMIT_MIN,
+        usersLimitChanged,
+        usersLimitError,
+        type UsersLimitMode
+    } from './usersLimit';
 
     let {
         project,
@@ -18,15 +24,12 @@
         policy: Models.PolicyUserLimit;
     } = $props();
 
-    let maxUsersInputField: HTMLInputElement | null = $state(null);
-
-    let value = $state(policy.total !== 0 ? 'limited' : 'unlimited');
+    let value = $state<UsersLimitMode>(policy.total !== 0 ? 'limited' : 'unlimited');
     let newLimit = $state(policy.total !== 0 ? policy.total : 100);
 
     const isLimited = $derived(value === 'limited');
-    const btnDisabled = $derived.by(() => {
-        return (!isLimited && policy.total === 0) || (isLimited && policy.total === newLimit);
-    });
+    const limitError = $derived(isLimited ? usersLimitError(newLimit) : null);
+    const btnDisabled = $derived(!!limitError || !usersLimitChanged(value, newLimit, policy.total));
 
     async function updateLimit() {
         try {
@@ -47,14 +50,6 @@
             trackError(error, Submit.AuthLimitUpdate);
         }
     }
-
-    $effect(() => {
-        if (isLimited && maxUsersInputField) {
-            tick().then(() => {
-                maxUsersInputField.focus();
-            });
-        }
-    });
 </script>
 
 <CardGrid>
@@ -83,10 +78,16 @@
                     name="limit"
                     id="limit"
                     class="input-text"
-                    max="10000"
+                    min={USERS_LIMIT_MIN}
+                    max={USERS_LIMIT_MAX}
+                    step={1}
+                    state={limitError ? 'error' : 'default'}
                     disabled={!isLimited}
                     bind:value={newLimit} />
             </Layout.Stack>
+            {#if limitError}
+                <Input.Helper state="error">{limitError}</Input.Helper>
+            {/if}
         </Layout.Stack>
     </svelte:fragment>
 

--- a/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/updateUsersLimit.svelte
@@ -11,8 +11,7 @@
     import {
         USERS_LIMIT_MAX,
         USERS_LIMIT_MIN,
-        usersLimitChanged,
-        usersLimitError,
+        usersLimitState,
         type UsersLimitMode
     } from './usersLimit';
 
@@ -28,8 +27,7 @@
     let newLimit = $state(policy.total !== 0 ? policy.total : 100);
 
     const isLimited = $derived(value === 'limited');
-    const limitError = $derived(isLimited ? usersLimitError(newLimit) : null);
-    const btnDisabled = $derived(!!limitError || !usersLimitChanged(value, newLimit, policy.total));
+    const limitState = $derived(usersLimitState(value, newLimit, policy.total));
 
     async function updateLimit() {
         try {
@@ -81,19 +79,19 @@
                     min={USERS_LIMIT_MIN}
                     max={USERS_LIMIT_MAX}
                     step={1}
-                    state={limitError ? 'error' : 'default'}
+                    state={limitState.error ? 'error' : 'default'}
                     disabled={!isLimited}
                     bind:value={newLimit} />
             </Layout.Stack>
-            {#if limitError}
-                <Input.Helper state="error">{limitError}</Input.Helper>
+            {#if limitState.error}
+                <Input.Helper state="error">{limitState.error}</Input.Helper>
             {/if}
         </Layout.Stack>
     </svelte:fragment>
 
     <svelte:fragment slot="actions">
         <Button
-            disabled={btnDisabled}
+            disabled={limitState.disabled}
             on:click={() => {
                 updateLimit();
             }}>Update</Button>

--- a/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.test.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.test.ts
@@ -1,70 +1,58 @@
 import { describe, expect, it } from 'vitest';
-import {
-    USERS_LIMIT_MAX,
-    USERS_LIMIT_MIN,
-    usersLimitChanged,
-    usersLimitError,
-    type UsersLimitMode
-} from './usersLimit';
+import { USERS_LIMIT_MAX, USERS_LIMIT_MIN, usersLimitState } from './usersLimit';
 
-describe('usersLimitError', () => {
-    it('accepts whole numbers within range', () => {
-        expect(usersLimitError(USERS_LIMIT_MIN)).toBeNull();
-        expect(usersLimitError(100)).toBeNull();
-        expect(usersLimitError(USERS_LIMIT_MAX)).toBeNull();
+describe('usersLimitState', () => {
+    describe('limited', () => {
+        it('accepts whole numbers within range', () => {
+            expect(usersLimitState('limited', USERS_LIMIT_MIN, 100).error).toBeNull();
+            expect(usersLimitState('limited', 250, 100).error).toBeNull();
+            expect(usersLimitState('limited', USERS_LIMIT_MAX, 100).error).toBeNull();
+        });
+
+        it('explains a limit of 0 instead of leaving Update dead', () => {
+            const state = usersLimitState('limited', 0, 0);
+
+            expect(state.error).toContain('Unlimited');
+            expect(state.disabled).toBe(true);
+        });
+
+        it('refuses to save 0, which the API would read as no limit', () => {
+            expect(usersLimitState('limited', 0, 100).disabled).toBe(true);
+        });
+
+        it('rejects a cleared field', () => {
+            expect(usersLimitState('limited', undefined, 100).error).not.toBeNull();
+            expect(usersLimitState('limited', NaN, 100).error).not.toBeNull();
+        });
+
+        it('rejects values outside the accepted range', () => {
+            expect(usersLimitState('limited', -1, 100).error).not.toBeNull();
+            expect(usersLimitState('limited', USERS_LIMIT_MAX + 1, 100).error).not.toBeNull();
+            expect(usersLimitState('limited', 1.5, 100).error).not.toBeNull();
+        });
+
+        it('enables Update for a valid new limit', () => {
+            expect(usersLimitState('limited', 100, 0).disabled).toBe(false);
+            expect(usersLimitState('limited', 1, 100).disabled).toBe(false);
+        });
+
+        it('disables Update when the limit is unchanged', () => {
+            expect(usersLimitState('limited', 100, 100).disabled).toBe(true);
+        });
     });
 
-    it('rejects zero, which the API reads as no limit', () => {
-        expect(usersLimitError(0)).not.toBeNull();
-    });
+    describe('unlimited', () => {
+        it('ignores whatever the disabled limit field holds', () => {
+            expect(usersLimitState('unlimited', 0, 100).error).toBeNull();
+            expect(usersLimitState('unlimited', undefined, 100).error).toBeNull();
+        });
 
-    it('rejects a cleared input', () => {
-        expect(usersLimitError(undefined)).not.toBeNull();
-        expect(usersLimitError(NaN)).not.toBeNull();
-    });
+        it('enables Update when a limit is being removed', () => {
+            expect(usersLimitState('unlimited', 100, 100).disabled).toBe(false);
+        });
 
-    it('rejects values outside the accepted range', () => {
-        expect(usersLimitError(-1)).not.toBeNull();
-        expect(usersLimitError(USERS_LIMIT_MAX + 1)).not.toBeNull();
-        expect(usersLimitError(1.5)).not.toBeNull();
-    });
-});
-
-describe('usersLimitChanged', () => {
-    it('detects a new limit on a limited project', () => {
-        expect(usersLimitChanged('limited', 200, 100)).toBe(true);
-        expect(usersLimitChanged('limited', 100, 100)).toBe(false);
-    });
-
-    it('detects switching between limited and unlimited', () => {
-        expect(usersLimitChanged('limited', 100, 0)).toBe(true);
-        expect(usersLimitChanged('unlimited', 100, 100)).toBe(true);
-        expect(usersLimitChanged('unlimited', 100, 0)).toBe(false);
-    });
-});
-
-describe('update button state', () => {
-    const isDisabled = (mode: UsersLimitMode, limit: number, total: number) =>
-        (mode === 'limited' && usersLimitError(limit) !== null) ||
-        !usersLimitChanged(mode, limit, total);
-
-    it('explains a limit of 0 instead of silently blocking the update', () => {
-        expect(isDisabled('limited', 0, 0)).toBe(true);
-        expect(usersLimitError(0)).toContain('Unlimited');
-    });
-
-    it('never submits a limit of 0 as a limit', () => {
-        expect(isDisabled('limited', 0, 100)).toBe(true);
-    });
-
-    it('enables the update for a valid change', () => {
-        expect(isDisabled('limited', 100, 0)).toBe(false);
-        expect(isDisabled('limited', 1, 100)).toBe(false);
-        expect(isDisabled('unlimited', 100, 100)).toBe(false);
-    });
-
-    it('ignores the limit field while unlimited is selected', () => {
-        expect(isDisabled('unlimited', 0, 100)).toBe(false);
-        expect(isDisabled('unlimited', 0, 0)).toBe(true);
+        it('disables Update when there is no limit to remove', () => {
+            expect(usersLimitState('unlimited', 100, 0).disabled).toBe(true);
+        });
     });
 });

--- a/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.test.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+    USERS_LIMIT_MAX,
+    USERS_LIMIT_MIN,
+    usersLimitChanged,
+    usersLimitError,
+    type UsersLimitMode
+} from './usersLimit';
+
+describe('usersLimitError', () => {
+    it('accepts whole numbers within range', () => {
+        expect(usersLimitError(USERS_LIMIT_MIN)).toBeNull();
+        expect(usersLimitError(100)).toBeNull();
+        expect(usersLimitError(USERS_LIMIT_MAX)).toBeNull();
+    });
+
+    it('rejects zero, which the API reads as no limit', () => {
+        expect(usersLimitError(0)).not.toBeNull();
+    });
+
+    it('rejects a cleared input', () => {
+        expect(usersLimitError(undefined)).not.toBeNull();
+        expect(usersLimitError(NaN)).not.toBeNull();
+    });
+
+    it('rejects values outside the accepted range', () => {
+        expect(usersLimitError(-1)).not.toBeNull();
+        expect(usersLimitError(USERS_LIMIT_MAX + 1)).not.toBeNull();
+        expect(usersLimitError(1.5)).not.toBeNull();
+    });
+});
+
+describe('usersLimitChanged', () => {
+    it('detects a new limit on a limited project', () => {
+        expect(usersLimitChanged('limited', 200, 100)).toBe(true);
+        expect(usersLimitChanged('limited', 100, 100)).toBe(false);
+    });
+
+    it('detects switching between limited and unlimited', () => {
+        expect(usersLimitChanged('limited', 100, 0)).toBe(true);
+        expect(usersLimitChanged('unlimited', 100, 100)).toBe(true);
+        expect(usersLimitChanged('unlimited', 100, 0)).toBe(false);
+    });
+});
+
+describe('update button state', () => {
+    const isDisabled = (mode: UsersLimitMode, limit: number, total: number) =>
+        (mode === 'limited' && usersLimitError(limit) !== null) ||
+        !usersLimitChanged(mode, limit, total);
+
+    it('explains a limit of 0 instead of silently blocking the update', () => {
+        expect(isDisabled('limited', 0, 0)).toBe(true);
+        expect(usersLimitError(0)).toContain('Unlimited');
+    });
+
+    it('never submits a limit of 0 as a limit', () => {
+        expect(isDisabled('limited', 0, 100)).toBe(true);
+    });
+
+    it('enables the update for a valid change', () => {
+        expect(isDisabled('limited', 100, 0)).toBe(false);
+        expect(isDisabled('limited', 1, 100)).toBe(false);
+        expect(isDisabled('unlimited', 100, 100)).toBe(false);
+    });
+
+    it('ignores the limit field while unlimited is selected', () => {
+        expect(isDisabled('unlimited', 0, 100)).toBe(false);
+        expect(isDisabled('unlimited', 0, 0)).toBe(true);
+    });
+});

--- a/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.ts
@@ -1,0 +1,17 @@
+export const USERS_LIMIT_MIN = 1;
+export const USERS_LIMIT_MAX = 10000;
+
+export type UsersLimitMode = 'limited' | 'unlimited';
+
+// The API reserves `total: 0` for "no limit", so `limited` cannot represent zero.
+export function usersLimitError(limit: number): string | null {
+    if (!Number.isInteger(limit) || limit < USERS_LIMIT_MIN || limit > USERS_LIMIT_MAX) {
+        return `Enter a whole number between ${USERS_LIMIT_MIN} and ${USERS_LIMIT_MAX}, or select "Unlimited" to allow any number of users.`;
+    }
+
+    return null;
+}
+
+export function usersLimitChanged(mode: UsersLimitMode, limit: number, total: number): boolean {
+    return mode === 'limited' ? limit !== total : total !== 0;
+}

--- a/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.ts
+++ b/src/routes/(console)/project-[region]-[project]/auth/security/usersLimit.ts
@@ -3,8 +3,13 @@ export const USERS_LIMIT_MAX = 10000;
 
 export type UsersLimitMode = 'limited' | 'unlimited';
 
+export type UsersLimitState = {
+    error: string | null;
+    disabled: boolean;
+};
+
 // The API reserves `total: 0` for "no limit", so `limited` cannot represent zero.
-export function usersLimitError(limit: number): string | null {
+function limitError(limit: number): string | null {
     if (!Number.isInteger(limit) || limit < USERS_LIMIT_MIN || limit > USERS_LIMIT_MAX) {
         return `Enter a whole number between ${USERS_LIMIT_MIN} and ${USERS_LIMIT_MAX}, or select "Unlimited" to allow any number of users.`;
     }
@@ -12,6 +17,19 @@ export function usersLimitError(limit: number): string | null {
     return null;
 }
 
-export function usersLimitChanged(mode: UsersLimitMode, limit: number, total: number): boolean {
+function limitChanged(mode: UsersLimitMode, limit: number, total: number): boolean {
     return mode === 'limited' ? limit !== total : total !== 0;
+}
+
+export function usersLimitState(
+    mode: UsersLimitMode,
+    limit: number,
+    total: number
+): UsersLimitState {
+    const error = mode === 'limited' ? limitError(limit) : null;
+
+    return {
+        error,
+        disabled: error !== null || !limitChanged(mode, limit, total)
+    };
 }


### PR DESCRIPTION
## What

`Auth > Security > Users limit` leaves **Update** disabled with nothing explaining why whenever the entered value is one the API cannot accept.

Reported on Discord: on a project with no limit, selecting **Limited** and entering `0` does nothing — the button never enables, so the change cannot be saved.

## Why

The user-limit policy reserves `total: 0` for "no limit" — from the SDK: *"Value can be between 0 and 10000. Use 0 or null to disable the limit."* The card let you type `0` as though it were a limit, and the disabled check conflated the two states:

```js
(!isLimited && policy.total === 0) || (isLimited && policy.total === newLimit)
```

With `policy.total === 0` and `newLimit === 0`, that is `0 === 0` — Update disabled. The button looks broken; it is actually refusing a state the API cannot represent, without saying so.

The same check had three more holes:

| Input | Before |
| --- | --- |
| Limited `0`, project already limited to 100 | Update **enabled**, saved `total: 0`, silently turning the limit **off** while the UI still read "Limited 0" |
| Field cleared | Binding yields `undefined` → Update enabled → SDK throws `Missing required parameter: "total"` as an error toast |
| Negative value | No `min` on the input → Update enabled → 400 from the API |

## Changes

- Move the valid range (1–10000) and the changed-vs-saved comparison into `usersLimit.ts`.
- Put `min` / `max` / `step` on the input.
- Show a rejected value as an inline error on the field instead of a dead button: *"Enter a whole number between 1 and 10000, or select "Unlimited" to allow any number of users."*
- `0` can no longer be submitted as a limit, so the card cannot drift out of sync with the saved policy.
- Drop `maxUsersInputField` and its focus effect — nothing ever bound it, so it was always `null` and never ran. Wiring it up would have auto-focused and scrolled to the card on every page load.

## Tests

`usersLimit.test.ts` covers the reported repro, the silent `0`-saves-as-unlimited path, cleared / decimal / out-of-range input, and the valid transitions. Colocated plain-vitest, same pattern as `rows/store.test.ts` — no jsdom or component-test scaffolding needed.

`format`, `check` (0 errors), `lint` (0 errors), `test:unit` (275 passed) and `build` are clean.

## Note for the original question

Setting the users limit to `0` to block client-side signups cannot work by design — `0` disables the policy. Verified against the server:

- `APP_LIMIT_USERS = 10_000` (`app/init/constants.php`), matching the range this card now enforces.
- The limit is checked in `app/controllers/api/account.php` only — six call sites covering email/password, magic URL, OAuth, phone and anonymous, so "regardless of authentication method" holds for the client Account API.
- `Platform/Modules/Users/Http/Users/Create.php` has no such check, so an API key can still create users past the limit.

So the workaround suggested in the thread does hold: set the limit to `1`, create one user yourself, and an Appwrite Function using an API key keeps creating users through the Users API while client-side signup returns `user_count_exceeded`.
