### PR TITLE
fix(helpers): guard calculateSize against non-finite and negative input

### DIFF
--- a/src/lib/helpers/sizeConvertion.test.ts
+++ b/src/lib/helpers/sizeConvertion.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'vitest';
+import { calculateSize } from '$lib/helpers/sizeConvertion';
+
+/*
+calculateSize - normal values
+*/
+test('formats zero as Bytes', () => {
+    expect(calculateSize(0)).toEqual('0 Bytes');
+});
+
+test('formats byte values under the base', () => {
+    expect(calculateSize(1)).toEqual('1 Bytes');
+    expect(calculateSize(999)).toEqual('999 Bytes');
+});
+
+test('scales to the correct unit (base 1000)', () => {
+    expect(calculateSize(1000)).toEqual('1 KB');
+    expect(calculateSize(1500)).toEqual('1.5 KB');
+    expect(calculateSize(1_000_000)).toEqual('1 MB');
+    expect(calculateSize(123_456_789)).toEqual('123.5 MB');
+});
+
+test('scales to the correct unit (base 1024)', () => {
+    expect(calculateSize(1024, 1, 1024)).toEqual('1 KB');
+    expect(calculateSize(1_073_741_824, 1, 1024)).toEqual('1 GB');
+});
+
+test('respects the decimals argument', () => {
+    expect(calculateSize(1500, 0)).toEqual('2 KB');
+    expect(calculateSize(1536, 2, 1024)).toEqual('1.5 KB');
+});
+
+/*
+calculateSize - invalid / edge input
+Regression: previously these produced strings like "NaN undefined" / "500 undefined"
+because Math.log of a non-finite/negative value yields an out-of-range unit index.
+*/
+test('handles non-finite input without emitting "undefined"', () => {
+    expect(calculateSize(NaN)).toEqual('0 Bytes');
+    expect(calculateSize(Infinity)).toEqual('0 Bytes');
+    expect(calculateSize(-Infinity)).toEqual('0 Bytes');
+});
+
+test('handles nullish input coerced to a number', () => {
+    // API sizes (e.g. a deployment still building) can be undefined/null at the call site.
+    expect(calculateSize(undefined as unknown as number)).toEqual('0 Bytes');
+    expect(calculateSize(null as unknown as number)).toEqual('0 Bytes');
+});
+
+test('handles negative input', () => {
+    expect(calculateSize(-5)).toEqual('0 Bytes');
+});
+
+test('handles sub-1-byte input without an undefined unit', () => {
+    expect(calculateSize(0.5)).toEqual('0.5 Bytes');
+});

--- a/src/lib/helpers/sizeConvertion.ts
+++ b/src/lib/helpers/sizeConvertion.ts
@@ -4,11 +4,16 @@ const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'] as const
 export type Size = (typeof sizes)[number];
 
 export function calculateSize(bytes: number, decimals = 1, base: 1000 | 1024 = 1000) {
-    if (bytes === 0) return '0 Bytes';
+    // Guard non-finite/negative input (e.g. an undefined API size coerced to NaN):
+    // without this the log math yields `NaN`/out-of-range indexes and the UI renders
+    // strings like "NaN undefined" or "500 undefined".
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 Bytes';
 
     const dm = decimals < 0 ? 0 : decimals;
 
-    const i = Math.floor(Math.log(bytes) / Math.log(base));
+    // Clamp the unit index so sub-1-byte and astronomically large values still map to a
+    // real unit rather than reading `sizes[-1]`/`sizes[9]` as `undefined`.
+    const i = Math.min(Math.max(Math.floor(Math.log(bytes) / Math.log(base)), 0), sizes.length - 1);
 
     return parseFloat((bytes / Math.pow(base, i)).toFixed(dm)) + ' ' + sizes[i];
 }


### PR DESCRIPTION
## What

`calculateSize()` returns broken strings for non-finite, negative, or sub-1-byte input:

| Input | Before | After |
|---|---|---|
| `NaN` | `"NaN undefined"` | `"0 Bytes"` |
| `undefined` / `null` | `"NaN undefined"` | `"0 Bytes"` |
| `Infinity` | `"NaN undefined"` | `"0 Bytes"` |
| `-5` | `"NaN undefined"` | `"0 Bytes"` |
| `0.5` | `"500 undefined"` | `"0.5 Bytes"` |

The cause: `Math.log(bytes)` of a non-finite/negative value yields a `NaN` or negative unit index, so `sizes[i]` reads back as `undefined`.

## Why it matters

Several call sites pass API size fields that can be nullish (e.g. a deployment still building or failed):

- `calculateSize(deployment.buildSize)`, `deployment.sourceSize`, `deployment.totalSize`
- `calculateSize(file.sizeOriginal)`, `calculateSize(backup.size)`

One deployments table already works around exactly this with `calculateSize(deployment?.totalSize ?? 0)` — but the sibling call sites don't, so users can see **"NaN undefined"** in the UI. Handling this gracefully also matches the existing convention of guarding `NaN` in `helpers/numbers` (see `numbers.test.ts`).

## Fix

`src/lib/helpers/sizeConvertion.ts`:

- Return `'0 Bytes'` for any non-finite or `<= 0` input (extends the existing `bytes === 0` guard).
- Clamp the unit index to `[0, sizes.length - 1]` so sub-1-byte and very large values map to a real unit instead of `undefined`.

Valid inputs are unchanged.

## Tests

Added `src/lib/helpers/sizeConvertion.test.ts` (the helper had no test file):

- normal scaling — base 1000 and 1024, and the decimals argument
- regression cases — `NaN`, `±Infinity`, `undefined`/`null`, negative, sub-1-byte

```
TZ=EST vitest run src/lib/helpers/sizeConvertion.test.ts
→ Test Files 1 passed (1) · Tests 9 passed (9)
```

Ran `format` (Prettier clean), `test:unit` (277 passed; the unrelated `oauth2-cimd` suite fails to load with `TypeError: Invalid URL` on a clean checkout too, and is untouched by this change).
