### PR TITLE
fix(console): allow selecting .tar.gz files in manual deployment pickers on macOS

### DIFF
--- a/src/lib/helpers/files.test.ts
+++ b/src/lib/helpers/files.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEPLOYMENT_ARCHIVE_EXTENSIONS,
+    getInvalidDeploymentArchiveReason
+} from './files';
+
+describe('deployment archive extensions', () => {
+    it('should include the compound tar.gz extension for the file picker accept attribute', () => {
+        // On macOS a bare '.gz' accept token does not match 'code.tar.gz' files
+        // (compound tar+gzip UTI), greying them out in the picker.
+        expect(DEPLOYMENT_ARCHIVE_EXTENSIONS).toContain('tar.gz');
+        expect(DEPLOYMENT_ARCHIVE_EXTENSIONS).toContain('gz');
+    });
+
+    it('should accept .tar.gz archives and reject other files', () => {
+        const ok = [new File(['x'], 'code.tar.gz')];
+        expect(getInvalidDeploymentArchiveReason(ok)).toBeNull();
+
+        const upper = [new File(['x'], 'CODE.TAR.GZ')];
+        expect(getInvalidDeploymentArchiveReason(upper)).toBeNull();
+
+        const zip = [new File(['x'], 'code.zip')];
+        expect(getInvalidDeploymentArchiveReason(zip)).toBe('invalid_extension');
+    });
+});

--- a/src/lib/helpers/files.ts
+++ b/src/lib/helpers/files.ts
@@ -80,6 +80,16 @@ export async function gzipUpload(files: FileList) {
     return uploadFile;
 }
 
+/**
+ * Extensions accepted for manual deployment archives.
+ *
+ * 'tar.gz' must be listed alongside 'gz': the file picker `accept` attribute is
+ * built from these extensions, and on macOS a bare '.gz' token does not match
+ * 'code.tar.gz' files (their UTI is the compound tar+gzip type), so the picker
+ * greys them out.
+ */
+export const DEPLOYMENT_ARCHIVE_EXTENSIONS = ['gz', 'tar.gz'];
+
 export function getInvalidDeploymentArchiveReason(
     files: FileList | File[] | null | undefined,
     maxSize?: number

--- a/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/create-function/manual/+page.svelte
@@ -22,7 +22,8 @@
     import {
         getInvalidDeploymentArchiveReason,
         InvalidFileType,
-        removeFile
+        removeFile,
+        DEPLOYMENT_ARCHIVE_EXTENSIONS
     } from '$lib/helpers/files';
     import { isCloud } from '$lib/system';
     import { humanFileSize } from '$lib/helpers/sizeConvertion';
@@ -224,7 +225,7 @@
                 <Upload.Dropzone
                     bind:files
                     title="Upload function"
-                    extensions={['gz']}
+                    extensions={DEPLOYMENT_ARCHIVE_EXTENSIONS}
                     {maxSize}
                     required
                     on:invalid={handleInvalid}>

--- a/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createManual.svelte
+++ b/src/routes/(console)/project-[region]-[project]/functions/function-[function]/(modals)/createManual.svelte
@@ -7,7 +7,8 @@
     import {
         getInvalidDeploymentArchiveReason,
         InvalidFileType,
-        removeFile
+        removeFile,
+        DEPLOYMENT_ARCHIVE_EXTENSIONS
     } from '$lib/helpers/files';
     import { addNotification } from '$lib/stores/notifications';
     import { IconInfo } from '@appwrite.io/pink-icons-svelte';
@@ -93,7 +94,7 @@
             Upload a tar.gz file containing your function source code
         </Typography.Text>
         <Upload.Dropzone
-            extensions={['gz']}
+            extensions={DEPLOYMENT_ARCHIVE_EXTENSIONS}
             bind:files
             {maxSize}
             required

--- a/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/create-site/manual/+page.svelte
@@ -19,7 +19,8 @@
     import {
         getInvalidDeploymentArchiveReason,
         InvalidFileType,
-        removeFile
+        removeFile,
+        DEPLOYMENT_ARCHIVE_EXTENSIONS
     } from '$lib/helpers/files';
     import { humanFileSize } from '$lib/helpers/sizeConvertion';
     import { isCloud } from '$lib/system';
@@ -219,7 +220,7 @@
                     Upload a tar.gz containing your site source code
                 </Typography.Text>
                 <Upload.Dropzone
-                    extensions={['gz']}
+                    extensions={DEPLOYMENT_ARCHIVE_EXTENSIONS}
                     bind:files
                     {maxSize}
                     required

--- a/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createManualDeploymentModal.svelte
+++ b/src/routes/(console)/project-[region]-[project]/sites/site-[site]/deployments/createManualDeploymentModal.svelte
@@ -6,7 +6,8 @@
     import {
         getInvalidDeploymentArchiveReason,
         InvalidFileType,
-        removeFile
+        removeFile,
+        DEPLOYMENT_ARCHIVE_EXTENSIONS
     } from '$lib/helpers/files';
     import { addNotification } from '$lib/stores/notifications';
     import { uploader } from '$lib/stores/uploader';
@@ -93,7 +94,7 @@
             Upload a tar.gz file containing your site source code
         </Typography.Text>
         <Upload.Dropzone
-            extensions={['gz']}
+            extensions={DEPLOYMENT_ARCHIVE_EXTENSIONS}
             bind:files
             {maxSize}
             required


### PR DESCRIPTION
Fixes appwrite/appwrite#13635 - reported by @shohag7552 on Appwrite Cloud (macOS).

## Problem

The manual-deployment upload dropzones (function create, function redeploy modal, site create, site redeploy modal) pass `extensions={['gz']}` to `Upload.Dropzone`, which builds the file picker's accept attribute as `.gz`. On macOS a bare `.gz` token does not match `code.tar.gz` files (they carry the compound tar+gzip UTI), so the picker greys them out and they can't be selected.

## Fix

Shared `DEPLOYMENT_ARCHIVE_EXTENSIONS = ['gz', 'tar.gz']` in `src/lib/helpers/files.ts`, used by all four dropzones, so accept becomes `.gz,.tar.gz`. The Dropzone's own extension validation (last-dot suffix) and `getInvalidDeploymentArchiveReason` (`.tar.gz` suffix, case-insensitive) are unchanged and still pass.

## Testing

- New `src/lib/helpers/files.test.ts`: accept-attribute constant includes the compound extension, and archive validation accepts `.tar.gz`/upper-case and rejects other extensions. Against the unpatched helper the accept-attribute test fails; with the patch both pass (vitest, real `files.ts`).
- `git apply --check` clean against `main` (843f17e).
- Caveat: no macOS/Safari reproduction here - the picker behavior is reasoned from the accept/UTI mechanism plus the reporter's screenshot. @shohag7552, once this lands, a quick confirm that the picker lets you select your `.tar.gz` would close the loop.

> Built by breken, your AI support engineer - breken.ai - this one's on us.