### PR TITLE
Fix: handle deleted or missing tables in database editor

### DIFF
--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.svelte
@@ -165,7 +165,8 @@
                 }
             },
             icon: IconPlus,
-            group: 'rows'
+            group: 'rows',
+            disabled: !table || !$canWriteTables
         },
         {
             label: 'Create column',
@@ -175,7 +176,7 @@
             },
             icon: IconPlus,
             group: 'columns',
-            disabled: !$canWriteTables
+            disabled: !table || !$canWriteTables
         },
         {
             label: 'Go to rows',
@@ -257,7 +258,7 @@
             },
             icon: IconPlus,
             group: 'indexes',
-            disabled: !$canWriteTables
+            disabled: !table || !$canWriteTables
         }
     ]);
 
@@ -385,7 +386,16 @@
     <title>{table?.name ?? 'Table'} - Appwrite</title>
 </svelte:head>
 
-<slot />
+{#if table}
+    <slot />
+{:else}
+    <Layout.Stack alignItems="center" justifyContent="center" style="min-height: 400px;">
+        <Typography.Title size="m">Table deleted or not found</Typography.Title>
+        <Typography.Text>
+            The table you're looking for no longer exists or could not be found.
+        </Typography.Text>
+    </Layout.Stack>
+{/if}
 
 <SideSheet
     closeOnBlur={false}

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.ts
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+layout.ts
@@ -3,6 +3,7 @@ import type { LayoutLoad } from './$types';
 import { Dependencies } from '$lib/constants';
 import { Breadcrumbs, toDatabaseType, useDatabaseSdk } from '$database/(entity)';
 import { guardResourceBlock } from '$lib/helpers/project';
+import { AppwriteException } from '@appwrite.io/console';
 
 export const load: LayoutLoad = async ({ params, depends, parent }) => {
     const { database, project } = await parent();
@@ -15,10 +16,18 @@ export const load: LayoutLoad = async ({ params, depends, parent }) => {
         toDatabaseType(database.type)
     );
 
-    const table = await databaseSdk.getEntity({
-        databaseId: params.database,
-        entityId: params.table
-    });
+    let table = null;
+
+    try {
+        table = await databaseSdk.getEntity({
+            databaseId: params.database,
+            entityId: params.table
+        });
+    } catch (e) {
+        if (!(e instanceof AppwriteException) || e.code !== 404) {
+            throw e;
+        }
+    }
 
     return {
         table,

--- a/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+page.ts
+++ b/src/routes/(console)/project-[region]-[project]/databases/database-[database]/table-[table]/+page.ts
@@ -7,6 +7,22 @@ import { buildGridQueries, extractSortFromQueries, loadGridRows } from '$databas
 
 export const load: PageLoad = async ({ params, depends, url, route, parent }) => {
     const { table } = await parent();
+
+    if (!table) {
+        return {
+            offset: 0,
+            limit: SPREADSHEET_PAGE_LIMIT,
+            view: View.Grid,
+            query: '',
+            currentSort: { column: null, direction: 'default' },
+            parsedQueries: new Map(),
+            rows: {
+                total: 0,
+                rows: []
+            }
+        };
+    }
+
     depends(Dependencies.ROWS);
 
     const page = getPage(url);


### PR DESCRIPTION
Fixes appwrite/appwrite#12918

### Problem

When a user navigates to a deleted or non-existent table, the database editor gets stuck in a loading state. The table request returns a 404 error, but the UI does not handle the missing table state correctly.

### Changes

* Handle 404 errors when fetching a table.
* Rethrow other `AppwriteException` errors to preserve existing error handling.
* Display a clear **"Table deleted or not found"** message when the requested table no longer exists.

### Testing

* Tested the deleted/non-existent table scenario locally.
* Verified that existing tables continue to load normally.
* Verified the changes with `bun run check` with 0 errors.
