### PR TITLE
feat(console): add a top banner for the new Console

### DIFF
--- a/src/lib/components/billing/gradientBanner.svelte
+++ b/src/lib/components/billing/gradientBanner.svelte
@@ -6,9 +6,17 @@
     import { isTabletViewport } from '$lib/stores/viewport';
     import PinkBackground from '$lib/images/pink-background.svg';
     import { bannerSpacing } from '$lib/layout/headerAlert.svelte';
-    import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+    import { createEventDispatcher, getContext, onMount, onDestroy } from 'svelte';
 
     export let variant: 'gradient' | 'image' = 'gradient';
+
+    /**
+     * An AlertStack parent is itself fixed and measures its children to offset the shell. This
+     * banner is position:fixed, so inside a stack it measures as 0 and the stack resets the
+     * header offset we just set, leaving the banner covering the navigation until the next
+     * resize. Mirror headerAlert.svelte and stand down when the stack is in charge.
+     */
+    const isInStack: boolean = getContext('isInAlertStack') ?? false;
 
     let container: HTMLElement;
     const dispatch = createEventDispatcher();
@@ -20,6 +28,8 @@
     });
 
     const setNavigationHeight = () => {
+        if (isInStack) return;
+
         const alertHeight = container?.getBoundingClientRect()?.height || 0;
         const { header, sidebar, content } = queryLayoutElements();
         const headerHeight = header?.getBoundingClientRect().height || 0;
@@ -51,6 +61,7 @@
 <div
     bind:this={container}
     class:darker={variant === 'image'}
+    class:in-stack={isInStack}
     class="top-banner alert is-action is-action-and-top-sticky">
     {#if variant === 'gradient'}
         <div class="top-banner-bg">
@@ -91,6 +102,11 @@
         z-index: 100;
         position: fixed;
         padding: 0.8rem;
+
+        &.in-stack {
+            position: relative;
+            z-index: unset;
+        }
 
         &.darker {
             background: var(--bgcolor-neutral-default);

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -76,6 +76,7 @@ export { default as EmptyCardImageCloud } from './emptyCardImageCloud.svelte';
 export { default as ImagePreview } from './imagePreview.svelte';
 export { default as MfaChallengeFormList } from './mfaChallengeFormList.svelte';
 export { default as BottomModalAlert } from './bottomModalAlert.svelte';
+export { default as NewConsoleBanner } from './newConsoleBanner.svelte';
 export { default as Navbar } from './navbar.svelte';
 export { default as Breadcrumbs } from './breadcrumbs.svelte';
 export { default as Sidebar } from './sidebar.svelte';

--- a/src/lib/components/newConsoleBanner.svelte
+++ b/src/lib/components/newConsoleBanner.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    import { trackEvent } from '$lib/actions/analytics';
+    import { Button } from '$lib/elements/forms';
+    import { Layout, Typography } from '@appwrite.io/pink-svelte';
+    import { isSmallViewport } from '$lib/stores/viewport';
+    import { activeHeaderAlert } from '$routes/(console)/store';
+    import GradientBanner from './billing/gradientBanner.svelte';
+
+    // utm_medium separates this from the promo card, so the two surfaces can be compared.
+    const href =
+        'https://appwrite.io/?utm_source=old-console&utm_medium=banner&utm_campaign=new-console';
+
+    let show = true;
+
+    function handleClose() {
+        show = false;
+        localStorage.setItem($activeHeaderAlert.id, new Date().getTime().toString());
+        trackEvent('close_new_console_banner', { source: 'new_console_banner' });
+    }
+</script>
+
+{#if show}
+    <GradientBanner on:close={handleClose}>
+        <Layout.Stack
+            gap="m"
+            alignItems="center"
+            alignContent="center"
+            direction={$isSmallViewport ? 'column' : 'row'}>
+            <Typography.Text>
+                Introducing the new Appwrite Console, rebuilt from the ground up.
+            </Typography.Text>
+
+            <Button
+                secondary
+                external
+                fullWidthMobile
+                class="u-line-height-1"
+                {href}
+                on:click={() => trackEvent('click_new_console', { source: 'new_console_banner' })}>
+                Try it now
+            </Button>
+        </Layout.Stack>
+    </GradientBanner>
+{/if}

--- a/src/lib/components/newConsoleBanner.svelte
+++ b/src/lib/components/newConsoleBanner.svelte
@@ -3,6 +3,7 @@
     import { Button } from '$lib/elements/forms';
     import { Layout, Typography } from '@appwrite.io/pink-svelte';
     import { isSmallViewport } from '$lib/stores/viewport';
+    import { headerAlert } from '$lib/stores/headerAlert';
     import { activeHeaderAlert } from '$routes/(console)/store';
     import GradientBanner from './billing/gradientBanner.svelte';
 
@@ -10,35 +11,36 @@
     const href =
         'https://appwrite.io/?utm_source=old-console&utm_medium=banner&utm_campaign=new-console';
 
-    let show = true;
-
     function handleClose() {
-        show = false;
-        localStorage.setItem($activeHeaderAlert.id, new Date().getTime().toString());
+        const { id } = $activeHeaderAlert;
+        localStorage.setItem(id, new Date().getTime().toString());
         trackEvent('close_new_console_banner', { source: 'new_console_banner' });
+
+        // Clear the store entry, not just this component. headerAlert.get() picks the highest
+        // importance and breaks ties by registration order, so an entry left visible keeps
+        // winning the importance-1 tie and hides the next eligible promo behind an empty slot.
+        headerAlert.updateShow(id, false);
     }
 </script>
 
-{#if show}
-    <GradientBanner on:close={handleClose}>
-        <Layout.Stack
-            gap="m"
-            alignItems="center"
-            alignContent="center"
-            direction={$isSmallViewport ? 'column' : 'row'}>
-            <Typography.Text>
-                Introducing the new Appwrite Console, rebuilt from the ground up.
-            </Typography.Text>
+<GradientBanner on:close={handleClose}>
+    <Layout.Stack
+        gap="m"
+        alignItems="center"
+        alignContent="center"
+        direction={$isSmallViewport ? 'column' : 'row'}>
+        <Typography.Text>
+            Introducing the new Appwrite Console, rebuilt from the ground up.
+        </Typography.Text>
 
-            <Button
-                secondary
-                external
-                fullWidthMobile
-                class="u-line-height-1"
-                {href}
-                on:click={() => trackEvent('click_new_console', { source: 'new_console_banner' })}>
-                Try it now
-            </Button>
-        </Layout.Stack>
-    </GradientBanner>
-{/if}
+        <Button
+            secondary
+            external
+            fullWidthMobile
+            class="u-line-height-1"
+            {href}
+            on:click={() => trackEvent('click_new_console', { source: 'new_console_banner' })}>
+            Try it now
+        </Button>
+    </Layout.Stack>
+</GradientBanner>

--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -44,8 +44,7 @@
     import { headerAlert } from '$lib/stores/headerAlert';
     import { UsageRates } from '$lib/components/billing';
     import { canSeeProjects } from '$lib/stores/roles';
-    import { BottomModalAlert } from '$lib/components';
-    import NewConsoleBanner from '$lib/components/newConsoleBanner.svelte';
+    import { BottomModalAlert, NewConsoleBanner } from '$lib/components';
     import { isSmallViewport } from '$lib/stores/viewport';
     import {
         IconAnnotation,

--- a/src/routes/(console)/+layout.svelte
+++ b/src/routes/(console)/+layout.svelte
@@ -45,6 +45,7 @@
     import { UsageRates } from '$lib/components/billing';
     import { canSeeProjects } from '$lib/stores/roles';
     import { BottomModalAlert } from '$lib/components';
+    import NewConsoleBanner from '$lib/components/newConsoleBanner.svelte';
     import { isSmallViewport } from '$lib/stores/viewport';
     import {
         IconAnnotation,
@@ -324,6 +325,19 @@
     }
 
     $registerSearchers(orgSearcher, projectsSearcher);
+
+    onMount(() => {
+        // Same shape as newDevUpgradePro: promo tier (importance 1) so it can never outrank a
+        // payment or usage warning, dismissal keyed on the alert id in localStorage.
+        if (isCloud && !localStorage.getItem('newConsoleBanner')) {
+            headerAlert.add({
+                id: 'newConsoleBanner',
+                component: NewConsoleBanner,
+                show: true,
+                importance: 1
+            });
+        }
+    });
 
     $: (void $headerAlert, ($activeHeaderAlert = headerAlert.getExcluding('impersonation')));
 </script>


### PR DESCRIPTION
Adds a top banner inviting users to the new Console, alongside the promo card from #3191.

## Approach

Uses `GradientBanner` — the same component `newDevUpgradePro` uses for the Cloud credits promo. Registered through `headerAlert` at **importance 1**, the promo tier, so it sits level with `newDevUpgradePro` and the backup-policy warning and can never outrank a payment or usage alert. Dismissal is keyed on the alert id in `localStorage`, matching `newDevUpgradePro`.

| File | Change |
| --- | --- |
| `src/lib/components/newConsoleBanner.svelte` | New, 44 lines |
| `src/routes/(console)/+layout.svelte` | Registration, +14 |
| `src/lib/components/billing/gradientBanner.svelte` | Layering fix, +17/-1 |

## Also fixes a pre-existing layering bug

`GradientBanner` is `position: fixed` and offsets the shell itself in `setNavigationHeight`. But it renders inside `AlertStack`, which is *also* fixed and measures its children to do the same job. Because the banner was out of flow, the stack measured **0px** and its `ResizeObserver` fired last, resetting `header.style.top = 0` — so the banner covered the navigation until the next resize.

Measured on first paint, before and after:

| | before | after |
| --- | --- | --- |
| banner `position` | `fixed` | `relative` |
| AlertStack height | 0px | 56px |
| `header.top` | 0px | 56px |
| overlaps navbar | **yes** | no |

The fix mirrors `headerAlert.svelte` — read `getContext('isInAlertStack')` and stand down when the stack is in charge. **This also fixes the same first-paint overlap for `newDevUpgradePro` and `enterpriseTrial`**, which both go through the same path.

## Copy

> Introducing the new Appwrite Console, rebuilt from the ground up.
> [ Try it now ]

CTA carries `utm_medium=banner`, so this surface can be compared against the card's `utm_medium=promo_card` in the sources pipeline.

## Worth noting

With #3191 merged, the banner and the promo card both run and say the same thing on the same page. That's a deliberate call, not an oversight — flagging it so it's a decision rather than a surprise.

## Test plan

- [x] `bun run format` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun run check` — no errors in changed files
- [x] Verified against the live console: banner renders above the navigation, no overlap on first paint
- [x] Verified dismissal persists